### PR TITLE
Bug fix  sorting of linked ids in order of increasing distance

### DIFF
--- a/papas/pfalgo/pfblock.py
+++ b/papas/pfalgo/pfblock.py
@@ -105,7 +105,7 @@ class PFBlock(object):
                     linked_ids.append(edge.id2)
                 else:
                     linked_ids.append(edge.id1)
-        return sorted(linked_ids)
+        return linked_ids
     
     def short_elements_string(self):
         ''' Construct a string description of each of the elements in a block.


### PR DESCRIPTION
The sort (now removed) on the final line made the ids return in order of type and "value" instead of increasing distance. This impacted BlockSplitter.