### PR TITLE
Matcher now returns dr depending on the collider type

### DIFF
--- a/analyzers/Matcher.py
+++ b/analyzers/Matcher.py
@@ -114,6 +114,5 @@ class Matcher(Analyzer):
                     drname = 'dr'
                     if pdgid:
                         drname = 'dr_{pdgid}'.format(pdgid=pdgid)
-                    dr = deltaR(ptc.theta(), ptc.phi(),
-                                match.theta(), match.phi())
+                    dr = deltaR(ptc, match)
                     setattr(ptc, drname, dr)


### PR DESCRIPTION
I replaced the explicit calls to the properties with the particles. It seems to be working fine, solves #52 