### PR TITLE
small bug fix + adapt batch tools to FCC 0.8 at CERN

### DIFF
--- a/analyzers/examples/zh/ZHTreeProducer.py
+++ b/analyzers/examples/zh/ZHTreeProducer.py
@@ -45,6 +45,8 @@ class ZHTreeProducer(Analyzer):
         higgses = getattr(event, self.cfg_ana.higgses)
         if len(higgses)>0:
             higgs = higgses[0]
+            # if higgs.m() < 30:
+            #    import pdb; pdb.set_trace()
             fillParticle(self.tree, 'higgs', higgs)
             fillLepton(self.tree, 'higgs_1', higgs.legs[0])
             fillLepton(self.tree, 'higgs_2', higgs.legs[1])

--- a/analyzers/fcc/JetClusterizer.py
+++ b/analyzers/fcc/JetClusterizer.py
@@ -1,7 +1,6 @@
 '''Jet clusterizer based on fastjet.'''
 
 from heppy.framework.analyzer import Analyzer
-from heppy.framework.event import Event
 
 from heppy.particles.tlv.jet import Jet
 from heppy.particles.jet import JetConstituents
@@ -18,8 +17,7 @@ elif os.environ.get('CMSSW_BASE'):
     from ROOT import heppy
     CCJetClusterizer = heppy.JetClusterizer
 
-import math
-    
+
 class JetClusterizer(Analyzer):
     '''Jet clusterizer based on fastjet (kt-ee algorithm)
     
@@ -54,6 +52,7 @@ class JetClusterizer(Analyzer):
         super(JetClusterizer, self).__init__(*args, **kwargs)
         args = self.cfg_ana.fastjet_args
         self.clusterize = None
+        self.njets = 0
         if 'ptmin' in args and 'njets' in args:
             raise ValueError('cannot specify both ptmin and njets arguments')
         if 'ptmin' in args:
@@ -62,9 +61,10 @@ class JetClusterizer(Analyzer):
                 return self.clusterizer.make_inclusive_jets(args['ptmin']) 
             self.clusterize = clusterize
         elif 'njets' in args:
+            self.njets = args['njets']
             self.clusterizer = CCJetClusterizer(1)
             def clusterize():
-                return self.clusterizer.make_exclusive_jets(args['njets']) 
+                return self.clusterizer.make_exclusive_jets(self.njets) 
             self.clusterize = clusterize
         else:
             raise ValueError('specify either ptmin or njets') 
@@ -97,7 +97,13 @@ class JetClusterizer(Analyzer):
         particles = getattr(event, self.cfg_ana.particles)
         # removing neutrinos
         particles = [ptc for ptc in particles if abs(ptc.pdgid()) not in [12,14,16]]
-        self.clusterizer.clear();
+        if len(particles) < self.njets:
+            err = 'Cannot make {} jets with {} particles -> Event discarded'.format(
+                self.njets, len(particles)
+            )
+            self.mainLogger.error(err)
+            return False
+        self.clusterizer.clear()
         for ptc in particles:
             self.clusterizer.add_p4( ptc.p4() )
         self.clusterize()

--- a/scripts/pythia_batch.py
+++ b/scripts/pythia_batch.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import os
 import shutil
 import re
@@ -8,6 +10,8 @@ def batchScriptLocal(index, cardfname):
     '''prepare a local version of the batch script, to run using nohup'''
 
     script = """#!/bin/bash
+pwd
+echo {cardfname}
 echo 'running job' {index}
 echo
 fcc-pythia8-generate {cardfname}
@@ -108,7 +112,7 @@ def main(options, args, batchManager):
     
     listOfValues = range(njobs)
     batchManager.PrepareJobs( listOfValues )
-    waitingTime = 0.1
+    waitingTime = 5
     batchManager.SubmitJobs( waitingTime )
 
 

--- a/scripts/pythia_batch.py
+++ b/scripts/pythia_batch.py
@@ -35,8 +35,10 @@ fi"""
 #BSUB -q 8nm
 # ulimit -v 3000000 # NO
 unset LD_LIBRARY_PATH
+unset PYTHONHOME
+unset PYTHONPATH
 echo 'copying job dir to worker'
-source /afs/cern.ch/exp/fcc/sw/0.8pre/setup.sh
+source /cvmfs/fcc.cern.ch/sw/0.8/init_fcc_stack.sh
 cd $HEPPY
 source ./init.sh
 echo 'environment:'

--- a/utils/absglob.py
+++ b/utils/absglob.py
@@ -1,0 +1,10 @@
+import glob as gglob
+import os
+
+def glob(pattern):
+    return [os.path.abspath(fname) for fname in gglob.glob(pattern)]
+
+if __name__ == "__main__":
+    import sys
+
+    print glob(sys.argv[1])


### PR DESCRIPTION
The bug that was fixed concerns jet clustering. 

When an exclusive number of jets njets was requested with a number of particles nparts smaller than njets, fastjet is sending an exception, and this exception was killing the processing. 
I've put a protection around the fast jet call. If nparts < njets, the event is discarded.

This bug was first reported by @MogensDam a few months ago.  