### PR TITLE
b tag: nicolo's model, fix of parametrized b tagger

### DIFF
--- a/analyzers/ChargedHadronsFromB.py
+++ b/analyzers/ChargedHadronsFromB.py
@@ -29,14 +29,18 @@ class ChargedHadronsFromB(Analyzer):
         event.hadrons_from_b = []
         event.hadrons_not_from_b = []
         for hadron in charged_hadrons:
-            ancestors = event.genbrowser.ancestors(hadron)
-            is_from_b = False 
-            for ancestor in ancestors:
-                if hasBottom(ancestor.pdgid() ):
-                    is_from_b = True
+            is_from_b = is_ptc_from_b(event, hadron, event.genbrowser)
             if is_from_b:
                 event.hadrons_from_b.append(hadron)
             else:
                 event.hadrons_not_from_b.append(hadron)
+
+def is_ptc_from_b(event, hadron, browser):
+    ancestors = browser.ancestors(hadron)
+    is_from_b = False 
+    for ancestor in ancestors:
+        if hasBottom(ancestor.pdgid() ):
+            is_from_b = True
+    return is_from_b
             
         

--- a/analyzers/ImpactParameterJetTag.py
+++ b/analyzers/ImpactParameterJetTag.py
@@ -1,0 +1,211 @@
+from heppy.framework.analyzer import Analyzer
+from ROOT import TVector3, TLorentzVector, TFile, TTree
+from heppy.papas.path import Helix
+import math
+import random
+from heppy.utils.computeIP import *
+# from heppy.utils.ComputeMVA import ComputeMVA
+
+class ImpactParameterJetTag(Analyzer):
+    """Compute impact paramaters for every charged track and combine them to obtain b-tag variables for every jet inside the event.
+
+    The analyzer requires a resolution function for the impact parameter and a track selection function.
+
+    In particular the analyzer does these steps:
+    - loop on every charged track
+        - compute the IP in the simple way
+        - apply a smearing on the IP according to the resolution
+        - compute track significance and track probability
+    - for each jet select the tracks according to the selection function and compute
+        - b tag variable, that is the probability that the jet comes from the primary vertex
+        - multiplicity, invariant mass and angle wrt to jet direction for the tracks with significance larger than 3 (it's an approximation of the secondary vertex variables)
+
+    Every variable is stored as an attribute of the corresponding object.
+
+    Here is an example to use the code inside the configuration file.
+
+    def track_selection_function(track):
+        return track.q() != 0 and \
+        abs(track.path.smeared_impact_parameter) < 2.5e-3 and \
+        track.path.ip_resolution < 7.5e-4 and \
+        track.e() > 0.4
+
+    import math
+    def aleph_resolution(ptc):
+        momentum = ptc.p3().Mag()
+        return math.sqrt(25.**2 + 95.**2/ (momentum**2) )*1e-6
+
+    from heppy.analyzers.ImpactParameterJetTag import ImpactParameterJetTag
+    ip_wrt_jet_dir = cfg.Analyzer(
+        ImpactParameterJetTag,
+        jets = 'jets',
+        method = 'simple',
+        track_selection = track_selection_function,
+        resolution = aleph_resolution,
+        #mva attributes, not mandatory
+        mva_filename = '../02_b_tagging/18_without_beampipe_simple_ILD/ntuple/qq_ILD_spIP/analyzers.ZqqIPJetsTreeProducer.ZqqIPJetsTreeProducer_1/tree.root',
+        mva_treename = 'events',
+        mva_background_selection = 'quark_type <= 4',
+        mva_signal_selection = 'quark_type == 5',
+    )
+
+    TODO: Fix implementation with MVA
+    """
+
+    def smearing_significance_IP(self, ptc):
+        """Given a particle, smear the IP and compute the track significance and the probability that the track comes from the primary vertex.
+
+        The smearing is made with a gaussian variable with mean = 0 and sigma = resolution; in addition the smearing is applied to the x' and y' component of the IP, that are the component in a frame in which the vector IP lies on the x'y' plane.
+        """
+        resolution = self.cfg_ana.resolution(ptc)
+        ptc.path.ip_resolution = resolution
+
+        ptc.path.x_prime = ptc.path.vector_impact_parameter.Mag()*math.cos(ptc.path.vector_impact_parameter.Phi())
+        ptc.path.y_prime = ptc.path.vector_impact_parameter.Mag()*math.sin(ptc.path.vector_impact_parameter.Phi())
+        ptc.path.z_prime = 0
+        ptc.path.vector_ip_rotated = TVector3(ptc.path.x_prime, ptc.path.y_prime, ptc.path.z_prime)
+
+        ptc.path.ip_smear_factor_x = random.gauss(0, ptc.path.ip_resolution)
+        ptc.path.ip_smear_factor_y = random.gauss(0, ptc.path.ip_resolution)
+        ptc.path.x_prime_smeared = ptc.path.x_prime + ptc.path.ip_smear_factor_x
+        ptc.path.y_prime_smeared = ptc.path.y_prime + ptc.path.ip_smear_factor_y
+        ptc.path.z_prime_smeared = 0
+        ptc.path.vector_ip_rotated_smeared = TVector3(ptc.path.x_prime_smeared, ptc.path.y_prime_smeared, ptc.path.z_prime_smeared)
+
+        ptc.path.smeared_impact_parameter = ptc.path.vector_ip_rotated_smeared.Mag() * ptc.path.sign_impact_parameter
+        ptc.path.significance_impact_parameter = ptc.path.smeared_impact_parameter / ptc.path.ip_resolution
+        ptc.path.track_probability = self.track_probability(ptc)
+
+        if self.cfg_ana.method == 'complex':
+            ptc.path.min_dist_to_jet_significance = ptc.path.sign_impact_parameter\
+                                                    * ptc.path.min_dist_to_jet.Mag()\
+                                                    / ptc.path.ip_resolution
+
+    def track_probability(self, particle):
+        """Compute the probability that the track comes from the primary vertex according to the resolution.
+
+        The track probability is computed as the p-value of the track significance with respect to the expected distribution produced only by the effect of the resoution. For a gaussian resolution, like in this case, this takes an easy expression.
+
+        If the track has negative significance, the probability as it had positive significance is assigned, but with the negative sign.
+        """
+        def gaussian(x):
+            return math.exp((-0.5)*x**2)
+
+        track_prob = gaussian(particle.path.significance_impact_parameter)
+        if particle.path.significance_impact_parameter < 0:
+            return (-1)*track_prob
+        else:
+            return track_prob
+
+    def jet_tag(self, jet):
+        """Combine all the track probabilities for tracks with positive significance passing the track selection to obtain the probability that the jet comes from the primary vertex.
+
+        Jet tags are stored as attributes of the jet object.
+        In particular these new attributes are added:
+        - btag: proability that the jet comes from the primary vertex
+        - logbtag: -log(btag), to better see the difference between jets with very small btag
+        - log10btag: log_10(btag), it's easier to compare with other works if you use this variable
+
+        If a jet doesn't contain any track with positive significance, btag = 1 is assigned.
+        """
+        logtag = 0.
+        n_track = 0
+        log_prob_product = 0.
+
+        for id, ptcs in jet.constituents.iteritems():
+            for ptc in ptcs :
+                if self.cfg_ana.track_selection(ptc) == True and \
+                ptc.path.significance_impact_parameter > 0:
+                    n_track += 1
+                    log_prob_product += 0.5 * ptc.path.significance_impact_parameter**2
+
+        if n_track == 0:
+            jet.btag = 1.
+            jet.logbtag = 0.
+            jet.log10btag = 0.
+            jet.tags['b_pvprob'] = 1
+        else:
+            sum_tr = 0
+            for j in range(n_track):
+                sum_tr += (log_prob_product)**j/math.factorial(j)
+
+            logtag = log_prob_product - math.log(sum_tr)
+            pvprob = math.exp(-logtag)
+            jet.btag = pvprob
+            jet.tags['b_pvprob'] = pvprob 
+            jet.logbtag = logtag
+            jet.log10btag = - logtag * math.log10(math.exp(1))
+        #COLIN hack define working point for integration
+        jet.tags['b'] = jet.tags['b_pvprob'] < 1e-2
+
+    def jet_attributes(self, jet, significance, sign):
+        """Given a jet, compute the multiplicity, invariant mass and angle of the tracks with signficance larger or smaller than a given value, passing the track selection.
+
+        If sign is positive (negative) only the track with significance larger (smaller) than the given value of significance are taken into account. If sign is 0 all the tracks are considered.
+
+        If no track inside the jet passes this selection, it returns 0, 0, 0.
+        """
+        track_list = []
+
+        for id, ptcs in jet.constituents.iteritems():
+            for ptc in ptcs :
+                if self.cfg_ana.track_selection(ptc) == True:
+                    if sign > 0:
+                        if ptc.path.significance_impact_parameter > significance:
+                            track_list.append(ptc)
+                    elif sign < 0:
+                        if ptc.path.significance_impact_parameter < significance:
+                            track_list.append(ptc)
+                    elif sign == 0:
+                        track_list.append(ptc)
+
+        totalp4 = reduce(lambda total, particle: total + particle.p4(),
+                         track_list, TLorentzVector(0., 0., 0., 0.))
+        angle_totalp4_wrt_jet = totalp4.Angle(jet.p3())
+
+        return len(track_list), totalp4.M(), angle_totalp4_wrt_jet
+
+    def beginLoop(self, setup):
+
+        super(ImpactParameterJetTag, self).beginLoop(setup)
+
+        if hasattr(self.cfg_ana, 'mva_bg_tree'):
+            my_file = TFile(self.cfg_ana.mva_filename, "OPEN")
+            my_tree = my_file.Get(self.cfg_ana.mva_treename)
+            mva_variables = ["jet_logbtag",
+                             "jet_n_signif_larger3",
+                             "jet_m_inv_signif_larger3",
+                             "jet_angle_wrt_jet_dir_larger3"]
+
+            self.b_tag_mva = ComputeMVA(mva_variables,
+                                        my_tree.CopyTree(self.cfg_ana.mva_background_selection),
+                                        my_tree.CopyTree(self.cfg_ana.mva_signal_selection)
+                                        )
+
+    def process(self, event):
+
+        primary_vertex = TVector3(0, 0, 0)
+        jets = getattr(event, self.cfg_ana.jets)
+
+        for i, jet in enumerate(jets):
+            for id, ptcs in jet.constituents.iteritems():
+                for ptc in ptcs:
+                    if ptc.q() == 0:
+                        continue
+                    if self.cfg_ana.method == 'simple':
+                        compute_IP(ptc.path, primary_vertex, jet.p3())
+                    elif self.cfg_ana.method == 'complex':
+                        compute_IP_wrt_direction(ptc.path, primary_vertex, jet.p3())
+                    self.smearing_significance_IP(ptc)
+
+            self.jet_tag(jet)
+            jet.n_signif_larger3, jet.m_inv_signif_larger3, jet.angle_wrt_jet_dir_larger3 = self.jet_attributes(jet,3,1)
+
+            if hasattr(self, 'b_tag_mva'):
+                jet_mva_variables = [jet.logbtag,
+                                     jet.n_signif_larger3,
+                                     jet.m_inv_signif_larger3,
+                                     jet.angle_wrt_jet_dir_larger]
+
+                jet.combined_b_tag = self.b_tag_mva.ComputePvalue(jet_mva_variables)
+

--- a/analyzers/JetTreeProducer.py
+++ b/analyzers/JetTreeProducer.py
@@ -39,15 +39,17 @@ class JetTreeProducer(Analyzer):
     def beginLoop(self, setup):
         '''create the output root file and book the tree.
         '''
+        super(JetTreeProducer, self).beginLoop(setup)        
         self.rootfile = TFile('/'.join([self.dirName,
                                         'jet_tree.root']),
                               'recreate')
         self.tree = Tree( self.cfg_ana.tree_name,
                           self.cfg_ana.tree_title )
-        bookJet(self.tree, 'jet1')
-        bookJet(self.tree, 'jet1_match')
-        bookJet(self.tree, 'jet2')
-        bookJet(self.tree, 'jet2_match')
+        self.njets = 2
+        self.taggers = ['b', 'bmatch', 'bfrac']
+        for ijet in range(self.njets):
+            bookJet(self.tree, 'jet{}'.format(ijet), self.taggers)
+            bookJet(self.tree, 'jet{}_match'.format(ijet))
         var(self.tree, 'event')
         var(self.tree, 'lumi')
         var(self.tree, 'run')
@@ -60,34 +62,24 @@ class JetTreeProducer(Analyzer):
          - self.cfg_ana.jets: the jet collection to be studied. 
         '''
         self.tree.reset()
-        if hasattr(event, 'eventId'): 
+        if hasattr(event, 'eventId'):  # the CMS case
             fill(self.tree, 'event', event.eventId)
             fill(self.tree, 'lumi', event.lumi)
             fill(self.tree, 'run', event.run)
         elif hasattr(event, 'iEv'):
             fill(self.tree, 'event', event.iEv)
         jets = getattr(event, self.cfg_ana.jets)
-        if( len(jets)>0 ):
-            jet = jets[0]
-            comp211 = jet.constituents.get(211, None)
-            if comp211: 
-                if comp211.num==2:
-                    import pdb; pdb.set_trace()
-            fillJet(self.tree, 'jet1', jet)
+        for ijet in range(self.njets):
+            jet = jets[ijet]
+            fillJet(self.tree, 'jet{}'.format(ijet), jet, self.taggers)
             if hasattr(jet, 'match') and jet.match:
-                fillJet(self.tree, 'jet1_match', jet.match)
-                # if jet.e()/jet.match.e() > 2.:
-                #     import pdb; pdb.set_trace()
-        if( len(jets)>1 ):
-            jet = jets[1]
-            fillJet(self.tree, 'jet2', jet)
-            if hasattr(jet, 'match') and jet.match:
-                fillJet(self.tree, 'jet2_match', jet.match)
+                fillJet(self.tree, 'jet{}_match'.format(ijet), jet.match)
         self.tree.tree.Fill()
-        
+    
         
     def write(self, setup):
         '''write root file.
         '''
+        self.rootfile.Write()        
         self.rootfile.Close()
         

--- a/analyzers/PapasPFReconstructor.py
+++ b/analyzers/PapasPFReconstructor.py
@@ -55,21 +55,13 @@ class PapasPFReconstructor(Analyzer):
            reconstructed paricles and updated history_nodes to the event object
            arguments:
                     event must contain a papasevent which must contain tracks, ecals, hcals and blocks'''
-    
-        ecals = event.papasevent.get_collection(self.cfg_ana.ecal_type_and_subtype);
-        hcals = event.papasevent.get_collection(self.cfg_ana.hcal_type_and_subtype);
-        tracks = event.papasevent.get_collection(self.cfg_ana.track_type_and_subtype);
-        blocks = event.papasevent.get_collection(self.cfg_ana.block_type_and_subtype);
-        particles = dict()
-        splitblocks = dict()
-        if blocks:
-            self.reconstructor.reconstruct( event.papasevent, self.cfg_ana.block_type_and_subtype)
-            particles = self.reconstructor.particles
-            splitblocks = self.reconstructor.splitblocks
+        self.reconstructor.reconstruct( event.papasevent, self.cfg_ana.block_type_and_subtype)
+        particles = self.reconstructor.particles
+        splitblocks = self.reconstructor.splitblocks
         event.papasevent.add_collection(particles)
         event.papasevent.add_collection(splitblocks)
         #for particle comparison we want a list of particles (instead of a dict) so that we can sort and compare
-        reconstructed_particle_list = sorted( self.reconstructor.particles.values(),
+        reconstructed_particle_list = sorted( particles.values(),
                                               key = lambda ptc: ptc.e(),
                                               reverse=True)
         setattr(event, self.cfg_ana.output, reconstructed_particle_list)

--- a/analyzers/ParametrizedBTagger.py
+++ b/analyzers/ParametrizedBTagger.py
@@ -16,7 +16,7 @@ def is_matched_to_b(jet):
     return is_bjet
 
 
-def is_from_b(jet, event, fraction=0.1):
+def is_from_b(jet, event, fraction=0.05):
     '''returns true if more than a fraction of the jet energy
     is from a b.'''
     history = HistoryHelper(event.papasevent)
@@ -24,17 +24,17 @@ def is_from_b(jet, event, fraction=0.1):
         event.genbrowser = GenBrowser(event.gen_particles,
                                       event.gen_vertices)       
     sum_e_from_b = 0
-    charged_ptcs = jet.constituents[211]
+    # charged_ptcs = jet.constituents[211]
     from_b = False
-    for ptc in charged_ptcs:
-        print ptc
+    for ptc in jet.constituents.particles:
         simids = history.get_linked_collection(ptc.uniqueid, 'ps')
         for simid in simids:
             simptc = event.papasevent.get_object(simid)
             if is_ptc_from_b(event, simptc.gen_ptc, event.genbrowser):
                 from_b = True
                 break
-        sum_e_from_b += ptc.e()        
+        if from_b:
+            sum_e_from_b += ptc.e()        
     bfrac = sum_e_from_b / jet.e()
     jet.tags['bfrac'] = bfrac
     return bfrac > fraction
@@ -78,7 +78,7 @@ class ParametrizedBTagger(Analyzer):
         '''
         jets = getattr(event, self.cfg_ana.input_jets)
         for jet in jets:
-            is_bjet = is_from_b(jet, event, fraction=0.1)
+            is_bjet = is_from_b(jet, event)
             is_btagged = self.cfg_ana.roc.is_tagged(is_bjet)
             jet.tags['b'] = is_btagged
             jet.tags['bmatch'] = is_bjet

--- a/analyzers/ParametrizedBTagger.py
+++ b/analyzers/ParametrizedBTagger.py
@@ -1,5 +1,48 @@
 '''Applies parametrized b tagging to a collection of jets.'''
 from heppy.framework.analyzer import Analyzer
+from heppy.papas.data.historyhelper import HistoryHelper
+from heppy.analyzers.ChargedHadronsFromB import is_ptc_from_b
+from heppy.particles.genbrowser import GenBrowser
+
+def is_matched_to_b(jet):
+    '''returns true if jet.match is a b quark.
+    matching must be done before.
+    does not work because of low matching efficiency? 
+    '''
+    is_bjet = False 
+    if jet.match and \
+       abs(jet.match.pdgid())== 5:
+        is_bjet = True    
+    return is_bjet
+
+
+def is_from_b(jet, event, fraction):
+    '''returns true if more than a fraction of the jet energy
+    is from a b.'''
+    history = HistoryHelper(event.papasevent)
+    if not hasattr(event, 'genbrowser'):
+        event.genbrowser = GenBrowser(event.gen_particles,
+                                      event.gen_vertices)       
+    sum_e_from_b = 0
+    charged_ptcs = jet.constituents[211]
+    print '*' * 50
+    print jet
+    for ptc in charged_ptcs:
+        print ptc
+        simids = history.get_linked_collection(ptc.uniqueid, 'ps')
+        for simid in simids:
+            simptc = event.papasevent.get_object(simid)
+            if is_ptc_from_b(event, simptc.gen_ptc, event.genbrowser):
+                print 'from b'
+                print simptc
+                sum_e_from_b += simptc.e()
+            else:
+                print 'NOT from b'
+        print '*'
+    print sum_e_from_b / jet.e()
+    return True
+    
+
 
 class ParametrizedBTagger(Analyzer):
     '''Applies parametrized b tagging to a collection of jets.
@@ -37,10 +80,7 @@ class ParametrizedBTagger(Analyzer):
         '''
         jets = getattr(event, self.cfg_ana.input_jets)
         for jet in jets:
-            is_bjet = False 
-            if jet.match and \
-               jet.match.match and \
-               abs(jet.match.match.pdgid())== 5:
-                is_bjet = True
+            is_bjet = is_from_b(jet, event, fraction=0.5)
             is_b_tagged = self.cfg_ana.roc.is_tagged(is_bjet)
             jet.tags['b'] = is_b_tagged
+            jet.tags['bmatch'] = is_bjet

--- a/analyzers/examples/zh/ZHTreeProducer.py
+++ b/analyzers/examples/zh/ZHTreeProducer.py
@@ -13,10 +13,11 @@ class ZHTreeProducer(Analyzer):
                               'recreate')
         self.tree = Tree( 'events', '')
         bookParticle(self.tree, 'recoil')
-        bookJet(self.tree, 'jet1')
-        bookJet(self.tree, 'jet2')
-        bookJet(self.tree, 'jet3')
-        bookJet(self.tree, 'jet4')
+        self.taggers = ['b', 'bmatch']
+        bookJet(self.tree, 'jet1', self.taggers)
+        bookJet(self.tree, 'jet2', self.taggers)
+        bookJet(self.tree, 'jet3', self.taggers)
+        bookJet(self.tree, 'jet4', self.taggers)
 ##        bookParticle(self.tree, 'zed')
 ##        bookLepton(self.tree, 'zed_1')
 ##        bookLepton(self.tree, 'zed_2')
@@ -42,7 +43,7 @@ class ZHTreeProducer(Analyzer):
         for ijet, jet in enumerate(jets):
             if ijet==4:
                 break
-            fillJet(self.tree, 'jet{ijet}'.format(ijet=ijet+1), jet)
+            fillJet(self.tree, 'jet{ijet}'.format(ijet=ijet+1), jet, self.taggers)
         higgses = getattr(event, self.cfg_ana.higgses)
         if len(higgses)>0:
             higgs = higgses[0]

--- a/analyzers/examples/zh/ZHTreeProducer.py
+++ b/analyzers/examples/zh/ZHTreeProducer.py
@@ -12,14 +12,15 @@ class ZHTreeProducer(Analyzer):
                                         'tree.root']),
                               'recreate')
         self.tree = Tree( 'events', '')
-        bookParticle(self.tree, 'zed')
         bookParticle(self.tree, 'recoil')
         bookJet(self.tree, 'jet1')
         bookJet(self.tree, 'jet2')
         bookJet(self.tree, 'jet3')
         bookJet(self.tree, 'jet4')
-        bookLepton(self.tree, 'zed_1')
-        bookLepton(self.tree, 'zed_2')
+##        bookParticle(self.tree, 'zed')
+##        bookLepton(self.tree, 'zed_1')
+##        bookLepton(self.tree, 'zed_2')
+        bookZed(self.tree, 'zed')        
         bookParticle(self.tree, 'higgs')
         bookParticle(self.tree, 'higgs_1')
         bookParticle(self.tree, 'higgs_2')
@@ -34,9 +35,9 @@ class ZHTreeProducer(Analyzer):
         zeds = getattr(event, self.cfg_ana.zeds)
         if len(zeds)>0:
             zed = zeds[0]
-            fillParticle(self.tree, 'zed', zed)
-            fillLepton(self.tree, 'zed_1', zed.legs[0])
-            fillLepton(self.tree, 'zed_2', zed.legs[1])
+            fillZed(self.tree, 'zed', zed)
+##            fillLepton(self.tree, 'zed_1', zed.legs[0])
+##            fillLepton(self.tree, 'zed_2', zed.legs[1])
         jets = getattr(event, self.cfg_ana.jets)
         for ijet, jet in enumerate(jets):
             if ijet==4:

--- a/analyzers/examples/zh/ZHTreeProducer.py
+++ b/analyzers/examples/zh/ZHTreeProducer.py
@@ -13,7 +13,7 @@ class ZHTreeProducer(Analyzer):
                               'recreate')
         self.tree = Tree( 'events', '')
         bookParticle(self.tree, 'recoil')
-        self.taggers = ['b', 'bmatch']
+        self.taggers = ['b', 'bmatch', 'bfrac']
         bookJet(self.tree, 'jet1', self.taggers)
         bookJet(self.tree, 'jet2', self.taggers)
         bookJet(self.tree, 'jet3', self.taggers)

--- a/analyzers/fcc/JetClusterizer.py
+++ b/analyzers/fcc/JetClusterizer.py
@@ -98,11 +98,21 @@ class JetClusterizer(Analyzer):
         # removing neutrinos
         particles = [ptc for ptc in particles if abs(ptc.pdgid()) not in [12,14,16]]
         if len(particles) < self.njets:
-            err = 'Cannot make {} jets with {} particles -> Event discarded'.format(
-                self.njets, len(particles)
-            )
-            self.mainLogger.error(err)
-            return False
+            if hasattr(self.cfg_ana, 'njets_required') and self.cfg_ana.njets_required == False:
+                # not enough particles for the required number of jets,
+                # making no jet
+                setattr(event, self.cfg_ana.output, [])
+                return True                
+
+            else:
+                # njets_required not provided, or njets_required set to True
+                err = 'Cannot make {} jets with {} particles -> Event discarded'.format(
+                    self.njets, len(particles)
+                )
+                self.mainLogger.error(err)
+                # killing the sequence, as the user requests exactly njets
+                return False
+        # enough particles to make the required number of jets
         self.clusterizer.clear()
         for ptc in particles:
             self.clusterizer.add_p4( ptc.p4() )

--- a/analyzers/ntuple.py
+++ b/analyzers/ntuple.py
@@ -1,4 +1,5 @@
 #!/bin/env python
+import math
 
 def var( tree, varName, type=float ):
     tree.var(varName, type)
@@ -28,22 +29,22 @@ def fillP4( tree, pName, p4 ):
 
 def bookParticle( tree, pName ):
     var(tree, '{pName}_pdgid'.format(pName=pName))
-    var(tree, '{pName}_ip'.format(pName=pName)) #TODO Colin clean up hierarchy
-    var(tree, '{pName}_ip_signif'.format(pName=pName))
+##    var(tree, '{pName}_ip'.format(pName=pName)) #TODO Colin clean up hierarchy
+##    var(tree, '{pName}_ip_signif'.format(pName=pName))
     bookP4(tree, pName)
     
 def fillParticle( tree, pName, particle ):
     fill(tree, '{pName}_pdgid'.format(pName=pName), particle.pdgid() )
-    ip = -99
-    ip_signif = -1e9
-    if hasattr(particle, 'path'):
-        path = particle.path
-        if hasattr(path, 'IP'):
-            ip = path.IP
-        if hasattr(path, 'IP_signif'):
-            ip_signif = path.IP_signif
-    fill(tree, '{pName}_ip'.format(pName=pName), ip )
-    fill(tree, '{pName}_ip_signif'.format(pName=pName), ip_signif )
+##    ip = -99
+##    ip_signif = -1e9
+##    if hasattr(particle, 'path'):
+##        path = particle.path
+##        if hasattr(path, 'IP'):
+##            ip = path.IP
+##        if hasattr(path, 'IP_signif'):
+##            ip_signif = path.IP_signif
+##    fill(tree, '{pName}_ip'.format(pName=pName), ip )
+##    fill(tree, '{pName}_ip_signif'.format(pName=pName), ip_signif )
     fillP4(tree, pName, particle )
 
 
@@ -149,13 +150,15 @@ def fillIsoParticle(tree, pName, ptc, lepton):
     
 def bookZed(tree, pName):
     bookParticle(tree, pName )
-    bookParticle(tree, '{pName}_leg1'.format(pName=pName)  )
-    bookParticle(tree, '{pName}_leg2'.format(pName=pName)  )
+    bookLepton(tree, '{pName}_1'.format(pName=pName)  )
+    bookLepton(tree, '{pName}_2'.format(pName=pName)  )
+    var(tree, '{pName}_acol'.format(pName=pName))
 
 def fillZed(tree, pName, zed):
     fillParticle(tree, pName, zed)
-    fillParticle(tree, '{pName}_leg1'.format(pName=pName), zed.leg1 )
-    fillParticle(tree, '{pName}_leg2'.format(pName=pName), zed.leg2 )
+    fillLepton(tree, '{pName}_1'.format(pName=pName), zed.leg1() )
+    fillLepton(tree, '{pName}_2'.format(pName=pName), zed.leg2() )
+    fill(tree, '{pName}_acol'.format(pName=pName), zed.acollinearity() * 180./math.pi)
 
 def bookMet(tree, pName):
     var(tree, '{pName}_pt'.format(pName=pName)  )

--- a/analyzers/ntuple.py
+++ b/analyzers/ntuple.py
@@ -12,6 +12,7 @@ def fill( tree, varName, value ):
 def bookP4( tree, pName ):
     var(tree, '{pName}_e'.format(pName=pName))
     var(tree, '{pName}_pt'.format(pName=pName))
+    var(tree, '{pName}_pz'.format(pName=pName))
     var(tree, '{pName}_theta'.format(pName=pName))
     var(tree, '{pName}_eta'.format(pName=pName))
     var(tree, '{pName}_phi'.format(pName=pName))
@@ -20,6 +21,7 @@ def bookP4( tree, pName ):
 def fillP4( tree, pName, p4 ):
     fill(tree, '{pName}_e'.format(pName=pName), p4.e() )
     fill(tree, '{pName}_pt'.format(pName=pName), p4.pt() )
+    fill(tree, '{pName}_pz'.format(pName=pName), p4.p3().Z() )
     fill(tree, '{pName}_theta'.format(pName=pName), p4.theta() )
     fill(tree, '{pName}_eta'.format(pName=pName), p4.eta() )
     fill(tree, '{pName}_phi'.format(pName=pName), p4.phi() )
@@ -153,12 +155,14 @@ def bookZed(tree, pName):
     bookLepton(tree, '{pName}_1'.format(pName=pName)  )
     bookLepton(tree, '{pName}_2'.format(pName=pName)  )
     var(tree, '{pName}_acol'.format(pName=pName))
+    var(tree, '{pName}_acop'.format(pName=pName))
 
 def fillZed(tree, pName, zed):
     fillParticle(tree, pName, zed)
     fillLepton(tree, '{pName}_1'.format(pName=pName), zed.leg1() )
     fillLepton(tree, '{pName}_2'.format(pName=pName), zed.leg2() )
     fill(tree, '{pName}_acol'.format(pName=pName), zed.acollinearity() * 180./math.pi)
+    fill(tree, '{pName}_acop'.format(pName=pName), zed.acoplanarity() * 180./math.pi)
 
 def bookMet(tree, pName):
     var(tree, '{pName}_pt'.format(pName=pName)  )

--- a/framework/config.py
+++ b/framework/config.py
@@ -357,7 +357,8 @@ class MCComponent( Component ):
     
     def __init__(self, name, files, triggers=[], xSection=1,
                  nGenEvents=None,
-                 effCorrFactor=None, **kwargs ):
+                 effCorrFactor=1,
+                 **kwargs ):
         super( MCComponent, self).__init__( name = name,
                                             files = files,
                                             triggers = triggers, **kwargs )
@@ -372,13 +373,13 @@ class MCComponent( Component ):
         '''Returns the normalization weight for a given integrated luminosity
         
         '''
-        # if intLumi is None:
-        #    intLumi = Weight.FBINV
+        if intLumi is None:
+            intLumi = self.intLumi
         #COLIN THIS WEIGHT STUFF IS REALLY BAD!!
         # use the existing Weight class or not? guess so...
         return Weight( genNEvents = self.nGenEvents,
                        xSection = self.xSection,
-                       intLumi = self.intLumi,
+                       intLumi = intLumi,
                        genEff = 1/self.effCorrFactor,
                        addWeight = self.addWeight )
 

--- a/framework/looper.py
+++ b/framework/looper.py
@@ -335,13 +335,25 @@ possibly skipping a number of events at the beginning.
             if self.memReportFirstEvent >=0 and iEv >= self.memReportFirstEvent:           
                 memNow=resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
                 if memNow > self.memLast :
-                   print  "Mem Jump detected before analyzer %s at event %s. RSS(before,after,difference) %s %s %s "%( analyzer.name, iEv, self.memLast, memNow, memNow-self.memLast)
+                    print  "Mem Jump detected before analyzer %s at event %s. RSS(before,after,difference) %s %s %s "%( analyzer.name, iEv, self.memLast, memNow, memNow-self.memLast)
                 self.memLast=memNow
-            ret = analyzer.process( self.event )
+            ret = False
+            try:
+                ret = analyzer.process( self.event )
+            except:
+                #TODO: check that this works fine with non podio inputs, e.g. plain TChains.
+                if hasattr(self.event, 'input') and \
+                   hasattr(self.event.input, 'current_filename'):
+                    print 'exception running analyzer {ana} on event {iev} in file\n {fname}'.format(
+                        ana=analyzer.cfg_ana.name,
+                        iev=self.event.iEv, 
+                        fname=self.event.input.current_filename()
+                    )   
+                raise 
             if self.memReportFirstEvent >=0 and iEv >= self.memReportFirstEvent:           
                 memNow=resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
                 if memNow > self.memLast :
-                   print "Mem Jump detected in analyzer %s at event %s. RSS(before,after,difference) %s %s %s "%( analyzer.name, iEv, self.memLast, memNow, memNow-self.memLast)
+                    print "Mem Jump detected in analyzer %s at event %s. RSS(before,after,difference) %s %s %s "%( analyzer.name, iEv, self.memLast, memNow, memNow-self.memLast)
                 self.memLast=memNow
             if self.timeReport:
                 self.timeReport[i]['events'] += 1

--- a/papas/data/papasevent.py
+++ b/papas/data/papasevent.py
@@ -62,7 +62,7 @@ class PapasEvent(Event):
         self.collections[the_type] = collection        
     
     def get_collection(self, type_and_subtype):
-        return self.collections.get(type_and_subtype, None)
+        return self.collections.get(type_and_subtype, {})
 
     def get_object(self, uid):
         '''get an object corresponding to a unique uid'''

--- a/papas/data/test_papasevent.py
+++ b/papas/data/test_papasevent.py
@@ -34,7 +34,7 @@ class TestPapasEvent(unittest.TestCase):
         self.assertRaises(ValueError, papasevent.add_collection, mixed)
         
         #get we can get back collections OK
-        self.assertTrue( papasevent.get_collection('zz') is None)
+        self.assertTrue( len(papasevent.get_collection('zz')) == 0 )  # this one does not exist 
         self.assertTrue( len(papasevent.get_collection('et'))  == 3 )
         
         #check get_object

--- a/papas/detectors/CMS.py
+++ b/papas/detectors/CMS.py
@@ -140,6 +140,7 @@ class Field(DetectorElement):
         super(Field, self).__init__('tracker', volume,  mat)
 
 class BeamPipe(DetectorElement):
+    '''Beam pipe is not used in the simulation at the moment, so no need to define it.'''
 
     def __init__(self):
         #Material Seamless AISI 316 LN, External diameter 53 mm, Wall thickness 1.5 mm (hors cms) X0 1.72 cm

--- a/papas/simulator.py
+++ b/papas/simulator.py
@@ -200,7 +200,6 @@ cannot be extrapolated to : {det}\n'''.format(ptc=ptc,
         #implement beam pipe scattering
         ecal = self.detector.elements['ecal']
         hcal = self.detector.elements['hcal']
-        beampipe = self.detector.elements['beampipe']
         frac_ecal = 0.
         if ptc.q() != 0 :
             #track is now made outside of the particle and then the particle is told where the track is
@@ -212,27 +211,6 @@ cannot be extrapolated to : {det}\n'''.format(ptc=ptc,
                 tracker.resolution,
                 tracker.acceptance
             )
-        propagator(ptc.q()).propagate_one(ptc,
-                                          beampipe.volume.inner,
-                                          self.detector.elements['field'].magnitude)
-
-        propagator(ptc.q()).propagate_one(ptc,
-                                          beampipe.volume.outer,
-                                          self.detector.elements['field'].magnitude)
-
-        #pdebug next line  must be editted out to match cpp
-        #mscat.multiple_scattering(ptc, beampipe, self.detector.elements['field'].magnitude)
-
-        #re-propagate after multiple scattering in the beam pipe
-        #indeed, multiple scattering is applied within the beam pipe,
-        #so the extrapolation points to the beam pipe entrance and exit
-        #change after multiple scattering.
-        propagator(ptc.q()).propagate_one(ptc,
-                                           beampipe.volume.inner,
-                                           self.detector.elements['field'].magnitude)
-        propagator(ptc.q()).propagate_one(ptc,
-                                           beampipe.volume.outer,
-                                           self.detector.elements['field'].magnitude)
         propagator(ptc.q()).propagate_one(ptc,
                                            ecal.volume.inner,
                                            self.detector.elements['field'].magnitude)

--- a/particles/jet.py
+++ b/particles/jet.py
@@ -94,6 +94,7 @@ class JetConstituents(dict):
                       ]
         for pdgid in all_pdgids:
             self[pdgid] = JetComponent(pdgid)
+        self.particles = []
 
     def validate(self, jet_energy, tolerance = 1e-2):
         '''Calls pdb if total component energy != jet energy'''
@@ -108,7 +109,8 @@ class JetConstituents(dict):
             self[pdgid].append(ptc)
         except KeyError:
             import pdb; pdb.set_trace()
-
+        self.particles.append(ptc)
+            
     def sort(self):
         '''Sort constituent particles by decreasing energy.'''
         for ptcs in self.values():

--- a/particles/tlv/resonance.py
+++ b/particles/tlv/resonance.py
@@ -1,6 +1,7 @@
 from heppy.particles.tlv.particle import Particle
-from ROOT import TLorentzVector
+from ROOT import TLorentzVector, TVector3
 from rootobj import RootObj
+import math
 
 class Resonance(Particle, RootObj):
     """Resonance decaying to two or more particles (legs).
@@ -30,7 +31,6 @@ class Resonance2(Resonance):
         pid is the pdg id of the resonance.
         '''
         super(Resonance2, self).__init__([leg1, leg2], pid)
-        self._acollinearity = leg1.p3().Angle(leg2.p3())
 
     def leg1(self):
         '''return first leg'''
@@ -42,6 +42,18 @@ class Resonance2(Resonance):
 
     def acollinearity(self):
         '''return the angle between the two legs, in radians'''
-        return self._acollinearity
+        return self.leg1().p3().Angle(self.leg2().p3())
     
+    def acoplanarity(self, axis=None):
+        '''return the angle between the lepton plane and the provided axis.
         
+        If axis is None, using the z axis.
+        '''
+        # normal to lepton plane
+        if axis is None:
+            axis = TVector3(0, 0, 1)
+        normal = self.leg1().p3().Cross(self.leg2().p3()).Unit()
+        angle = normal.Angle(axis)
+        while angle > math.pi / 2.:
+            angle -= math.pi / 2.
+        return angle

--- a/particles/tlv/resonance.py
+++ b/particles/tlv/resonance.py
@@ -30,6 +30,7 @@ class Resonance2(Resonance):
         pid is the pdg id of the resonance.
         '''
         super(Resonance2, self).__init__([leg1, leg2], pid)
+        self._acollinearity = leg1.p3().Angle(leg2.p3())
 
     def leg1(self):
         '''return first leg'''
@@ -38,3 +39,9 @@ class Resonance2(Resonance):
     def leg2(self):
         '''return second leg'''
         return self.legs[1]
+
+    def acollinearity(self):
+        '''return the angle between the two legs, in radians'''
+        return self._acollinearity
+    
+        

--- a/scripts/pythia_batch.py
+++ b/scripts/pythia_batch.py
@@ -36,7 +36,7 @@ fi"""
 # ulimit -v 3000000 # NO
 unset LD_LIBRARY_PATH
 echo 'copying job dir to worker'
-source /afs/cern.ch/exp/fcc/sw/0.8pre/setup.sh
+source /afs/cern.ch/exp/fcc/sw/0.8/setup.sh
 cd $HEPPY
 source ./init.sh
 echo 'environment:'

--- a/test/analysis_ee_Z_cfg.py
+++ b/test/analysis_ee_Z_cfg.py
@@ -80,8 +80,6 @@ zed_tree = cfg.Analyzer(
 
 
 from heppy.test.papas_cfg import gen_particles_stable, papas_sequence, detector, papas, papasdisplay, papasdisplaycompare
-from heppy.test.jet_tree_cff import jet_tree_sequence
-
 
 # definition of a sequence of analyzers,
 # the analyzers will process each event in this order
@@ -89,9 +87,6 @@ sequence = cfg.Sequence(
     source,
     # gen_particles_stable, 
     papas_sequence,
-#    jet_tree_sequence('gen_particles_stable',
-#                      'rec_particles',
-#                      2, None),
     sum_particles,
     sum_gen, 
     zed_tree

--- a/test/btag_parametrized_cfg.py
+++ b/test/btag_parametrized_cfg.py
@@ -1,0 +1,43 @@
+import heppy.framework.config as cfg
+from heppy.configuration import Collider
+
+# select b quarks for jet to parton matching
+def is_bquark(ptc):
+    '''returns True if the particle is an outgoing b quark,
+    see
+    http://home.thep.lu.se/~torbjorn/pythia81html/ParticleProperties.html
+    '''
+    return abs(ptc.pdgid()) == 5 and ptc.status() == 23
+    
+from heppy.analyzers.Selector import Selector
+bquarks = cfg.Analyzer(
+    Selector,
+    'bquarks',
+    output = 'bquarks',
+    input_objects = 'gen_particles',
+    filter_func =is_bquark
+)
+
+# match jets to genjets (so jets are matched to b quarks through gen jets)
+from heppy.analyzers.Matcher import Matcher
+jet_to_bquark_match = cfg.Analyzer(
+    Matcher,
+    match_particles='bquarks',
+    particles='jets',
+    delta_r=0.5
+)
+
+from heppy.analyzers.ParametrizedBTagger import ParametrizedBTagger
+from heppy.analyzers.roc import cms_roc
+cms_roc.set_working_point(0.7)
+btag = cfg.Analyzer(
+    ParametrizedBTagger,
+    input_jets='jets',
+    roc=cms_roc
+)
+
+btag_parametrized = [
+    bquarks,
+    jet_to_bquark_match,
+    btag
+]

--- a/test/btag_parametrized_cfg.py
+++ b/test/btag_parametrized_cfg.py
@@ -38,6 +38,6 @@ btag = cfg.Analyzer(
 
 btag_parametrized = [
     bquarks,
-    jet_to_bquark_match,
+    # jet_to_bquark_match,
     btag
 ]

--- a/test/gun_papas_cfg.py
+++ b/test/gun_papas_cfg.py
@@ -91,8 +91,6 @@ from heppy.test.papas_cfg import papas, papas_sequence, detector
 
 from heppy.test.papas_cfg import papasdisplay as display 
 
-from jet_tree_cff import jet_tree_sequence
-
 from heppy.analyzers.P4SumBuilder import P4SumBuilder
 sum_particles = cfg.Analyzer(
     P4SumBuilder, 
@@ -121,11 +119,6 @@ sequence = cfg.Sequence(
     source, 
     papas_sequence,
     display
-#    jet_tree_sequence('gen_particles_stable','rec_particles',
-#    njets=None, ptmin=0.5),
-#    sum_particles,
-#    sum_gen,
-#    zed_tree
 )
 
 # Specifics for particle gun events

--- a/test/jet_tree_cff.py
+++ b/test/jet_tree_cff.py
@@ -1,13 +1,26 @@
 import heppy.framework.config as cfg
 
-def jet_tree_sequence(gen_ptcs, rec_ptcs, njets, ptmin):
-
+def jet_tree_sequence(gen_ptcs, rec_ptcs, njets=None, ptmin=None):
+    '''returns this sequence:
+    
+        return ( {'gen_jets': gen_jets,
+              'jets': jets,
+              'jet_match': jet_match,
+              'jet_tree': jet_tree},
+             sequence )
+             
+    @param gen_ptcs: gen particles to be used for gen jets
+    @param rec_ptcs: rec particles to be used for rec jets
+    @param njets: number of jets in exclusive mode
+    @param ptmin: minimum jet pt in inclusive mode
+    '''
     fastjet_args = None
     if njets:
         fastjet_args = dict(njets=njets)
-    else:
+    elif ptmin is not None:
         fastjet_args = dict(ptmin=ptmin)
-    
+    else:
+        raise ValueError('provide either njets or ptmin')
     
     from heppy.analyzers.fcc.JetClusterizer import JetClusterizer
     gen_jets = cfg.Analyzer(
@@ -27,8 +40,8 @@ def jet_tree_sequence(gen_ptcs, rec_ptcs, njets, ptmin):
     from heppy.analyzers.Matcher import Matcher
     jet_match = cfg.Analyzer(
         Matcher,
-        match_particles = 'jets',
-        particles = 'gen_jets',
+        match_particles = 'gen_jets',
+        particles = 'jets',
         delta_r = 0.3
         )
 
@@ -37,7 +50,12 @@ def jet_tree_sequence(gen_ptcs, rec_ptcs, njets, ptmin):
         JetTreeProducer,
         tree_name = 'events',
         tree_title = 'jets',
-        jets = 'gen_jets'
+        jets = 'jets'
         )
 
-    return [gen_jets, jets, jet_match, jet_tree]
+    sequence = [gen_jets, jets, jet_match, jet_tree]
+    return ( {'gen_jets': gen_jets,
+              'jets': jets,
+              'jet_match': jet_match,
+              'jet_tree': jet_tree},
+             sequence )

--- a/utils/computeIP.py
+++ b/utils/computeIP.py
@@ -1,0 +1,298 @@
+import math
+from ROOT import TVector3, TLorentzVector
+from scipy.optimize import minimize_scalar
+from numpy import sign
+
+class straight_line(object):
+    """Simple class describing a straight line, based on ROOT TVector3 class.
+
+    Straight line is described by an origin and a direction:
+    point = origin + direction * par, where par is a number that parametrizes the line.
+
+    It includes methods to get the point given a certain parameter,
+    and to find the minimum approach between the line and an external point.
+    """
+
+    def __init__(self, origin, direction):
+        """Simple constructor with 2 TVector3 objects, origin and direction
+        (which is then normalized)."""
+        self.origin = origin
+        self.direction = direction.Unit()
+
+    def point_at_parameter(self, par):
+        """Returns the point (TVector3 object) at a certain value of the parameter parametrizing the line."""
+        return self.origin + par * self.direction
+
+    def distance_from_point(self, point):
+        """Given an external point, returns the TVector3 starting from this
+        point and going to the line point of closest approach to the external one.
+
+        The result is of the form: w = origin + alpha*direction - point
+        """
+        alpha = self.direction.Dot( ( point - self.origin ) )
+        w =  self.point_at_parameter(alpha) - point
+        return w
+
+
+def velocity_at_time(helix, time):
+    """Given a helix object, compute the velocity vector at a given time"""
+    v_x = helix.v_over_omega.Y() * math.sin(helix.omega*time) * helix.omega \
+        + helix.v_over_omega.X() * math.cos(helix.omega*time) * helix.omega
+    v_y = - helix.v_over_omega.X() * math.sin(helix.omega*time) * helix.omega \
+        + helix.v_over_omega.Y() * math.cos(helix.omega*time) * helix.omega
+    v_z = helix.vz()
+    return TVector3(v_x, v_y, v_z)
+
+
+def compute_IP_wrt_direction(helix, primary_vertex, jet_direction, debug = False):
+    """Given a helix object, compute the impact parameter with respect to a given direction, as illustrated in the following note:
+    D. Brown, M. Frank, Tagging b hadrons using impact parameters, ALEPH note 92-135.
+
+    primary_vertex and jet_direction must be TVector3 objects.
+    The function computes the IP and all the other quantities and store these as attributes of the helix object.
+
+    This version of the impact parameter is more complicated than the common one,
+    because it computes firstly the minimum approach between the helix and the jet
+    direction, then the track is linearized at this point, and the impact
+    parameter is computed as the closest approach between
+    the linearized track and the primary vertex.
+
+    debug option prints some important variables while running the code.
+
+    In the code you can find a few comments with the names of the variables
+    used in the ALEPH note.
+    """
+    helix.primary_vertex = primary_vertex    # primary_vertex = v
+    helix.jet_direction = jet_direction      # jet_direction = j
+    helix.jet_line = straight_line(helix.primary_vertex, helix.jet_direction)
+
+    def jet_track_distance(time):
+        helix_point = helix.point_at_time(time)
+        jet_track_vector = helix.jet_line.distance_from_point(helix_point)
+        return jet_track_vector.Mag()
+
+    helix.min_approach = minimize_scalar(jet_track_distance,
+                                        bracket = None,
+                                        bounds = [-1e-11, 1e-11],
+                                        args=(),
+                                        method='bounded',
+                                        tol=None,
+                                        options={'disp': 0, 'maxiter': 1e5, 'xatol': 1e-20} )
+    helix.min_approach_time = helix.min_approach.x
+
+    if debug:
+        print
+        print "time_min_approach"
+        print helix.min_approach_time
+        print
+
+    helix.point_min_approach = helix.point_at_time(helix.min_approach_time)          # S_t
+    helix.velocity_min_approach = velocity_at_time(helix, helix.min_approach_time)
+    helix.linearized_track = straight_line(helix.point_min_approach, helix.velocity_min_approach)
+
+    if debug:
+        print "point_min_approach"
+        helix.point_min_approach.Dump()
+        print
+        print "velocity_min_approach"
+        helix.velocity_min_approach.Dump()
+        print
+        print "distance between point min approach and jet dir"
+        print jet_track_distance(helix.min_approach_time)
+        print
+
+    # S_j
+    helix.jet_point_min_approach = helix.point_min_approach \
+                                   + helix.jet_line.distance_from_point(helix.point_min_approach)
+
+    if debug:
+        print "helix.jet_line.distance_from_point(point_min_approach)"
+        helix.jet_line.distance_from_point(point_min_approach).Dump()
+        print
+        print "jet_point_min_approach"
+        jet_point_min_approach.Dump()
+        print
+
+
+    helix.min_dist_to_jet = helix.point_min_approach - helix.jet_point_min_approach    # D_j = S_t - S_j
+
+    # D
+    helix.vector_impact_parameter = helix.linearized_track.distance_from_point(helix.primary_vertex)
+    helix.s_j_minus_v_wrt_jet_dir = helix.jet_direction.Dot( helix.jet_point_min_approach\
+                                                           - helix.primary_vertex )
+    helix.sign_impact_parameter = sign( helix.s_j_minus_v_wrt_jet_dir )
+    helix.s_j_wrt_pr_vtx = (helix.jet_point_min_approach - helix.primary_vertex).Mag() * helix.sign_impact_parameter
+    helix.impact_parameter = helix.vector_impact_parameter.Mag() * helix.sign_impact_parameter
+
+    if debug:
+        print "jet_point_min_approach - primary_vertex"
+        (jet_point_min_approach - primary_vertex).Dump()
+        print
+        print "vector_impact_parameter"
+        vector_impact_parameter.Dump()
+        print
+
+
+def compute_IP(helix, primary_vertex, jet_direction):
+    """ Given a helix object and a primary vertex, compute the impact parameter
+    with respect to the primary vertex.
+
+    The impact parameter is the vector of closest approach between the helix and
+    the primary vertex. The jet direction is used only to give a sign to the IP.
+    Primary vertex and jet direction must be TVector3 objects.
+
+    The function returns the vector IP (pointing from the primary vertex to the
+    helix point of closest approach), the sign and the IP (that is the magnitude
+    of the vector IP with the proper sign) as attributes of the helix object.
+    """
+    helix.primary_vertex = primary_vertex
+    helix.jet_direction = jet_direction.Unit()
+
+    def pr_vertex_track_distance(time):
+        helix_point = helix.point_at_time(time)
+        pr_vertex_track_vector = helix_point - helix.primary_vertex
+        return pr_vertex_track_vector.Mag()
+
+    helix.min_approach = minimize_scalar(pr_vertex_track_distance,
+                                        bracket = None,
+                                        bounds = [-1e-11, 1e-11],
+                                        args=(),
+                                        method='bounded',
+                                        tol=None,
+                                        options={'disp': 0, 'maxiter': 1e5, 'xatol': 1e-20} )
+    helix.min_approach_time = helix.min_approach.x
+
+    helix.vector_impact_parameter = helix.point_at_time(helix.min_approach_time) - helix.primary_vertex
+    helix.ip_proj_jet_axis = helix.jet_direction.Dot( helix.vector_impact_parameter )
+    helix.sign_impact_parameter = sign( helix.ip_proj_jet_axis )
+    helix.impact_parameter = helix.vector_impact_parameter.Mag() * helix.sign_impact_parameter
+
+
+from ROOT import TCanvas, TGraph, TLine
+class vertex_displayer(object):
+    """Debug class for displaying vertices, tracks and impact parameters on the transverse plane, based on ROOT classes.
+    """
+
+    def __init__(self, name, title, lenght, time_min, time_max, helix, n_points = 100, ip_algorithm = 'complex'):
+        """
+        Constructor providing:
+        name: string used to identify ROOT objects
+        title: string used as title of canvases and graphs
+        lenght: half of the axis dimension
+        time_min and time_max: defining the time interval for which the track is shown
+        helix: helix object to be shown; having the ip attributes is mandatory
+        n_points: number of points that show the track
+        ip_algorithm: if 'complex' it shows also the distance of
+        closest approach to the jet direction, and the linearized track at
+        that point. It requires to have run the function compute_IP_wrt_direction
+        on the helix object.
+        """
+        self.name = name
+        self.title = title
+        self.helix = helix
+        self.ip_algorithm = ip_algorithm
+
+        self.gr_transverse = TGraph()
+        self.gr_transverse.SetNameTitle("g_tr_" + name, title)
+        self.gr_transverse.SetPoint(0,0.,0.)
+        self.gr_transverse.SetPoint(1,0.,lenght)
+        self.gr_transverse.SetPoint(2,0.,-lenght)
+        self.gr_transverse.SetPoint(3,lenght,0.)
+        self.gr_transverse.SetPoint(4,-lenght,0.)
+        self.gr_transverse.SetMarkerStyle(22)
+        self.gr_transverse.SetMarkerColor(3)
+        self.gr_transverse.GetXaxis().SetTitle("X axis")
+        self.gr_transverse.GetYaxis().SetTitle("Y axis")
+
+        # Origin
+        self.gr_transverse.SetPoint(5, helix.origin.X(), helix.origin.Y())
+
+        # Track
+        self.ell_transverse = TGraph()
+        self.ell_transverse.SetNameTitle("g_ellipse_" + name, title)
+        self.ell_transverse.SetMarkerStyle(7)
+        self.ell_transverse.SetMarkerColor(1)
+
+        for i in range(n_points):
+            time_coord = time_min + i*(time_max-time_min)/n_points
+            point = helix.point_at_time(time_coord)
+            self.ell_transverse.SetPoint(i, point.X(), point.Y())
+
+        # Jet direction
+        jet_dir_x1 = self.helix.primary_vertex.X() - lenght * self.helix.jet_direction.X()
+        jet_dir_x2 = self.helix.primary_vertex.X() + lenght * self.helix.jet_direction.X()
+        jet_dir_y1 = self.helix.primary_vertex.Y() - lenght * self.helix.jet_direction.Y()
+        jet_dir_y2 = self.helix.primary_vertex.Y() + lenght * self.helix.jet_direction.Y()
+
+        self.jet_dir = TLine(jet_dir_x1, jet_dir_y1, jet_dir_x2, jet_dir_y2)
+        self.jet_dir.SetLineColor(6)
+        self.jet_dir.SetLineStyle(1)
+        self.jet_dir.SetLineWidth(1)
+
+        # Impact Parameter D
+        impact_parameter_x1 = self.helix.primary_vertex.X()
+        impact_parameter_y1 = self.helix.primary_vertex.Y()
+        impact_parameter_x2 = self.helix.vector_impact_parameter.X()
+        impact_parameter_y2 = self.helix.vector_impact_parameter.Y()
+
+        self.impact_parameter = TLine(impact_parameter_x1,
+                                      impact_parameter_y1,
+                                      impact_parameter_x2,
+                                      impact_parameter_y2)
+        self.impact_parameter.SetLineColor(4)
+        self.impact_parameter.SetLineStyle(6)
+        self.impact_parameter.SetLineWidth(4)
+
+        if self.ip_algorithm == 'complex':
+            # Linearized_track
+            lin_track_x1 = self.helix.linearized_track.origin.X() \
+                         - lenght * self.helix.linearized_track.direction.X()
+            lin_track_x2 = self.helix.linearized_track.origin.X() \
+                         + lenght * self.helix.linearized_track.direction.X()
+            lin_track_y1 = self.helix.linearized_track.origin.Y() \
+                         - lenght * self.helix.linearized_track.direction.Y()
+            lin_track_y2 = self.helix.linearized_track.origin.Y() \
+                         + lenght * self.helix.linearized_track.direction.Y()
+
+            self.lin_track = TLine(lin_track_x1,
+                                   lin_track_y1,
+                                   lin_track_x2,
+                                   lin_track_y2)
+            self.lin_track.SetLineColor(2)
+            self.lin_track.SetLineStyle(9)
+            self.lin_track.SetLineWidth(2)
+
+            # Jet-track distance D_j: vector from S_j to S_t
+            jet_track_distance_x1 = self.helix.jet_point_min_approach.X()
+            jet_track_distance_y1 = self.helix.jet_point_min_approach.Y()
+            jet_track_distance_x2 = self.helix.point_min_approach.X()
+            jet_track_distance_y2 = self.helix.point_min_approach.Y()
+
+            self.jet_track_distance = TLine(jet_track_distance_x1,
+                                            jet_track_distance_y1,
+                                            jet_track_distance_x2,
+                                            jet_track_distance_y2)
+            self.jet_track_distance.SetLineColor(3)
+            self.jet_track_distance.SetLineStyle(3)
+            self.jet_track_distance.SetLineWidth(4)
+
+    def draw(self):
+        """Draw the canvas showing the transverse plane to the beam axis.
+
+        In particular it shows the x-y axis, the track, the jet direction and
+        the impact parameter.
+        If the ip_algorithm 'complex' is enabled it also shows the distance of
+        closest approach to the jet direction, and the linearized track at
+        that point.
+        """
+        self.c_transverse = TCanvas("c_tr_" + self.name, self.title, 800, 600)
+        self.c_transverse.cd()
+        self.c_transverse.SetGrid()
+        self.gr_transverse.Draw("AP")
+        self.ell_transverse.Draw("same LP")
+        self.jet_dir.Draw("same")
+        self.impact_parameter.Draw("same")
+
+        if self.ip_algorithm == 'complex':
+            self.lin_track.Draw("same")
+            self.jet_track_distance.Draw("same")


### PR DESCRIPTION
This pull request is mainly about the modelling of b tagging. 
It includes Nicolò's model and a fix of the parametrized b tagging. 

Nicolò's modelling is discussed here: 
https://github.com/HEP-FCC/heppy/issues/48
There is still work to be done on the tuning and the software integration side, but it is worth starting to use it. 

The parametrized b tagging involves a matching of reconstructed jets to the b quarks, to decide whether a jet should be considered as a bjet or not. 
Previously, this matching was done by delta R in the eta, phi space, and it was fairly inefficient, leading to an artificial degradation of the b tagging efficiency. 

Now, it's done in the following way: 
   * the gen particles corresponding to the reconstructed jet particles are found using @alicerobson history tools
   * if a gen particle comes from the decay of a B hadron (again @alicerobson history tool), the corresponding reconstructed particle is flagged as coming from B
   * the jet energy fraction carried by reconstructed particles coming from b is computed 
   * if the fraction is > 0.05, the jet is flagged as a b jet, and we can then apply the chosen detector performance. 

The matching efficiency is now ~99% (depends on the jet energy), for a mismatching rate (probability to flag a light jet as coming from a b) of about 10^-3. Therefore, one can consider that the matching does not bias the b tagging efficiency anymore. 

The other features affect analyses I'm the only one to perform at the moment and are not worth mentioning.

@kbehr @JanikvA @jndrf