### PR TITLE
Pdebugtest: Adding tests to heppy which check the papas Physics outputs have not changed

### DIFF
--- a/analyzers/PDebugger.py
+++ b/analyzers/PDebugger.py
@@ -39,7 +39,7 @@ class PDebugger(Analyzer):
             pdebug.set_stream(sys.stdout,level=logging.INFO)
             pdebug.pdebugger.setLevel(logging.INFO)
 
-        #turn on output to file if requested
+        #turn on output to file if requested, if filename is None then no output is produced
         if hasattr(self.cfg_ana, 'debug_filename') and self.cfg_ana.debug_filename:
             pdebug.set_file(self.cfg_ana.debug_filename)
             pdebug.pdebugger.setLevel(logging.INFO)

--- a/analyzers/PDebugger.py
+++ b/analyzers/PDebugger.py
@@ -40,7 +40,7 @@ class PDebugger(Analyzer):
             pdebug.pdebugger.setLevel(logging.INFO)
 
         #turn on output to file if requested
-        if hasattr(self.cfg_ana, 'debug_filename'):
+        if hasattr(self.cfg_ana, 'debug_filename') and self.cfg_ana.debug_filename:
             pdebug.set_file(self.cfg_ana.debug_filename)
             pdebug.pdebugger.setLevel(logging.INFO)
 

--- a/papas/pfalgo/blockbuilder.py
+++ b/papas/pfalgo/blockbuilder.py
@@ -59,7 +59,7 @@ class BlockBuilder(SubgraphBuilder):
             block = PFBlock(subgraph, self.edges, self.startindex + len(self.blocks), subtype=self.subtype)        
             pdebugger.info("Made {}".format(block))
             #put the block in the dict of blocks            
-            self.blocks[block.uniqueid] = block        
+            self.blocks[block.uniqueid] = block
             
             #make a node for the block and add into the history Nodes
             if (self.history != None):

--- a/papas/pfalgo/pfreconstructor.py
+++ b/papas/pfalgo/pfreconstructor.py
@@ -92,12 +92,14 @@ class PFReconstructor(object):
             sblock = self.splitblocks[b]
             pdebugger.info('Processing {}'.format(sblock))
             self.reconstruct_block(sblock)
+            pdebugger.info("Finished block")
 
         #check if anything is unused
         if len(self.unused):
             self.log.warning(str(self.unused))
         self.log.info("Particles:")
-        self.log.info(str(self))         
+        self.log.info(str(self))
+        pdebugger.info("Finished reconstruction")
 
     def simplify_blocks(self, block, history_nodes=None):
         ''' Block: a block which contains list of element ids and set of edges that connect them

--- a/test/analysis_ee_ZH_cfg.py
+++ b/test/analysis_ee_ZH_cfg.py
@@ -217,7 +217,7 @@ from heppy.analyzers.PDebugger import PDebugger
 pdebug = cfg.Analyzer(
 PDebugger,
 output_to_stdout = False, #optional
-debug_filename = None #os.getcwd()+'/python_physics_debug.log' #optional argument
+debug_filename = None #No physics debug output unless this is subsequently set
 )
 
 # definition of a sequence of analyzers,

--- a/test/analysis_ee_ZH_cfg.py
+++ b/test/analysis_ee_ZH_cfg.py
@@ -217,14 +217,14 @@ from heppy.analyzers.PDebugger import PDebugger
 pdebug = cfg.Analyzer(
 PDebugger,
 output_to_stdout = False, #optional
-debug_filename = os.getcwd()+'/python_physics_debug.log' #optional argument
+debug_filename = None #os.getcwd()+'/python_physics_debug.log' #optional argument
 )
 
 # definition of a sequence of analyzers,
 # the analyzers will process each event in this order
 sequence = cfg.Sequence(
     source,
-    #pdebug,
+    pdebug,
     papas_sequence,
     leptons_true,
     iso_leptons,

--- a/test/analysis_ee_Z_cfg.py
+++ b/test/analysis_ee_Z_cfg.py
@@ -87,10 +87,19 @@ if do_clic:
     display.detector = clic
     pfreconstruct.detector = clic
 
+        
+from heppy.analyzers.PDebugger import PDebugger
+pdebug = cfg.Analyzer(
+PDebugger,
+output_to_stdout = False, #optional
+debug_filename = None #os.getcwd()+'/python_physics_dd.log' #optional argument
+)
+
 # definition of a sequence of analyzers,
 # the analyzers will process each event in this order
 sequence = cfg.Sequence(
     source,
+    pdebug,
     # gen_particles_stable, 
     papas_sequence,
     sum_particles,

--- a/test/analysis_ee_Z_cfg.py
+++ b/test/analysis_ee_Z_cfg.py
@@ -87,12 +87,11 @@ if do_clic:
     display.detector = clic
     pfreconstruct.detector = clic
 
-        
 from heppy.analyzers.PDebugger import PDebugger
 pdebug = cfg.Analyzer(
 PDebugger,
 output_to_stdout = False, #optional
-debug_filename = None #os.getcwd()+'/python_physics_dd.log' #optional argument
+debug_filename = None #No output
 )
 
 # definition of a sequence of analyzers,

--- a/test/data/pdebug_python_check.sh
+++ b/test/data/pdebug_python_check.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#pdebug_python_CMS.sh ../physics_cms.txt $HEPPY/data/required_cms_physics.txt
+FILE="compare.out"
+if [ -f $FILE ]
+then
+rm $FILE
+fi
+if [ ! $# == 2 ]
+then
+ echo "Usage: pdebug_python.sh input file compare file"
+ return 1
+fi
+
+PHYSICS=$1 #"physics_cms.txt"
+MATCHPHYSICS=$2 #$HEPPY/data/required_cms_physics.txt
+
+if ([ -f $PHYSICS ] && [ -f $MATCHPHYSICS ])
+then
+
+diff $MATCHPHYSICS $PHYSICS  >  $FILE
+
+if [ -f $FILE ]
+then
+if [[ -s $FILE ]];
+then
+echo "$FILE is different"
+return 1
+else
+echo "$FILE matches"
+return 0
+#rm $FILE
+
+fi
+else
+echo "$FILE not found."
+fi
+else
+echo "$PHYSICS or $MATCHPHYSICS not found."
+fi
+return 1

--- a/test/data/required_clic_physics_dd.txt
+++ b/test/data/required_clic_physics_dd.txt
@@ -1,0 +1,11662 @@
+Event: 0
+Made Particle :ps0   :10261498607108620288: pdgid =  -211, status =   1, q = -1, e =  13.3, theta = -1.38, phi = -2.25, mass =  0.14
+Made Particle :ps1   :10261490060979339265: pdgid =  -211, status =   1, q = -1, e =   9.4, theta = -1.35, phi = -1.93, mass =  0.14
+Made Particle :ps2   :10261481210916110338: pdgid =   211, status =   1, q =  1, e =   6.7, theta =  1.21, phi =  0.81, mass =  0.14
+Made Particle :ps3   :10261474723567239171: pdgid =   211, status =   1, q =  1, e =   5.2, theta =  1.25, phi =  1.23, mass =  0.14
+Made Particle :ps4   :10261474081645789188: pdgid =  -211, status =   1, q = -1, e =   5.1, theta =  1.39, phi =  0.35, mass =  0.14
+Made Particle :ps5   :10261473545005563909: pdgid =   130, status =   1, q =  0, e =   5.0, theta =  1.42, phi = -2.01, mass =  0.50
+Made Particle :ps6   :10261468715417600006: pdgid =  -211, status =   1, q = -1, e =   3.9, theta = -1.39, phi = -2.05, mass =  0.14
+Made Particle :ps7   :10261464894979178503: pdgid =    22, status =   1, q =  0, e =   3.5, theta = -1.35, phi = -2.45, mass =  0.00
+Made Particle :ps8   :10261463987241615368: pdgid =   130, status =   1, q =  0, e =   3.4, theta =  1.28, phi =  0.20, mass =  0.50
+Made Particle :ps9   :10261463082788192265: pdgid =  -321, status =   1, q = -1, e =   3.3, theta =  1.32, phi =  1.25, mass =  0.49
+Made Particle :ps10  :10261458547615203338: pdgid =  -211, status =   1, q = -1, e =   2.8, theta =  1.22, phi =  1.14, mass =  0.14
+Made Particle :ps11  :10261457984393576459: pdgid =    22, status =   1, q =  0, e =   2.7, theta =  1.32, phi =  2.03, mass =  0.00
+Made Particle :ps12  :10261457545098952716: pdgid =   211, status =   1, q =  1, e =   2.7, theta = -1.33, phi = -1.73, mass =  0.14
+Made Particle :ps13  :10261452786583470093: pdgid =    22, status =   1, q =  0, e =   2.1, theta =  1.44, phi =  0.13, mass =  0.00
+Made Particle :ps14  :10261448010242195470: pdgid =    22, status =   1, q =  0, e =   1.8, theta = -1.24, phi = -2.70, mass =  0.00
+Made Particle :ps15  :10261446753907638287: pdgid =    22, status =   1, q =  0, e =   1.7, theta =  1.24, phi =  0.95, mass =  0.00
+Made Particle :ps16  :10261446601186738192: pdgid =   211, status =   1, q =  1, e =   1.7, theta = -1.35, phi = -2.03, mass =  0.14
+Made Particle :ps17  :10261444104676179985: pdgid =   211, status =   1, q =  1, e =   1.6, theta =  1.18, phi =  0.92, mass =  0.14
+Made Particle :ps18  :10261442165957722130: pdgid =    22, status =   1, q =  0, e =   1.5, theta = -1.51, phi =  2.80, mass =  0.00
+Made Particle :ps19  :10261440306142511123: pdgid =  -211, status =   1, q = -1, e =   1.3, theta = -1.16, phi = -2.90, mass =  0.14
+Made Particle :ps20  :10261439152390144020: pdgid =   321, status =   1, q =  1, e =   1.3, theta =  1.53, phi =  1.44, mass =  0.49
+Made Particle :ps21  :10261439010320678933: pdgid =   211, status =   1, q =  1, e =   1.3, theta = -1.15, phi = -2.03, mass =  0.14
+Made Particle :ps22  :10261431146441080854: pdgid =    22, status =   1, q =  0, e =   0.9, theta =  1.34, phi =  0.76, mass =  0.00
+Made Particle :ps23  :10261428676786651159: pdgid =   211, status =   1, q =  1, e =   0.8, theta =  1.11, phi =  2.13, mass =  0.14
+Made Particle :ps24  :10261428168762064920: pdgid =    22, status =   1, q =  0, e =   0.8, theta = -1.25, phi = -2.88, mass =  0.00
+Made Particle :ps25  :10261427248015867929: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  1.25, phi =  1.80, mass =  0.00
+Made Particle :ps26  :10261427087829106714: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  1.34, phi = -0.08, mass =  0.00
+Made Particle :ps27  :10261426472839282715: pdgid =    22, status =   1, q =  0, e =   0.8, theta = -1.41, phi = -2.76, mass =  0.00
+Made Particle :ps28  :10261425531337572380: pdgid =  -211, status =   1, q = -1, e =   0.8, theta =  0.84, phi =  1.15, mass =  0.14
+Made Particle :ps29  :10261424344318083101: pdgid =    22, status =   1, q =  0, e =   0.7, theta = -1.13, phi = -2.79, mass =  0.00
+Made Particle :ps30  :10261422556040921118: pdgid =    22, status =   1, q =  0, e =   0.7, theta = -0.95, phi = -0.00, mass =  0.00
+Made Particle :ps31  :10261418861440008223: pdgid =   211, status =   1, q =  1, e =   0.6, theta = -0.30, phi =  2.66, mass =  0.14
+Made Particle :ps32  :10261411245657686048: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -1.20, phi = -0.03, mass =  0.00
+Made Particle :ps33  :10261409756753166369: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -1.28, phi = -2.10, mass =  0.00
+Made Particle :ps34  :10261406339324444706: pdgid =  -211, status =   1, q = -1, e =   0.4, theta =  0.50, phi = -0.51, mass =  0.14
+Made Particle :ps35  :10261402189345849379: pdgid =  -211, status =   1, q = -1, e =   0.3, theta =  0.69, phi = -1.54, mass =  0.14
+Made Particle :ps36  :10261400409943834660: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -1.33, phi = -1.83, mass =  0.00
+Made Particle :ps37  :10261395243144314917: pdgid =   211, status =   1, q =  1, e =   0.2, theta =  0.46, phi = -1.82, mass =  0.14
+Made Particle :ps38  :10261386093907673126: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.94, phi = -1.76, mass =  0.00
+Made Particle :ps39  :10261275077418942503: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.97, phi = -2.73, mass =  0.00
+Simulating Particle :ps0   :10261498607108620288: pdgid =  -211, status =   1, q = -1, e =  13.3, theta = -1.38, phi = -2.25, mass =  0.14
+Simulating Hadron
+Made Track: tt0   :7964662795539054592:   13.31    2.52 -1.38 -2.25
+Made SmearedTrack: ts0   :7955655456431538176:   13.24    2.51 -1.38 -2.25
+Made Cluster: et0   :3352966091155439616:    8.45 -1.38 -2.19 sub(et0, )
+Made SmearedCluster: es0   :3343961681505026048:    9.72 -1.38 -2.19 sub(es0, )
+Made Cluster: ht0   :5658794306924707840:    4.86 -1.38 -2.18 sub(ht0, )
+Made SmearedCluster: hs0   :5649794395665334272:    6.52 -1.38 -2.18 sub(hs0, )
+Simulating Particle :ps1   :10261490060979339265: pdgid =  -211, status =   1, q = -1, e =   9.4, theta = -1.35, phi = -1.93, mass =  0.14
+Simulating Hadron
+Made Track: tt1   :7964654248747073537:    9.42    2.02 -1.35 -1.93
+Made SmearedTrack: ts1   :7955646938961936385:    9.37    2.01 -1.35 -1.93
+Made Cluster: et1   :3352954792017133569:    5.65 -1.35 -1.84 sub(et1, )
+Made SmearedCluster: es1   :3343947884729991169:    5.72 -1.35 -1.84 sub(es1, )
+Made Cluster: ht1   :5658788472043864065:    3.77 -1.35 -1.83 sub(ht1, )
+Made SmearedCluster: hs1   :5649785307717959681:    4.45 -1.35 -1.83 sub(hs1, )
+Simulating Particle :ps2   :10261481210916110338: pdgid =   211, status =   1, q =  1, e =   6.7, theta =  1.21, phi =  0.81, mass =  0.14
+Simulating Hadron
+Made Track: tt2   :7964645394560843778:    6.70    2.39  1.21  0.81
+Made SmearedTrack: ts2   :7955638181305516034:    6.69    2.39  1.21  0.81
+Made Cluster: et2   :3352928932342005762:    1.94  1.21  0.68 sub(et2, )
+Made SmearedCluster: es2   :3343901177346523138:    0.89  1.21  0.68 sub(es2, )
+Made Cluster: ht2   :5658793843208749058:    4.75  1.21  0.67 sub(ht2, )
+Made SmearedCluster: hs2   :5649784452671340546:    4.26  1.21  0.67 sub(hs2, )
+Simulating Particle :ps3   :10261474723567239171: pdgid =   211, status =   1, q =  1, e =   5.2, theta =  1.25, phi =  1.23, mass =  0.14
+Simulating Hadron
+Made Track: tt3   :7964638905404227587:    5.22    1.67  1.25  1.23
+Made SmearedTrack: ts3   :7955631586106408963:    5.19    1.66  1.25  1.23
+Made Cluster: ht3   :5658795904394592259:    5.22  1.25  1.06 sub(ht3, )
+Made SmearedCluster: hs3   :5649793861644451843:    6.40  1.25  1.06 sub(hs3, )
+Simulating Particle :ps4   :10261474081645789188: pdgid =  -211, status =   1, q = -1, e =   5.1, theta =  1.39, phi =  0.35, mass =  0.14
+Simulating Hadron
+Made Track: tt4   :7964638263249993732:    5.08    0.91  1.39  0.35
+Made SmearedTrack: ts4   :7955631177795108868:    5.10    0.92  1.39  0.35
+Made Cluster: et3   :3352943314629296131:    3.52  1.39  0.51 sub(et3, )
+Made SmearedCluster: es3   :3343887618778595331:    0.50  1.39  0.51 sub(es3, )
+Made Cluster: ht4   :5658765101675577348:    1.55  1.39  0.52 sub(ht4, )
+Made SmearedCluster: hs4   :5649747044332470276:    0.97  1.39  0.52 sub(hs4, )
+Rejected SmearedCluster: hs4   :5649747044332470276:    0.97  1.39  0.52 sub(hs4, )
+Simulating Particle :ps5   :10261473545005563909: pdgid =   130, status =   1, q =  0, e =   5.0, theta =  1.42, phi = -2.01, mass =  0.50
+Simulating Hadron
+Made Cluster: et4   :3352934182314573828:    2.48  1.42 -2.01 sub(et4, )
+Made SmearedCluster: es4   :3343929045973729284:    2.72  1.42 -2.01 sub(es4, )
+Made Cluster: ht5   :5658777075765477381:    2.47  1.42 -2.01 sub(ht5, )
+Made SmearedCluster: hs4   :5649781989086068740:    3.85  1.42 -2.01 sub(hs4, )
+Simulating Particle :ps6   :10261468715417600006: pdgid =  -211, status =   1, q = -1, e =   3.9, theta = -1.39, phi = -2.05, mass =  0.14
+Simulating Hadron
+Made Track: tt5   :7964632883644071941:    3.93    0.70 -1.39 -2.05
+Made SmearedTrack: ts5   :7955625694086561797:    3.93    0.70 -1.39 -2.05
+Made Cluster: et5   :3352911010460598277:    0.96 -1.39 -1.85 sub(et5, )
+Made SmearedCluster: es5   :3343870813785817093:    0.26 -1.39 -1.85 sub(es5, )
+Rejected SmearedCluster: es5   :3343870813785817093:    0.26 -1.39 -1.85 sub(es5, )
+Made Cluster: ht6   :5658781430134603782:    2.97 -1.39 -1.83 sub(ht6, )
+Made SmearedCluster: hs5   :5649770680642699269:    2.56 -1.39 -1.83 sub(hs5, )
+Simulating Particle :ps7   :10261464894979178503: pdgid =    22, status =   1, q =  0, e =   3.5, theta = -1.35, phi = -2.45, mass =  0.00
+Simulating Photon
+Made Cluster: et6   :3352943066592837638:    3.49 -1.35 -2.45 sub(et6, )
+Made SmearedCluster: es5   :3343932824183898117:    3.15 -1.35 -2.45 sub(es5, )
+Simulating Particle :ps8   :10261463987241615368: pdgid =   130, status =   1, q =  0, e =   3.4, theta =  1.28, phi =  0.20, mass =  0.50
+Simulating Hadron
+Made Cluster: ht7   :5658785168068968455:    3.39  1.28  0.20 sub(ht7, )
+Made SmearedCluster: hs6   :5649771029908684806:    2.60  1.28  0.20 sub(hs6, )
+Simulating Particle :ps9   :10261463082788192265: pdgid =  -321, status =   1, q = -1, e =   3.3, theta =  1.32, phi =  1.25, mass =  0.49
+Simulating Hadron
+Made Track: tt6   :7964626944998244358:    3.25    0.80  1.32  1.25
+Made SmearedTrack: ts6   :7955619570587271174:    3.23    0.79  1.32  1.25
+Made Cluster: ht8   :5658784263615545352:    3.29  1.33  1.52 sub(ht8, )
+Made SmearedCluster: hs7   :5649785678460878855:    4.54  1.33  1.52 sub(hs7, )
+Simulating Particle :ps10  :10261458547615203338: pdgid =  -211, status =   1, q = -1, e =   2.8, theta =  1.22, phi =  1.14, mass =  0.14
+Simulating Hadron
+Made Track: tt7   :7964622706737938439:    2.77    0.94  1.22  1.14
+Made SmearedTrack: ts7   :7955616035401367559:    2.83    0.96  1.22  1.14
+Made Cluster: ht9   :5658779728442556425:    2.77  1.23  1.47 sub(ht9, )
+Made SmearedCluster: hs8   :5649784175887122440:    4.19  1.23  1.47 sub(hs8, )
+Simulating Particle :ps11  :10261457984393576459: pdgid =    22, status =   1, q =  0, e =   2.7, theta =  1.32, phi =  2.03, mass =  0.00
+Simulating Photon
+Made Cluster: et7   :3352936156007235591:    2.71  1.32  2.03 sub(et7, )
+Made SmearedCluster: es6   :3343929363155386374:    2.75  1.32  2.03 sub(es6, )
+Simulating Particle :ps12  :10261457545098952716: pdgid =   211, status =   1, q =  1, e =   2.7, theta = -1.33, phi = -1.73, mass =  0.14
+Simulating Hadron
+Made Track: tt8   :7964621702894190600:    2.66    0.64 -1.33 -1.73
+Made SmearedTrack: ts8   :7955614673162731528:    2.67    0.64 -1.33 -1.73
+Rejected SmearedTrack: ts8   :7955614673162731528:    2.67    0.64 -1.33 -1.73
+Made Cluster: et8   :3352921401232195592:    1.52 -1.33 -2.04 sub(et8, )
+Made SmearedCluster: es7   :3343923398972538887:    2.08 -1.33 -2.04 sub(es7, )
+Made Cluster: ht10  :5658757857036730378:    1.14 -1.33 -2.06 sub(ht10, )
+Made SmearedCluster: hs9   :5649746017046757385:    0.94 -1.33 -2.06 sub(hs9, )
+Rejected SmearedCluster: hs9   :5649746017046757385:    0.94 -1.33 -2.06 sub(hs9, )
+Simulating Particle :ps13  :10261452786583470093: pdgid =    22, status =   1, q =  0, e =   2.1, theta =  1.44, phi =  0.13, mass =  0.00
+Simulating Photon
+Made Cluster: et9   :3352930958197129225:    2.12  1.44  0.13 sub(et9, )
+Made SmearedCluster: es8   :3343922217921544200:    1.97  1.44  0.13 sub(es8, )
+Simulating Particle :ps14  :10261448010242195470: pdgid =    22, status =   1, q =  0, e =   1.8, theta = -1.24, phi = -2.70, mass =  0.00
+Simulating Photon
+Made Cluster: et10  :3352926181855854602:    1.79 -1.24 -2.70 sub(et10, )
+Made SmearedCluster: es9   :3343922860656689161:    2.02 -1.24 -2.70 sub(es9, )
+Simulating Particle :ps15  :10261446753907638287: pdgid =    22, status =   1, q =  0, e =   1.7, theta =  1.24, phi =  0.95, mass =  0.00
+Simulating Photon
+Made Cluster: et11  :3352924925521297419:    1.72  1.24  0.95 sub(et11, )
+Made SmearedCluster: es10  :3343909977772261386:    1.28  1.24  0.95 sub(es10, )
+Simulating Particle :ps16  :10261446601186738192: pdgid =   211, status =   1, q =  1, e =   1.7, theta = -1.35, phi = -2.03, mass =  0.14
+Simulating Hadron
+Made Track: tt9   :7964610690696609801:    1.70    0.38 -1.35 -2.03
+Made SmearedTrack: ts8   :7955603783833092104:    1.72    0.38 -1.35 -2.03
+Rejected SmearedTrack: ts8   :7955603783833092104:    1.72    0.38 -1.35 -2.03
+Made Cluster: et12  :3352899868921167884:    0.65 -1.35 -2.50 sub(et12, )
+Made SmearedCluster: es11  :3343908936364326923:    1.22 -1.35 -2.50 sub(es11, )
+Made Cluster: ht11  :5658756420563107851:    1.06 -1.36 -2.55 sub(ht11, )
+Made SmearedCluster: hs9   :5649763365742968841:    1.87 -1.36 -2.55 sub(hs9, )
+Simulating Particle :ps17  :10261444104676179985: pdgid =   211, status =   1, q =  1, e =   1.6, theta =  1.18, phi =  0.92, mass =  0.14
+Simulating Hadron
+Made Track: tt10  :7964608185038274570:    1.56    0.59  1.18  0.92
+Made SmearedTrack: ts8   :7955601087805784072:    1.56    0.59  1.18  0.92
+Made Cluster: et13  :3352913939389218829:    1.09  1.20  0.38 sub(et13, )
+Made SmearedCluster: es12  :3343886927878160396:    0.49  1.20  0.38 sub(es12, )
+Rejected SmearedCluster: es12  :3343886927878160396:    0.49  1.20  0.38 sub(es12, )
+Made Cluster: ht12  :5658735910649331724:    0.47  1.20  0.33 sub(ht12, )
+Made SmearedCluster: hs10  :5649729448931491850:    0.48  1.20  0.33 sub(hs10, )
+Rejected SmearedCluster: hs10  :5649729448931491850:    0.48  1.20  0.33 sub(hs10, )
+Simulating Particle :ps18  :10261442165957722130: pdgid =    22, status =   1, q =  0, e =   1.5, theta = -1.51, phi =  2.80, mass =  0.00
+Simulating Photon
+Made Cluster: et14  :3352920337571381262:    1.46 -1.51  2.80 sub(et14, )
+Made SmearedCluster: es12  :3343910529165950988:    1.31 -1.51  2.80 sub(es12, )
+Rejected SmearedCluster: es12  :3343910529165950988:    1.31 -1.51  2.80 sub(es12, )
+Simulating Particle :ps19  :10261440306142511123: pdgid =  -211, status =   1, q = -1, e =   1.3, theta = -1.16, phi = -2.90, mass =  0.14
+Simulating Hadron
+Made Track: tt11  :7964604368865460235:    1.34    0.54 -1.16 -2.90
+Made SmearedTrack: ts9   :7955597341579280393:    1.35    0.54 -1.16 -2.90
+Made Cluster: ht13  :5658761486969864205:    1.35 -1.19 -2.21 sub(ht13, )
+Made SmearedCluster: hs10  :5649757824419364874:    1.55 -1.19 -2.21 sub(hs10, )
+Simulating Particle :ps21  :10261439010320678933: pdgid =   211, status =   1, q =  1, e =   1.3, theta = -1.15, phi = -2.03, mass =  0.14
+Simulating Hadron
+Made Track: tt12  :7964603065649070092:    1.27    0.52 -1.15 -2.03
+Made SmearedTrack: ts10  :7955596187134853130:    1.29    0.53 -1.15 -2.03
+Made Cluster: ht14  :5658760191148032014:    1.28 -1.18 -2.77 sub(ht14, )
+Made SmearedCluster: hs11  :5649768498713329675:    2.31 -1.18 -2.77 sub(hs11, )
+Simulating Particle :ps22  :10261431146441080854: pdgid =    22, status =   1, q =  0, e =   0.9, theta =  1.34, phi =  0.76, mass =  0.00
+Simulating Photon
+Made Cluster: et15  :3352909318054739983:    0.91  1.34  0.76 sub(et15, )
+Made SmearedCluster: es12  :3343898954107453452:    0.82  1.34  0.76 sub(es12, )
+Simulating Particle :ps23  :10261428676786651159: pdgid =   211, status =   1, q =  1, e =   0.8, theta =  1.11, phi =  2.13, mass =  0.14
+Simulating Hadron
+Made Track: tt13  :7964592458073899021:    0.83    0.37  1.11  2.13
+Made SmearedTrack: ts11  :7955585127944290315:    0.83    0.37  1.11  2.13
+Rejected SmearedTrack: ts11  :7955585127944290315:    0.83    0.37  1.11  2.13
+Made Cluster: et16  :3352863484997009424:    0.15  1.18  1.08 sub(et16, )
+Made SmearedCluster: es13  :3343875635941474317:    0.33  1.18  1.08 sub(es13, )
+Rejected SmearedCluster: es13  :3343875635941474317:    0.33  1.18  1.08 sub(es13, )
+Made Cluster: ht15  :5658744476777054223:    0.69  1.20  0.98 sub(ht15, )
+Made SmearedCluster: hs12  :5649736751210561548:    0.68  1.20  0.98 sub(hs12, )
+Rejected SmearedCluster: hs12  :5649736751210561548:    0.68  1.20  0.98 sub(hs12, )
+Simulating Particle :ps24  :10261428168762064920: pdgid =    22, status =   1, q =  0, e =   0.8, theta = -1.25, phi = -2.88, mass =  0.00
+Simulating Photon
+Made Cluster: et17  :3352906340375724049:    0.83 -1.25 -2.88 sub(et17, )
+Made SmearedCluster: es13  :3343893613625999373:    0.67 -1.25 -2.88 sub(es13, )
+Simulating Particle :ps25  :10261427248015867929: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  1.25, phi =  1.80, mass =  0.00
+Simulating Photon
+Made Cluster: et18  :3352905419629527058:    0.80  1.25  1.80 sub(et18, )
+Made SmearedCluster: es14  :3343899675657764878:    0.84  1.25  1.80 sub(es14, )
+Simulating Particle :ps26  :10261427087829106714: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  1.34, phi = -0.08, mass =  0.00
+Simulating Photon
+Made Cluster: et19  :3352905259442765843:    0.80  1.34 -0.08 sub(et19, )
+Made SmearedCluster: es15  :3343906139961032719:    1.06  1.34 -0.08 sub(es15, )
+Simulating Particle :ps27  :10261426472839282715: pdgid =    22, status =   1, q =  0, e =   0.8, theta = -1.41, phi = -2.76, mass =  0.00
+Simulating Photon
+Made Cluster: et20  :3352904644452941844:    0.78 -1.41 -2.76 sub(et20, )
+Made SmearedCluster: es16  :3343898417857298448:    0.81 -1.41 -2.76 sub(es16, )
+Simulating Particle :ps28  :10261425531337572380: pdgid =  -211, status =   1, q = -1, e =   0.8, theta =  0.84, phi =  1.15, mass =  0.14
+Simulating Hadron
+Made Track: tt14  :7964589263408857102:    0.74    0.49  0.84  1.15
+Made SmearedTrack: ts11  :7955582097668702219:    0.74    0.49  0.84  1.15
+Made Cluster: et21  :3352874715136917525:    0.23  1.01  2.55 sub(et21, )
+Made SmearedCluster: es17  :3341670923508908049:   -0.20  1.01  2.55 sub(es17, )
+Rejected SmearedCluster: es17  :3341670923508908049:   -0.20  1.01  2.55 sub(es17, )
+Made Cluster: ht16  :5658738523792998416:    0.52  1.05  2.69 sub(ht16, )
+Made SmearedCluster: hs12  :5649739604016758796:    0.76  1.05  2.69 sub(hs12, )
+Rejected SmearedCluster: hs12  :5649739604016758796:    0.76  1.05  2.69 sub(hs12, )
+Simulating Particle :ps29  :10261424344318083101: pdgid =    22, status =   1, q =  0, e =   0.7, theta = -1.13, phi = -2.79, mass =  0.00
+Simulating Photon
+Made Cluster: et22  :3352902515931742230:    0.72 -1.13 -2.79 sub(et22, )
+Made SmearedCluster: es17  :3343894287174598673:    0.69 -1.13 -2.79 sub(es17, )
+Simulating Particle :ps30  :10261422556040921118: pdgid =    22, status =   1, q =  0, e =   0.7, theta = -0.95, phi = -0.00, mass =  0.00
+Simulating Photon
+Made Cluster: et23  :3352900727654580247:    0.67 -0.95 -0.00 sub(et23, )
+Made SmearedCluster: es18  :3343894704824516626:    0.70 -0.95 -0.00 sub(es18, )
+Simulating Particle :ps31  :10261418861440008223: pdgid =   211, status =   1, q =  1, e =   0.6, theta = -0.30, phi =  2.66, mass =  0.14
+Simulating Hadron
+Made Track: tt15  :7964582435650273295:    0.55    0.52 -0.30  2.66
+Made SmearedTrack: ts12  :7955575229934206988:    0.55    0.52 -0.30  2.66
+Made Cluster: et24  :3352865446618464280:    0.17 -0.98  0.94 sub(et24, )
+Made SmearedCluster: es19  :3341670923508908051:   -0.11 -0.98  0.94 sub(es19, )
+Rejected SmearedCluster: es19  :3341670923508908051:   -0.11 -0.98  0.94 sub(es19, )
+Made Cluster: ht17  :5658730594629058577:    0.40 -1.11  0.48 sub(ht17, )
+Made SmearedCluster: hs12  :5649716437223211020:    0.30 -1.11  0.48 sub(hs12, )
+Rejected SmearedCluster: hs12  :5649716437223211020:    0.30 -1.11  0.48 sub(hs12, )
+Simulating Particle :ps32  :10261411245657686048: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -1.20, phi = -0.03, mass =  0.00
+Simulating Photon
+Made Cluster: et25  :3352889417271345177:    0.42 -1.20 -0.03 sub(et25, )
+Made SmearedCluster: es19  :3343872020283654163:    0.28 -1.20 -0.03 sub(es19, )
+Rejected SmearedCluster: es19  :3343872020283654163:    0.28 -1.20 -0.03 sub(es19, )
+Simulating Particle :ps33  :10261409756753166369: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -1.28, phi = -2.10, mass =  0.00
+Simulating Photon
+Made Cluster: et26  :3352887928366825498:    0.40 -1.28 -2.10 sub(et26, )
+Made SmearedCluster: es19  :3343885465372590099:    0.47 -1.28 -2.10 sub(es19, )
+Rejected SmearedCluster: es19  :3343885465372590099:    0.47 -1.28 -2.10 sub(es19, )
+Simulating Particle :ps34  :10261406339324444706: pdgid =  -211, status =   1, q = -1, e =   0.4, theta =  0.50, phi = -0.51, mass =  0.14
+Simulating Hadron
+Made Track: tt16  :7964568515623518224:    0.33    0.29  0.50 -0.51
+Made SmearedTrack: ts13  :7955561180844523533:    0.32    0.28  0.50 -0.51
+Rejected SmearedTrack: ts13  :7955561180844523533:    0.32    0.28  0.50 -0.51
+Made Cluster: et27  :3352853902379712539:    0.10  1.23  1.31 sub(et27, )
+Made SmearedCluster: es19  :3341670923508908051:   -0.02  1.23  1.31 sub(es19, )
+Rejected SmearedCluster: es19  :3341670923508908051:   -0.02  1.23  1.31 sub(es19, )
+Made Cluster: ht18  :5658720118612426770:    0.25  1.33  1.79 sub(ht18, )
+Made SmearedCluster: hs12  :5649673933924859916:    0.06  1.33  1.79 sub(hs12, )
+Rejected SmearedCluster: hs12  :5649673933924859916:    0.06  1.33  1.79 sub(hs12, )
+Simulating Particle :ps35  :10261402189345849379: pdgid =  -211, status =   1, q = -1, e =   0.3, theta =  0.69, phi = -1.54, mass =  0.14
+Simulating Hadron
+Made Track: tt17  :7964563915579326481:    0.26    0.20  0.69 -1.54
+Made SmearedTrack: ts13  :7955556504289935373:    0.26    0.20  0.69 -1.54
+Rejected SmearedTrack: ts13  :7955556504289935373:    0.26    0.20  0.69 -1.54
+Made Cluster: ht19  :5658723370173202451:    0.30  1.36  0.48 sub(ht19, )
+Made SmearedCluster: hs12  :5649738740956921868:    0.73  1.36  0.48 sub(hs12, )
+Rejected SmearedCluster: hs12  :5649738740956921868:    0.73  1.36  0.48 sub(hs12, )
+Simulating Particle :ps36  :10261400409943834660: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -1.33, phi = -1.83, mass =  0.00
+Simulating Photon
+Made Cluster: et28  :3352878581557493788:    0.27 -1.33 -1.83 sub(et28, )
+Made SmearedCluster: es19  :3343812987732361235:    0.03 -1.33 -1.83 sub(es19, )
+Rejected SmearedCluster: es19  :3343812987732361235:    0.03 -1.33 -1.83 sub(es19, )
+Simulating Particle :ps38  :10261386093907673126: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.94, phi = -1.76, mass =  0.00
+Simulating Photon
+Made Cluster: et29  :3352864265521332253:    0.16  0.94 -1.76 sub(et29, )
+Made SmearedCluster: es19  :3343863606293823507:    0.20  0.94 -1.76 sub(es19, )
+Rejected SmearedCluster: es19  :3343863606293823507:    0.20  0.94 -1.76 sub(es19, )
+Simulating Particle :ps39  :10261275077418942503: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.97, phi = -2.73, mass =  0.00
+Simulating Photon
+Made Cluster: et30  :3352753249032601630:    0.00 -0.97 -2.73 sub(et30, )
+Made SmearedCluster: es19  :3343775407110357011:    0.01 -0.97 -2.73 sub(es19, )
+Rejected SmearedCluster: es19  :3343775407110357011:    0.01 -0.97 -2.73 sub(es19, )
+Made MergedCluster: em0   :3289844423250149376:    0.50  1.39  0.51 sub(es3, )
+Made MergedCluster: em1   :3289850418097553409:    0.67 -1.25 -2.88 sub(es13, )
+Made MergedCluster: em2   :3289851091646152706:    0.69 -1.13 -2.79 sub(es17, )
+Made MergedCluster: em3   :3289851509296070659:    0.70 -0.95 -0.00 sub(es18, )
+Made MergedCluster: em4   :3289855222328852484:    0.81 -1.41 -2.76 sub(es16, )
+Made MergedCluster: em5   :3289855758579007493:    0.82  1.34  0.76 sub(es12, )
+Made MergedCluster: em6   :3289856480129318918:    0.84  1.25  1.80 sub(es14, )
+Made MergedCluster: em7   :3289857981818077191:    0.89  1.21  0.68 sub(es2, )
+Made MergedCluster: em8   :3289862944432586760:    1.06  1.34 -0.08 sub(es15, )
+Made MergedCluster: em9   :3289865740835880969:    1.22 -1.35 -2.50 sub(es11, )
+Made MergedCluster: em10  :3289866782243815434:    1.28  1.24  0.95 sub(es10, )
+Made MergedCluster: em11  :3289879022393098251:    1.97  1.44  0.13 sub(es8, )
+Made MergedCluster: em12  :3289879665128243212:    2.02 -1.24 -2.70 sub(es9, )
+Made MergedCluster: em13  :3289880203444092941:    2.08 -1.33 -2.04 sub(es7, )
+Made MergedCluster: em14  :3289885850445283342:    2.72  1.42 -2.01 sub(es4, )
+Made MergedCluster: em15  :3289886167626940431:    2.75  1.32  2.03 sub(es6, )
+Made MergedCluster: em16  :3289889628655452176:    3.15 -1.35 -2.45 sub(es5, )
+Made MergedCluster: em17  :3289904689201545233:    5.72 -1.35 -1.84 sub(es1, )
+Made MergedCluster: em18  :3289918485976580114:    9.72 -1.38 -2.19 sub(es0, )
+Made MergedCluster: hm0   :5595714628890918912:    1.55 -1.19 -2.21 sub(hs10, )
+Made MergedCluster: hm1   :5595720170214522881:    1.87 -1.36 -2.55 sub(hs9, )
+Made MergedCluster: hm2   :5595725303184883714:    2.31 -1.18 -2.77 sub(hs11, )
+Made MergedCluster: hm3   :5595753382336790531:    7.01 -1.37 -1.83 sub(hs1, hs5, )
+Made MergedCluster: hm4   :5595727834380238852:    2.60  1.28  0.20 sub(hs6, )
+Made MergedCluster: hm5   :5595738793557622789:    3.85  1.42 -2.01 sub(hs4, )
+Made MergedCluster: hm6   :5595759323830550534:    8.73  1.28  1.49 sub(hs7, hs8, )
+Made MergedCluster: hm7   :5595741257142894599:    4.26  1.21  0.67 sub(hs2, )
+Made MergedCluster: hm8   :5595750666116005896:    6.40  1.25  1.06 sub(hs3, )
+Made MergedCluster: hm9   :5595751200136888329:    6.52 -1.38 -2.18 sub(hs0, )
+Made block:E1T1     :br0   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts4       value=  5.1 (7955631177795108868)
+      e1 = em0       value=  0.5 (3289844423250149376)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.7 (3289850418097553409)
+
+Made block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.7 (3289851091646152706)
+
+Made block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.7 (3289851509296070659)
+
+Made block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.8 (3289855222328852484)
+
+Made block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.8 (3289855758579007493)
+
+Made block:E1       :br6   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.8 (3289856480129318918)
+
+Made block:E1H1T1   :br7   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts2       value=  6.7 (7955638181305516034)
+      h1 = hm7       value=  4.3 (5595741257142894599)
+      e2 = em7       value=  0.9 (3289857981818077191)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  1.1 (3289862944432586760)
+
+Made block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  1.2 (3289865740835880969)
+
+Made block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  1.3 (3289866782243815434)
+
+Made block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  2.0 (3289879022393098251)
+
+Made block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  2.0 (3289879665128243212)
+
+Made block:E1       :br13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  2.1 (3289880203444092941)
+
+Made block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  2.7 (3289885850445283342)
+
+Made block:E1       :br15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  2.8 (3289886167626940431)
+
+Made block:E1       :br16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  3.1 (3289889628655452176)
+
+Made block:E2H3T3   :br17  : ecals = 2 hcals = 3 tracks = 3
+    elements:
+      t0 = ts0       value= 13.2 (7955655456431538176)
+      t1 = ts1       value=  9.4 (7955646938961936385)
+      t2 = ts5       value=  3.9 (7955625694086561797)
+      h3 = hm3       value=  7.0 (5595753382336790531)
+      h4 = hm9       value=  6.5 (5595751200136888329)
+      h5 = hm1       value=  1.9 (5595720170214522881)
+      e6 = em18      value=  9.7 (3289918485976580114)
+      e7 = em17      value=  5.7 (3289904689201545233)
+    distances:
+              t0      t1      t2      h3      h4      h5      e6      e7
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      h3  0.1904  0.0000  0.0000       .
+      h4  0.0000  0.2153  0.1904     ---       .
+      h5  0.2259     ---     ---     ---     ---       .
+      e6  0.0000     ---     ---     ---     ---     ---       .
+      e7     ---  0.0000     ---     ---     ---     ---     ---       .
+
+Made block:H1T1     :br18  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  1.4 (7955597341579280393)
+      h1 = hm0       value=  1.6 (5595714628890918912)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br19  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts10      value=  1.3 (7955596187134853130)
+      h1 = hm2       value=  2.3 (5595725303184883714)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1       :br20  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm4       value=  2.6 (5595727834380238852)
+
+Made block:H1       :br21  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  3.8 (5595738793557622789)
+
+Made block:H1T1     :br22  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  5.2 (7955631586106408963)
+      h1 = hm8       value=  6.4 (5595750666116005896)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T2     :br23  : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts6       value=  3.2 (7955619570587271174)
+      t1 = ts7       value=  2.8 (7955616035401367559)
+      h2 = hm6       value=  8.7 (5595759323830550534)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+
+Made block:T1       :br24  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  0.5 (7955575229934206988)
+
+Made block:T1       :br25  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  0.7 (7955582097668702219)
+
+Made block:T1       :br26  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  1.6 (7955601087805784072)
+
+Splitting block:E2H3T3   :br17  : ecals = 2 hcals = 3 tracks = 3
+    elements:
+      t0 = ts0       value= 13.2 (7955655456431538176)
+      t1 = ts1       value=  9.4 (7955646938961936385)
+      t2 = ts5       value=  3.9 (7955625694086561797)
+      h3 = hm3       value=  7.0 (5595753382336790531)
+      h4 = hm9       value=  6.5 (5595751200136888329)
+      h5 = hm1       value=  1.9 (5595720170214522881)
+      e6 = em18      value=  9.7 (3289918485976580114)
+      e7 = em17      value=  5.7 (3289904689201545233)
+    distances:
+              t0      t1      t2      h3      h4      h5      e6      e7
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      h3  0.1904  0.0000  0.0000       .
+      h4  0.0000  0.2153  0.1904     ---       .
+      h5  0.2259     ---     ---     ---     ---       .
+      e6  0.0000     ---     ---     ---     ---     ---       .
+      e7     ---  0.0000     ---     ---     ---     ---     ---       .
+
+Made block:E1H1T2   :bs0   : ecals = 1 hcals = 1 tracks = 2
+    elements:
+      t0 = ts1       value=  9.4 (7955646938961936385)
+      t1 = ts5       value=  3.9 (7955625694086561797)
+      h2 = hm3       value=  7.0 (5595753382336790531)
+      e3 = em17      value=  5.7 (3289904689201545233)
+    distances:
+              t0      t1      h2      e3
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+      e3  0.0000     ---     ---       .
+
+Made block:E1H1T1   :bs1   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts0       value= 13.2 (7955655456431538176)
+      h1 = hm9       value=  6.5 (5595751200136888329)
+      e2 = em18      value=  9.7 (3289918485976580114)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:H1       :bs2   : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm1       value=  1.9 (5595720170214522881)
+
+Splitting block:H1T2     :br23  : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts6       value=  3.2 (7955619570587271174)
+      t1 = ts7       value=  2.8 (7955616035401367559)
+      h2 = hm6       value=  8.7 (5595759323830550534)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+
+Made block:H1T2     :bs3   : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts6       value=  3.2 (7955619570587271174)
+      t1 = ts7       value=  2.8 (7955616035401367559)
+      h2 = hm6       value=  8.7 (5595759323830550534)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+
+Splitting block:E1H1T1   :br7   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts2       value=  6.7 (7955638181305516034)
+      h1 = hm7       value=  4.3 (5595741257142894599)
+      e2 = em7       value=  0.9 (3289857981818077191)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs4   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts2       value=  6.7 (7955638181305516034)
+      h1 = hm7       value=  4.3 (5595741257142894599)
+      e2 = em7       value=  0.9 (3289857981818077191)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:H1T1     :br22  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  5.2 (7955631586106408963)
+      h1 = hm8       value=  6.4 (5595750666116005896)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs5   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  5.2 (7955631586106408963)
+      h1 = hm8       value=  6.4 (5595750666116005896)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br19  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts10      value=  1.3 (7955596187134853130)
+      h1 = hm2       value=  2.3 (5595725303184883714)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs6   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts10      value=  1.3 (7955596187134853130)
+      h1 = hm2       value=  2.3 (5595725303184883714)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br18  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  1.4 (7955597341579280393)
+      h1 = hm0       value=  1.6 (5595714628890918912)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs7   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  1.4 (7955597341579280393)
+      h1 = hm0       value=  1.6 (5595714628890918912)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:E1T1     :br0   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts4       value=  5.1 (7955631177795108868)
+      e1 = em0       value=  0.5 (3289844423250149376)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs8   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts4       value=  5.1 (7955631177795108868)
+      e1 = em0       value=  0.5 (3289844423250149376)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:T1       :br26  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  1.6 (7955601087805784072)
+
+Made block:T1       :bs9   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  1.6 (7955601087805784072)
+
+Splitting block:T1       :br25  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  0.7 (7955582097668702219)
+
+Made block:T1       :bs10  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  0.7 (7955582097668702219)
+
+Splitting block:T1       :br24  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  0.5 (7955575229934206988)
+
+Made block:T1       :bs11  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  0.5 (7955575229934206988)
+
+Splitting block:H1       :br21  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  3.8 (5595738793557622789)
+
+Made block:H1       :bs12  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  3.8 (5595738793557622789)
+
+Splitting block:H1       :br20  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm4       value=  2.6 (5595727834380238852)
+
+Made block:H1       :bs13  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm4       value=  2.6 (5595727834380238852)
+
+Splitting block:E1       :br16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  3.1 (3289889628655452176)
+
+Made block:E1       :bs14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  3.1 (3289889628655452176)
+
+Splitting block:E1       :br15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  2.8 (3289886167626940431)
+
+Made block:E1       :bs15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  2.8 (3289886167626940431)
+
+Splitting block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  2.7 (3289885850445283342)
+
+Made block:E1       :bs16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  2.7 (3289885850445283342)
+
+Splitting block:E1       :br13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  2.1 (3289880203444092941)
+
+Made block:E1       :bs17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  2.1 (3289880203444092941)
+
+Splitting block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  2.0 (3289879665128243212)
+
+Made block:E1       :bs18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  2.0 (3289879665128243212)
+
+Splitting block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  2.0 (3289879022393098251)
+
+Made block:E1       :bs19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  2.0 (3289879022393098251)
+
+Splitting block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  1.3 (3289866782243815434)
+
+Made block:E1       :bs20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  1.3 (3289866782243815434)
+
+Splitting block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  1.2 (3289865740835880969)
+
+Made block:E1       :bs21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  1.2 (3289865740835880969)
+
+Splitting block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  1.1 (3289862944432586760)
+
+Made block:E1       :bs22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  1.1 (3289862944432586760)
+
+Splitting block:E1       :br6   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.8 (3289856480129318918)
+
+Made block:E1       :bs23  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.8 (3289856480129318918)
+
+Splitting block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.8 (3289855758579007493)
+
+Made block:E1       :bs24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.8 (3289855758579007493)
+
+Splitting block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.8 (3289855222328852484)
+
+Made block:E1       :bs25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.8 (3289855222328852484)
+
+Splitting block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.7 (3289851509296070659)
+
+Made block:E1       :bs26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.7 (3289851509296070659)
+
+Splitting block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.7 (3289851091646152706)
+
+Made block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.7 (3289851091646152706)
+
+Splitting block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.7 (3289850418097553409)
+
+Made block:E1       :bs28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.7 (3289850418097553409)
+
+Processing block:E1H1T2   :bs0   : ecals = 1 hcals = 1 tracks = 2
+    elements:
+      t0 = ts1       value=  9.4 (7955646938961936385)
+      t1 = ts5       value=  3.9 (7955625694086561797)
+      h2 = hm3       value=  7.0 (5595753382336790531)
+      e3 = em17      value=  5.7 (3289904689201545233)
+    distances:
+              t0      t1      h2      e3
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+      e3  0.0000     ---     ---       .
+
+Made Particle :pr0   :10252482751187910656: pdgid =  -211, status =   1, q = -1, e =   9.4, theta = -1.35, phi = -1.93, mass =  0.14 from SmearedTrack: ts1   :7955646938961936385:    9.37    2.01 -1.35 -1.93
+Made Particle :pr1   :10252461525675540481: pdgid =  -211, status =   1, q = -1, e =   3.9, theta = -1.39, phi = -2.05, mass =  0.14 from SmearedTrack: ts5   :7955625694086561797:    3.93    0.70 -1.39 -2.05
+Finished block
+Processing block:E1H1T1   :bs4   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts2       value=  6.7 (7955638181305516034)
+      h1 = hm7       value=  4.3 (5595741257142894599)
+      e2 = em7       value=  0.9 (3289857981818077191)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr2   :10252473997610450946: pdgid =   211, status =   1, q =  1, e =   6.7, theta =  1.21, phi =  0.81, mass =  0.14 from SmearedTrack: ts2   :7955638181305516034:    6.69    2.39  1.21  0.81
+Finished block
+Processing block:H1T2     :bs3   : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts6       value=  3.2 (7955619570587271174)
+      t1 = ts7       value=  2.8 (7955616035401367559)
+      h2 = hm6       value=  8.7 (5595759323830550534)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+
+Made Particle :pr3   :10252455406834024451: pdgid =  -211, status =   1, q = -1, e =   3.2, theta =  1.32, phi =  1.25, mass =  0.14 from SmearedTrack: ts6   :7955619570587271174:    3.23    0.79  1.32  1.25
+Made Particle :pr4   :10252451875376857092: pdgid =  -211, status =   1, q = -1, e =   2.8, theta =  1.22, phi =  1.14, mass =  0.14 from SmearedTrack: ts7   :7955616035401367559:    2.83    0.96  1.22  1.14
+Finished block
+Processing block:E1H1T1   :bs1   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts0       value= 13.2 (7955655456431538176)
+      h1 = hm9       value=  6.5 (5595751200136888329)
+      e2 = em18      value=  9.7 (3289918485976580114)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr5   :10252491267994812421: pdgid =  -211, status =   1, q = -1, e =  13.2, theta = -1.38, phi = -2.25, mass =  0.14 from SmearedTrack: ts0   :7955655456431538176:   13.24    2.51 -1.38 -2.25
+Finished block
+Processing block:E1T1     :bs8   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts4       value=  5.1 (7955631177795108868)
+      e1 = em0       value=  0.5 (3289844423250149376)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr6   :10252466996081852422: pdgid =  -211, status =   1, q = -1, e =   5.1, theta =  1.39, phi =  0.35, mass =  0.14 from SmearedTrack: ts4   :7955631177795108868:    5.10    0.92  1.39  0.35
+Finished block
+Processing block:H1T1     :bs7   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  1.4 (7955597341579280393)
+      h1 = hm0       value=  1.6 (5595714628890918912)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr7   :10252433276912271367: pdgid =  -211, status =   1, q = -1, e =   1.4, theta = -1.16, phi = -2.90, mass =  0.14 from SmearedTrack: ts9   :7955597341579280393:    1.35    0.54 -1.16 -2.90
+Finished block
+Processing block:H1T1     :bs6   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts10      value=  1.3 (7955596187134853130)
+      h1 = hm2       value=  2.3 (5595725303184883714)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr8   :10252432128826408968: pdgid =   211, status =   1, q =  1, e =   1.3, theta = -1.15, phi = -2.03, mass =  0.14 from SmearedTrack: ts10  :7955596187134853130:    1.29    0.53 -1.15 -2.03
+Finished block
+Processing block:H1T1     :bs5   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  5.2 (7955631586106408963)
+      h1 = hm8       value=  6.4 (5595750666116005896)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr9   :10252467404244254729: pdgid =   211, status =   1, q =  1, e =   5.2, theta =  1.25, phi =  1.23, mass =  0.14 from SmearedTrack: ts3   :7955631586106408963:    5.19    1.66  1.25  1.23
+Finished block
+Processing block:E1       :bs28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.7 (3289850418097553409)
+
+Made Particle :pr10  :10252415442012340234: pdgid =    22, status =   1, q =  0, e =   0.7, theta = -1.25, phi = -2.88, mass =  0.00 from MergedCluster: em1   :3289850418097553409:    0.67 -1.25 -2.88 sub(es13, )
+Finished block
+Processing block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.7 (3289851091646152706)
+
+Made Particle :pr11  :10252416115560939531: pdgid =    22, status =   1, q =  0, e =   0.7, theta = -1.13, phi = -2.79, mass =  0.00 from MergedCluster: em2   :3289851091646152706:    0.69 -1.13 -2.79 sub(es17, )
+Finished block
+Processing block:E1       :bs26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.7 (3289851509296070659)
+
+Made Particle :pr12  :10252416533210857484: pdgid =    22, status =   1, q =  0, e =   0.7, theta = -0.95, phi = -0.00, mass =  0.00 from MergedCluster: em3   :3289851509296070659:    0.70 -0.95 -0.00 sub(es18, )
+Finished block
+Processing block:E1       :bs25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.8 (3289855222328852484)
+
+Made Particle :pr13  :10252420246243639309: pdgid =    22, status =   1, q =  0, e =   0.8, theta = -1.41, phi = -2.76, mass =  0.00 from MergedCluster: em4   :3289855222328852484:    0.81 -1.41 -2.76 sub(es16, )
+Finished block
+Processing block:E1       :bs24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.8 (3289855758579007493)
+
+Made Particle :pr14  :10252420782493794318: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  1.34, phi =  0.76, mass =  0.00 from MergedCluster: em5   :3289855758579007493:    0.82  1.34  0.76 sub(es12, )
+Finished block
+Processing block:E1       :bs23  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.8 (3289856480129318918)
+
+Made Particle :pr15  :10252421504044105743: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  1.25, phi =  1.80, mass =  0.00 from MergedCluster: em6   :3289856480129318918:    0.84  1.25  1.80 sub(es14, )
+Finished block
+Processing block:E1       :bs22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  1.1 (3289862944432586760)
+
+Made Particle :pr16  :10252427968347373584: pdgid =    22, status =   1, q =  0, e =   1.1, theta =  1.34, phi = -0.08, mass =  0.00 from MergedCluster: em8   :3289862944432586760:    1.06  1.34 -0.08 sub(es15, )
+Finished block
+Processing block:E1       :bs21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  1.2 (3289865740835880969)
+
+Made Particle :pr17  :10252430764750667793: pdgid =    22, status =   1, q =  0, e =   1.2, theta = -1.35, phi = -2.50, mass =  0.00 from MergedCluster: em9   :3289865740835880969:    1.22 -1.35 -2.50 sub(es11, )
+Finished block
+Processing block:E1       :bs20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  1.3 (3289866782243815434)
+
+Made Particle :pr18  :10252431806158602258: pdgid =    22, status =   1, q =  0, e =   1.3, theta =  1.24, phi =  0.95, mass =  0.00 from MergedCluster: em10  :3289866782243815434:    1.28  1.24  0.95 sub(es10, )
+Finished block
+Processing block:E1       :bs19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  2.0 (3289879022393098251)
+
+Made Particle :pr19  :10252444046307885075: pdgid =    22, status =   1, q =  0, e =   2.0, theta =  1.44, phi =  0.13, mass =  0.00 from MergedCluster: em11  :3289879022393098251:    1.97  1.44  0.13 sub(es8, )
+Finished block
+Processing block:E1       :bs18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  2.0 (3289879665128243212)
+
+Made Particle :pr20  :10252444689043030036: pdgid =    22, status =   1, q =  0, e =   2.0, theta = -1.24, phi = -2.70, mass =  0.00 from MergedCluster: em12  :3289879665128243212:    2.02 -1.24 -2.70 sub(es9, )
+Finished block
+Processing block:E1       :bs17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  2.1 (3289880203444092941)
+
+Made Particle :pr21  :10252445227358879765: pdgid =    22, status =   1, q =  0, e =   2.1, theta = -1.33, phi = -2.04, mass =  0.00 from MergedCluster: em13  :3289880203444092941:    2.08 -1.33 -2.04 sub(es7, )
+Finished block
+Processing block:E1       :bs16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  2.7 (3289885850445283342)
+
+Made Particle :pr22  :10252450874360070166: pdgid =    22, status =   1, q =  0, e =   2.7, theta =  1.42, phi = -2.01, mass =  0.00 from MergedCluster: em14  :3289885850445283342:    2.72  1.42 -2.01 sub(es4, )
+Finished block
+Processing block:E1       :bs15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  2.8 (3289886167626940431)
+
+Made Particle :pr23  :10252451191541727255: pdgid =    22, status =   1, q =  0, e =   2.8, theta =  1.32, phi =  2.03, mass =  0.00 from MergedCluster: em15  :3289886167626940431:    2.75  1.32  2.03 sub(es6, )
+Finished block
+Processing block:E1       :bs14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  3.1 (3289889628655452176)
+
+Made Particle :pr24  :10252454652570239000: pdgid =    22, status =   1, q =  0, e =   3.1, theta = -1.35, phi = -2.45, mass =  0.00 from MergedCluster: em16  :3289889628655452176:    3.15 -1.35 -2.45 sub(es5, )
+Finished block
+Processing block:H1       :bs13  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm4       value=  2.6 (5595727834380238852)
+
+Made Particle :pr25  :10252449849081331737: pdgid =   130, status =   1, q =  0, e =   2.6, theta =  1.28, phi =  0.20, mass =  0.50 from MergedCluster: hm4   :5595727834380238852:    2.60  1.28  0.20 sub(hs6, )
+Finished block
+Processing block:H1       :bs12  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  3.8 (5595738793557622789)
+
+Made Particle :pr26  :10252460808258715674: pdgid =   130, status =   1, q =  0, e =   3.8, theta =  1.42, phi = -2.01, mass =  0.50 from MergedCluster: hm5   :5595738793557622789:    3.85  1.42 -2.01 sub(hs4, )
+Finished block
+Processing block:T1       :bs11  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  0.5 (7955575229934206988)
+
+Made Particle :pr27  :10252411650978086939: pdgid =   211, status =   1, q =  1, e =   0.6, theta = -0.30, phi =  2.66, mass =  0.14 from SmearedTrack: ts12  :7955575229934206988:    0.55    0.52 -0.30  2.66
+Finished block
+Processing block:T1       :bs10  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  0.7 (7955582097668702219)
+
+Made Particle :pr28  :10252418361325518876: pdgid =  -211, status =   1, q = -1, e =   0.8, theta =  0.84, phi =  1.15, mass =  0.14 from SmearedTrack: ts11  :7955582097668702219:    0.74    0.49  0.84  1.15
+Finished block
+Processing block:T1       :bs9   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  1.6 (7955601087805784072)
+
+Made Particle :pr29  :10252437006149746717: pdgid =   211, status =   1, q =  1, e =   1.6, theta =  1.18, phi =  0.92, mass =  0.14 from SmearedTrack: ts8   :7955601087805784072:    1.56    0.59  1.18  0.92
+Finished block
+Processing block:H1       :bs2   : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm1       value=  1.9 (5595720170214522881)
+
+Made Particle :pr30  :10252442184915615774: pdgid =   130, status =   1, q =  0, e =   1.9, theta = -1.36, phi = -2.55, mass =  0.50 from MergedCluster: hm1   :5595720170214522881:    1.87 -1.36 -2.55 sub(hs9, )
+Finished block
+Finished reconstruction
+Event: 1
+Made Particle :ps0   :10261496354536685568: pdgid =  -211, status =   1, q = -1, e =  12.3, theta = -0.72, phi = -1.71, mass =  0.14
+Made Particle :ps1   :10261489911093788673: pdgid =    22, status =   1, q =  0, e =   9.4, theta =  0.15, phi =  2.53, mass =  0.00
+Made Particle :ps2   :10261488119140319234: pdgid = -2112, status =   1, q =  0, e =   8.5, theta = -0.66, phi = -1.80, mass =  0.94
+Made Particle :ps3   :10261485619561627651: pdgid =   130, status =   1, q =  0, e =   7.7, theta =  0.18, phi =  2.57, mass =  0.50
+Made Particle :ps4   :10261482007664001028: pdgid =   211, status =   1, q =  1, e =   6.9, theta =  0.52, phi =  0.27, mass =  0.14
+Made Particle :ps5   :10261469890151972869: pdgid =  -211, status =   1, q = -1, e =   4.1, theta =  0.54, phi =  0.42, mass =  0.14
+Made Particle :ps6   :10261463605786443782: pdgid = -2112, status =   1, q =  0, e =   3.3, theta =  0.56, phi =  0.55, mass =  0.94
+Made Particle :ps7   :10261461731175825415: pdgid =   130, status =   1, q =  0, e =   3.1, theta =  0.51, phi =  0.29, mass =  0.50
+Made Particle :ps8   :10261461162640015368: pdgid =  2212, status =   1, q =  1, e =   3.1, theta = -0.71, phi = -1.96, mass =  0.94
+Made Particle :ps9   :10261460159198920713: pdgid =  2112, status =   1, q =  0, e =   3.0, theta =  0.50, phi =  0.39, mass =  0.94
+Made Particle :ps10  :10261452979194298378: pdgid =    22, status =   1, q =  0, e =   2.1, theta =  0.60, phi =  0.57, mass =  0.00
+Made Particle :ps11  :10261452589960790027: pdgid =   211, status =   1, q =  1, e =   2.1, theta = -0.04, phi =  2.49, mass =  0.14
+Made Particle :ps12  :10261451959705796620: pdgid =  2112, status =   1, q =  0, e =   2.0, theta =  0.89, phi =  0.49, mass =  0.94
+Made Particle :ps13  :10261451210670211085: pdgid =   130, status =   1, q =  0, e =   2.0, theta =  0.07, phi =  2.46, mass =  0.50
+Made Particle :ps14  :10261449809195958286: pdgid =    22, status =   1, q =  0, e =   1.9, theta = -0.77, phi = -2.04, mass =  0.00
+Made Particle :ps15  :10261447789607125007: pdgid =   211, status =   1, q =  1, e =   1.8, theta =  0.37, phi =  0.26, mass =  0.14
+Made Particle :ps16  :10261446083454435344: pdgid =   211, status =   1, q =  1, e =   1.7, theta =  0.47, phi =  0.58, mass =  0.14
+Made Particle :ps17  :10261443045429870609: pdgid =  -211, status =   1, q = -1, e =   1.5, theta =  0.25, phi =  0.71, mass =  0.14
+Made Particle :ps18  :10261439859101007890: pdgid = -2112, status =   1, q =  0, e =   1.3, theta =  0.48, phi =  0.83, mass =  0.94
+Made Particle :ps19  :10261439086455685139: pdgid =   211, status =   1, q =  1, e =   1.3, theta = -0.46, phi = -2.05, mass =  0.14
+Made Particle :ps20  :10261438899033210900: pdgid =   211, status =   1, q =  1, e =   1.3, theta =  0.73, phi = -1.14, mass =  0.14
+Made Particle :ps21  :10261433440362561557: pdgid =    22, status =   1, q =  0, e =   1.0, theta = -0.61, phi = -1.58, mass =  0.00
+Made Particle :ps22  :10261432127071453206: pdgid =  -321, status =   1, q = -1, e =   0.9, theta =  0.23, phi =  1.27, mass =  0.49
+Made Particle :ps23  :10261431930857717783: pdgid =  -211, status =   1, q = -1, e =   0.9, theta =  0.05, phi = -1.91, mass =  0.14
+Made Particle :ps24  :10261425827841310744: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.64, phi =  2.62, mass =  0.00
+Made Particle :ps25  :10261423432629485593: pdgid =   211, status =   1, q =  1, e =   0.7, theta = -0.80, phi = -1.62, mass =  0.14
+Made Particle :ps26  :10261419720001454106: pdgid =  -211, status =   1, q = -1, e =   0.6, theta = -0.56, phi = -1.78, mass =  0.14
+Made Particle :ps27  :10261416610017312795: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.92, phi = -2.52, mass =  0.00
+Made Particle :ps28  :10261414444156321820: pdgid =  -211, status =   1, q = -1, e =   0.5, theta =  0.19, phi =  0.02, mass =  0.14
+Made Particle :ps29  :10261413315643179037: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.77, phi = -1.75, mass =  0.00
+Made Particle :ps30  :10261410637917716510: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.09, phi =  2.55, mass =  0.00
+Made Particle :ps31  :10261409885172269087: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -1.25, phi = -2.40, mass =  0.00
+Made Particle :ps32  :10261409084301377568: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.72, phi = -1.84, mass =  0.00
+Made Particle :ps33  :10261408127976996897: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.27, phi =  2.41, mass =  0.00
+Made Particle :ps34  :10261407722184376354: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.09, phi =  2.47, mass =  0.00
+Made Particle :ps35  :10261407670776889379: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.13, phi =  1.86, mass =  0.00
+Made Particle :ps36  :10261401275576877092: pdgid =  -211, status =   1, q = -1, e =   0.3, theta =  0.28, phi =  2.53, mass =  0.14
+Made Particle :ps37  :10261397767725252645: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.46, phi = -1.63, mass =  0.00
+Made Particle :ps38  :10261397515555307558: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.74, phi =  0.42, mass =  0.00
+Made Particle :ps39  :10261397405488381991: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  1.07, phi =  1.73, mass =  0.00
+Made Particle :ps40  :10261393704616984616: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.39, phi = -0.17, mass =  0.00
+Made Particle :ps41  :10261385020702720041: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.42, phi = -0.63, mass =  0.00
+Made Particle :ps42  :10261381184061702186: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.64, phi = -2.33, mass =  0.00
+Made Particle :ps43  :10261380521384738859: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -1.46, phi = -0.74, mass =  0.00
+Made Particle :ps44  :10261368757460926508: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.57, phi =  1.46, mass =  0.00
+Made Particle :ps45  :10261368416281559085: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.82, phi = -1.46, mass =  0.00
+Made Particle :ps46  :10261367043601203246: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.25, phi = -2.22, mass =  0.00
+Made Particle :ps47  :10261366425794904111: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.98, phi = -1.40, mass =  0.00
+Made Particle :ps48  :10261366018985164848: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.31, phi =  2.07, mass =  0.00
+Made Particle :ps49  :10261267717164105777: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.68, phi =  2.44, mass =  0.00
+Simulating Particle :ps0   :10261496354536685568: pdgid =  -211, status =   1, q = -1, e =  12.3, theta = -0.72, phi = -1.71, mass =  0.14
+Simulating Hadron
+Made Track: tt0   :7964660542832902144:   12.28    9.24 -0.72 -1.71
+Made SmearedTrack: ts0   :7955653494449373184:   12.35    9.29 -0.72 -1.71
+Made Cluster: ht0   :5658817535364038656:   12.28 -0.72 -1.63 sub(ht0, )
+Made SmearedCluster: hs0   :5649808070671335424:   11.25 -0.72 -1.63 sub(hs0, )
+Simulating Particle :ps1   :10261489911093788673: pdgid =    22, status =   1, q =  0, e =   9.4, theta =  0.15, phi =  2.53, mass =  0.00
+Simulating Photon
+Made Cluster: et0   :3352968082707447808:    9.35  0.15  2.53 sub(et0, )
+Made SmearedCluster: es0   :3343958917672599552:    8.46  0.15  2.53 sub(es0, )
+Simulating Particle :ps2   :10261488119140319234: pdgid = -2112, status =   1, q =  0, e =   8.5, theta = -0.66, phi = -1.80, mass =  0.94
+Simulating Hadron
+Made Cluster: et1   :3352950176200261633:    4.61 -0.66 -1.80 sub(et1, )
+Made SmearedCluster: es1   :3343948749465452545:    5.92 -0.66 -1.80 sub(es1, )
+Made Cluster: ht1   :5658789936319430657:    3.93 -0.66 -1.80 sub(ht1, )
+Made SmearedCluster: hs1   :5649773896734343169:    2.93 -0.66 -1.80 sub(hs1, )
+Simulating Particle :ps3   :10261485619561627651: pdgid =   130, status =   1, q =  0, e =   7.7, theta =  0.18, phi =  2.57, mass =  0.50
+Simulating Hadron
+Made Cluster: et2   :3352901920757907458:    0.70  0.18  2.57 sub(et2, )
+Made SmearedCluster: es2   :3343906117355831298:    1.06  0.18  2.57 sub(es2, )
+Made Cluster: ht2   :5658803703545593858:    7.00  0.18  2.57 sub(ht2, )
+Made SmearedCluster: hs2   :5649791453545627650:    5.85  0.18  2.57 sub(hs2, )
+Simulating Particle :ps4   :10261482007664001028: pdgid =   211, status =   1, q =  1, e =   6.9, theta =  0.52, phi =  0.27, mass =  0.14
+Simulating Hadron
+Made Track: tt1   :7964646191478603777:    6.88    5.95  0.52  0.27
+Made SmearedTrack: ts1   :7955638976874807297:    6.87    5.95  0.52  0.27
+Made Cluster: ht3   :5658803188491354115:    6.88  0.53  0.15 sub(ht3, )
+Made SmearedCluster: hs3   :5649789555631456259:    5.42  0.53  0.15 sub(hs3, )
+Simulating Particle :ps5   :10261469890151972869: pdgid =  -211, status =   1, q = -1, e =   4.1, theta =  0.54, phi =  0.42, mass =  0.14
+Simulating Hadron
+Made Track: tt2   :7964634069803728898:    4.12    3.53  0.54  0.42
+Made SmearedTrack: ts2   :7955626820861165570:    4.11    3.52  0.54  0.42
+Made Cluster: ht4   :5658791070979325956:    4.12  0.55  0.63 sub(ht4, )
+Made SmearedCluster: hs4   :5649786242261319684:    4.66  0.55  0.63 sub(hs4, )
+Simulating Particle :ps6   :10261463605786443782: pdgid = -2112, status =   1, q =  0, e =   3.3, theta =  0.56, phi =  0.55, mass =  0.94
+Simulating Hadron
+Made Cluster: et3   :3352925577286778883:    1.75  0.56  0.55 sub(et3, )
+Made SmearedCluster: es3   :3343923301236867075:    2.07  0.56  0.55 sub(es3, )
+Made Cluster: ht5   :5658765802352934917:    1.59  0.56  0.55 sub(ht5, )
+Made SmearedCluster: hs5   :5649757064587640837:    1.51  0.56  0.55 sub(hs5, )
+Simulating Particle :ps7   :10261461731175825415: pdgid =   130, status =   1, q =  0, e =   3.1, theta =  0.51, phi =  0.29, mass =  0.50
+Simulating Hadron
+Made Cluster: et4   :3352901797220974596:    0.70  0.51  0.29 sub(et4, )
+Made SmearedCluster: es4   :3343903781917032452:    0.96  0.51  0.29 sub(es4, )
+Made Cluster: ht6   :5658776749203259398:    2.43  0.51  0.29 sub(ht6, )
+Made SmearedCluster: hs6   :5649775406769766406:    3.10  0.51  0.29 sub(hs6, )
+Simulating Particle :ps8   :10261461162640015368: pdgid =  2212, status =   1, q =  1, e =   3.1, theta = -0.71, phi = -1.96, mass =  0.94
+Simulating Hadron
+Made Track: tt3   :7964624060581675011:    2.92    2.22 -0.71 -1.96
+Made SmearedTrack: ts3   :7955617114690158595:    2.95    2.24 -0.71 -1.96
+Made Cluster: et5   :3352899694744305669:    0.64 -0.71 -2.20 sub(et5, )
+Made SmearedCluster: es5   :3343891993370558469:    0.63 -0.71 -2.20 sub(es5, )
+Made Cluster: ht7   :5658776706287140871:    2.43 -0.72 -2.23 sub(ht7, )
+Made SmearedCluster: hs7   :5649786767040053255:    4.78 -0.72 -2.23 sub(hs7, )
+Simulating Particle :ps9   :10261460159198920713: pdgid =  2112, status =   1, q =  0, e =   3.0, theta =  0.50, phi =  0.39, mass =  0.94
+Simulating Hadron
+Made Cluster: ht8   :5658781340026273800:    2.96  0.49  0.39 sub(ht8, )
+Made SmearedCluster: hs8   :5649774024796930056:    2.94  0.49  0.39 sub(hs8, )
+Simulating Particle :ps10  :10261452979194298378: pdgid =    22, status =   1, q =  0, e =   2.1, theta =  0.60, phi =  0.57, mass =  0.00
+Simulating Photon
+Made Cluster: et6   :3352931150807957510:    2.14  0.60  0.57 sub(et6, )
+Made SmearedCluster: es6   :3343926460741058566:    2.42  0.60  0.57 sub(es6, )
+Simulating Particle :ps11  :10261452589960790027: pdgid =   211, status =   1, q =  1, e =   2.1, theta = -0.04, phi =  2.49, mass =  0.14
+Simulating Hadron
+Made Track: tt4   :7964616739069624324:    2.09    2.09 -0.04  2.49
+Made SmearedTrack: ts4   :7955609552311812100:    2.09    2.09 -0.04  2.49
+Made Cluster: et7   :3352914588011069447:    1.13 -0.04  2.17 sub(et7, )
+Made SmearedCluster: es7   :3341670923508908039:   -0.02 -0.04  2.17 sub(es7, )
+Rejected SmearedCluster: es7   :3341670923508908039:   -0.02 -0.04  2.17 sub(es7, )
+Made Cluster: ht9   :5658754180353884169:    0.97 -0.04  2.14 sub(ht9, )
+Made SmearedCluster: hs9   :5649758228225982473:    1.57 -0.04  2.14 sub(hs9, )
+Simulating Particle :ps12  :10261451959705796620: pdgid =  2112, status =   1, q =  0, e =   2.0, theta =  0.89, phi =  0.49, mass =  0.94
+Simulating Hadron
+Made Cluster: et8   :3352910913278574600:    0.96  0.89  0.49 sub(et8, )
+Made SmearedCluster: es7   :3343894398977966087:    0.69  0.89  0.49 sub(es7, )
+Made Cluster: ht10  :5658756465645584394:    1.06  0.89  0.49 sub(ht10, )
+Made SmearedCluster: hs10  :5649676329252028426:    0.06  0.89  0.49 sub(hs10, )
+Rejected SmearedCluster: hs10  :5649676329252028426:    0.06  0.89  0.49 sub(hs10, )
+Simulating Particle :ps13  :10261451210670211085: pdgid =   130, status =   1, q =  0, e =   2.0, theta =  0.07, phi =  2.46, mass =  0.50
+Simulating Hadron
+Made Cluster: et9   :3352766369209778185:    0.00  0.07  2.46 sub(et9, )
+Made SmearedCluster: es8   :3343792043076878344:    0.01  0.07  2.46 sub(es8, )
+Rejected SmearedCluster: es8   :3343792043076878344:    0.01  0.07  2.46 sub(es8, )
+Made Cluster: ht11  :5658772332980731915:    1.97  0.07  2.46 sub(ht11, )
+Made SmearedCluster: hs10  :5649757840600989706:    1.55  0.07  2.46 sub(hs10, )
+Simulating Particle :ps14  :10261449809195958286: pdgid =    22, status =   1, q =  0, e =   1.9, theta = -0.77, phi = -2.04, mass =  0.00
+Simulating Photon
+Made Cluster: et10  :3352927980809617418:    1.89 -0.77 -2.04 sub(et10, )
+Made SmearedCluster: es8   :3343916233029320712:    1.63 -0.77 -2.04 sub(es8, )
+Simulating Particle :ps15  :10261447789607125007: pdgid =   211, status =   1, q =  1, e =   1.8, theta =  0.37, phi =  0.26, mass =  0.14
+Simulating Hadron
+Made Track: tt5   :7964611882954784773:    1.77    1.65  0.37  0.26
+Made SmearedTrack: ts5   :7955604751960244229:    1.77    1.65  0.37  0.26
+Made Cluster: et11  :3352907532153651211:    0.86  0.38 -0.14 sub(et11, )
+Made SmearedCluster: es9   :3343903978590044169:    0.97  0.38 -0.14 sub(es9, )
+Made Cluster: ht12  :5658752215129522188:    0.91  0.39 -0.19 sub(ht12, )
+Made SmearedCluster: hs11  :5649729535254462475:    0.49  0.39 -0.19 sub(hs11, )
+Rejected SmearedCluster: hs11  :5649729535254462475:    0.49  0.39 -0.19 sub(hs11, )
+Simulating Particle :ps16  :10261446083454435344: pdgid =   211, status =   1, q =  1, e =   1.7, theta =  0.47, phi =  0.58, mass =  0.14
+Simulating Hadron
+Made Track: tt6   :7964610171194310662:    1.67    1.49  0.47  0.58
+Made SmearedTrack: ts6   :7955602730823712774:    1.66    1.48  0.47  0.58
+Made Cluster: et12  :3352868940188483596:    0.19  0.49  0.15 sub(et12, )
+Made SmearedCluster: es10  :3343873250024226826:    0.30  0.49  0.15 sub(es10, )
+Rejected SmearedCluster: es10  :3343873250024226826:    0.30  0.49  0.15 sub(es10, )
+Made Cluster: ht13  :5658763891962806285:    1.49  0.49  0.09 sub(ht13, )
+Made SmearedCluster: hs11  :5649766069483601931:    2.04  0.49  0.09 sub(hs11, )
+Simulating Particle :ps17  :10261443045429870609: pdgid =  -211, status =   1, q = -1, e =   1.5, theta =  0.25, phi =  0.71, mass =  0.14
+Simulating Hadron
+Made Track: tt7   :7964607121385848839:    1.50    1.45  0.25  0.71
+Made SmearedTrack: ts7   :7955599911844577287:    1.50    1.45  0.25  0.71
+Made Cluster: et13  :3352911319972970509:    0.97  0.26  1.17 sub(et13, )
+Made SmearedCluster: es10  :3343913421876756490:    1.47  0.26  1.17 sub(es10, )
+Made Cluster: ht14  :5658738938955694094:    0.53  0.26  1.23 sub(ht14, )
+Made SmearedCluster: hs12  :5647513932722601996:   -0.04  0.26  1.23 sub(hs12, )
+Rejected SmearedCluster: hs12  :5647513932722601996:   -0.04  0.26  1.23 sub(hs12, )
+Simulating Particle :ps18  :10261439859101007890: pdgid = -2112, status =   1, q =  0, e =   1.3, theta =  0.48, phi =  0.83, mass =  0.94
+Simulating Hadron
+Made Cluster: ht15  :5658761039928360975:    1.32  0.48  0.83 sub(ht15, )
+Made SmearedCluster: hs12  :5649757705158524940:    1.54  0.48  0.83 sub(hs12, )
+Simulating Particle :ps19  :10261439086455685139: pdgid =   211, status =   1, q =  1, e =   1.3, theta = -0.46, phi = -2.05, mass =  0.14
+Simulating Hadron
+Made Track: tt8   :7964603142243352584:    1.27    1.14 -0.46 -2.05
+Made SmearedTrack: ts8   :7955595933217980424:    1.27    1.14 -0.46 -2.05
+Rejected SmearedTrack: ts8   :7955595933217980424:    1.27    1.14 -0.46 -2.05
+Made Cluster: et14  :3352901397354905614:    0.69 -0.48 -2.65 sub(et14, )
+Made SmearedCluster: es11  :3343902485736587275:    0.92 -0.48 -2.65 sub(es11, )
+Made Cluster: ht16  :5658740943625388048:    0.59 -0.49 -2.73 sub(ht16, )
+Made SmearedCluster: hs13  :5649748655092006925:    1.03 -0.49 -2.73 sub(hs13, )
+Simulating Particle :ps20  :10261438899033210900: pdgid =   211, status =   1, q =  1, e =   1.3, theta =  0.73, phi = -1.14, mass =  0.14
+Simulating Hadron
+Made Track: tt9   :7964602953686319113:    1.26    0.94  0.73 -1.14
+Made SmearedTrack: ts8   :7955595631362310152:    1.25    0.94  0.73 -1.14
+Made Cluster: et15  :3352907976896675855:    0.88  0.78 -1.90 sub(et15, )
+Made SmearedCluster: es12  :3343895590690881548:    0.73  0.78 -1.90 sub(es12, )
+Made Cluster: ht17  :5658730231056302097:    0.39  0.79 -2.01 sub(ht17, )
+Made SmearedCluster: hs14  :5649678309334712334:    0.06  0.79 -2.01 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649678309334712334:    0.06  0.79 -2.01 sub(hs14, )
+Simulating Particle :ps21  :10261433440362561557: pdgid =    22, status =   1, q =  0, e =   1.0, theta = -0.61, phi = -1.58, mass =  0.00
+Simulating Photon
+Made Cluster: et16  :3352911611976220688:    0.98 -0.61 -1.58 sub(et16, )
+Made SmearedCluster: es13  :3343907059044188173:    1.11 -0.61 -1.58 sub(es13, )
+Simulating Particle :ps22  :10261432127071453206: pdgid =  -321, status =   1, q = -1, e =   0.9, theta =  0.23, phi =  1.27, mass =  0.49
+Simulating Hadron
+Made Track: tt10  :7964591402516480010:    0.80    0.78  0.23  1.27
+Made SmearedTrack: ts9   :7955584208259252233:    0.80    0.78  0.23  1.27
+Made Cluster: et17  :3352864549215666193:    0.16  0.27  2.24 sub(et17, )
+Made SmearedCluster: es14  :3341670923508908046:   -0.37  0.27  2.24 sub(es14, )
+Rejected SmearedCluster: es14  :3341670923508908046:   -0.37  0.27  2.24 sub(es14, )
+Made Cluster: ht18  :5658747661006667794:    0.78  0.29  2.44 sub(ht18, )
+Made SmearedCluster: hs14  :5649740895296159758:    0.79  0.29  2.44 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649740895296159758:    0.79  0.29  2.44 sub(hs14, )
+Simulating Particle :ps23  :10261431930857717783: pdgid =  -211, status =   1, q = -1, e =   0.9, theta =  0.05, phi = -1.91, mass =  0.14
+Simulating Hadron
+Made Track: tt11  :7964595752987000843:    0.93    0.93  0.05 -1.91
+Made SmearedTrack: ts10  :7955588572399009802:    0.93    0.93  0.05 -1.91
+Made Cluster: et18  :3352820580517675026:    0.03  0.05 -1.14 sub(et18, )
+Made SmearedCluster: es14  :3343808249401966606:    0.02  0.05 -1.14 sub(es14, )
+Rejected SmearedCluster: es14  :3343808249401966606:    0.02  0.05 -1.14 sub(es14, )
+Made Cluster: ht19  :5658752130578645011:    0.91  0.06 -1.02 sub(ht19, )
+Made SmearedCluster: hs14  :5649747891600752654:    0.99  0.06 -1.02 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649747891600752654:    0.99  0.06 -1.02 sub(hs14, )
+Simulating Particle :ps24  :10261425827841310744: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.64, phi =  2.62, mass =  0.00
+Simulating Photon
+Made Cluster: et19  :3352903999454969875:    0.76  0.64  2.62 sub(et19, )
+Made SmearedCluster: es14  :3343895462166921230:    0.73  0.64  2.62 sub(es14, )
+Simulating Particle :ps25  :10261423432629485593: pdgid =   211, status =   1, q =  1, e =   0.7, theta = -0.80, phi = -1.62, mass =  0.14
+Simulating Hadron
+Made Track: tt12  :7964587124620001292:    0.68    0.47 -0.80 -1.62
+Made SmearedTrack: ts11  :7955580109981745163:    0.69    0.48 -0.80 -1.62
+Made Cluster: et20  :3352882345475571732:    0.32 -1.02  3.07 sub(et20, )
+Made SmearedCluster: es15  :3343889711463661583:    0.56 -1.02  3.07 sub(es15, )
+Made Cluster: ht20  :5658728687852322836:    0.37 -1.07  2.92 sub(ht20, )
+Made SmearedCluster: hs14  :5647513932722601998:   -0.09 -1.07  2.92 sub(hs14, )
+Rejected SmearedCluster: hs14  :5647513932722601998:   -0.09 -1.07  2.92 sub(hs14, )
+Simulating Particle :ps26  :10261419720001454106: pdgid =  -211, status =   1, q = -1, e =   0.6, theta = -0.56, phi = -1.78, mass =  0.14
+Simulating Hadron
+Made Track: tt13  :7964583320461770765:    0.57    0.49 -0.56 -1.78
+Made SmearedTrack: ts12  :7955576424002224140:    0.58    0.49 -0.56 -1.78
+Made Cluster: et21  :3352859593202991125:    0.13 -1.23  0.51 sub(et21, )
+Made SmearedCluster: es16  :3343815064044961808:    0.03 -1.23  0.51 sub(es16, )
+Rejected SmearedCluster: es16  :3343815064044961808:    0.03 -1.23  0.51 sub(es16, )
+Made Cluster: ht21  :5658735238461784085:    0.46 -1.37  0.76 sub(ht21, )
+Made SmearedCluster: hs14  :5649725094872743950:    0.42 -1.37  0.76 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649725094872743950:    0.42 -1.37  0.76 sub(hs14, )
+Simulating Particle :ps27  :10261416610017312795: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.92, phi = -2.52, mass =  0.00
+Simulating Photon
+Made Cluster: et22  :3352894781630971926:    0.50 -0.92 -2.52 sub(et22, )
+Made SmearedCluster: es16  :3343879599279833104:    0.39 -0.92 -2.52 sub(es16, )
+Rejected SmearedCluster: es16  :3343879599279833104:    0.39 -0.92 -2.52 sub(es16, )
+Simulating Particle :ps28  :10261414444156321820: pdgid =  -211, status =   1, q = -1, e =   0.5, theta =  0.19, phi =  0.02, mass =  0.14
+Simulating Hadron
+Made Track: tt14  :7964577141746565134:    0.45    0.44  0.19  0.02
+Made SmearedTrack: ts13  :7955569949752164365:    0.45    0.44  0.19  0.02
+Made Cluster: et23  :3352865966993178647:    0.17  1.34  2.47 sub(et23, )
+Made SmearedCluster: es16  :3341670923508908048:   -0.15  1.34  2.47 sub(es16, )
+Rejected SmearedCluster: es16  :3341670923508908048:   -0.15  1.34  2.47 sub(es16, )
+Made Cluster: ht22  :5658723622309593110:    0.30  1.33  0.38 sub(ht22, )
+Made SmearedCluster: hs14  :5649734523678621710:    0.61  1.33  0.38 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649734523678621710:    0.61  1.33  0.38 sub(hs14, )
+Simulating Particle :ps29  :10261413315643179037: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.77, phi = -1.75, mass =  0.00
+Simulating Photon
+Made Cluster: et24  :3352891487256838168:    0.45 -0.77 -1.75 sub(et24, )
+Made SmearedCluster: es16  :3343868280147279888:    0.24 -0.77 -1.75 sub(es16, )
+Rejected SmearedCluster: es16  :3343868280147279888:    0.24 -0.77 -1.75 sub(es16, )
+Simulating Particle :ps30  :10261410637917716510: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.09, phi =  2.55, mass =  0.00
+Simulating Photon
+Made Cluster: et25  :3352888809531375641:    0.42  0.09  2.55 sub(et25, )
+Made SmearedCluster: es16  :3343866522979270672:    0.23  0.09  2.55 sub(es16, )
+Rejected SmearedCluster: es16  :3343866522979270672:    0.23  0.09  2.55 sub(es16, )
+Simulating Particle :ps31  :10261409885172269087: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -1.25, phi = -2.40, mass =  0.00
+Simulating Photon
+Made Cluster: et26  :3352888056785928218:    0.41 -1.25 -2.40 sub(et26, )
+Made SmearedCluster: es16  :3343878600888680464:    0.37 -1.25 -2.40 sub(es16, )
+Rejected SmearedCluster: es16  :3343878600888680464:    0.37 -1.25 -2.40 sub(es16, )
+Simulating Particle :ps32  :10261409084301377568: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.72, phi = -1.84, mass =  0.00
+Simulating Photon
+Made Cluster: et27  :3352887255915036699:    0.39 -0.72 -1.84 sub(et27, )
+Made SmearedCluster: es16  :3343888919543414800:    0.54 -0.72 -1.84 sub(es16, )
+Simulating Particle :ps33  :10261408127976996897: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.27, phi =  2.41, mass =  0.00
+Simulating Photon
+Made Cluster: et28  :3352886299590656028:    0.38  0.27  2.41 sub(et28, )
+Made SmearedCluster: es17  :3343885360928129041:    0.47  0.27  2.41 sub(es17, )
+Rejected SmearedCluster: es17  :3343885360928129041:    0.47  0.27  2.41 sub(es17, )
+Simulating Particle :ps34  :10261407722184376354: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.09, phi =  2.47, mass =  0.00
+Simulating Photon
+Made Cluster: et29  :3352885893798035485:    0.37 -0.08  2.47 sub(et29, )
+Made SmearedCluster: es17  :3343868435424608273:    0.24 -0.08  2.47 sub(es17, )
+Rejected SmearedCluster: es17  :3343868435424608273:    0.24 -0.08  2.47 sub(es17, )
+Simulating Particle :ps35  :10261407670776889379: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.13, phi =  1.86, mass =  0.00
+Simulating Photon
+Made Cluster: et30  :3352885842390548510:    0.37 -0.13  1.86 sub(et30, )
+Made SmearedCluster: es17  :3343875586043936785:    0.33 -0.13  1.86 sub(es17, )
+Rejected SmearedCluster: es17  :3343875586043936785:    0.33 -0.13  1.86 sub(es17, )
+Simulating Particle :ps36  :10261401275576877092: pdgid =  -211, status =   1, q = -1, e =   0.3, theta =  0.28, phi =  2.53, mass =  0.14
+Simulating Hadron
+Made Track: tt15  :7964562579869663247:    0.25    0.24  0.28  2.53
+Made SmearedTrack: ts14  :7955555322563657742:    0.25    0.24  0.28  2.53
+Rejected SmearedTrack: ts14  :7955555322563657742:    0.25    0.24  0.28  2.53
+Made Cluster: et31  :3352864780044992543:    0.16  1.33 -1.54 sub(et31, )
+Made SmearedCluster: es17  :3343845234785124369:    0.10  1.33 -1.54 sub(es17, )
+Rejected SmearedCluster: es17  :3343845234785124369:    0.10  1.33 -1.54 sub(es17, )
+Made Cluster: ht23  :5658701315308519447:    0.12  1.52  2.72 sub(ht23, )
+Made SmearedCluster: hs14  :5649695394056110094:    0.13  1.52  2.72 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649695394056110094:    0.13  1.52  2.72 sub(hs14, )
+Simulating Particle :ps37  :10261397767725252645: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.46, phi = -1.63, mass =  0.00
+Simulating Photon
+Made Cluster: et32  :3352875939338911776:    0.24 -0.46 -1.63 sub(et32, )
+Made SmearedCluster: es17  :3343873927525957649:    0.31 -0.46 -1.63 sub(es17, )
+Rejected SmearedCluster: es17  :3343873927525957649:    0.31 -0.46 -1.63 sub(es17, )
+Simulating Particle :ps38  :10261397515555307558: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.74, phi =  0.42, mass =  0.00
+Simulating Photon
+Made Cluster: et33  :3352875687168966689:    0.24  0.74  0.42 sub(et33, )
+Made SmearedCluster: es17  :3343865731084189713:    0.22  0.74  0.42 sub(es17, )
+Rejected SmearedCluster: es17  :3343865731084189713:    0.22  0.74  0.42 sub(es17, )
+Simulating Particle :ps39  :10261397405488381991: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  1.07, phi =  1.73, mass =  0.00
+Simulating Photon
+Made Cluster: et34  :3352875577102041122:    0.24  1.07  1.73 sub(et34, )
+Made SmearedCluster: es17  :3343855403304747025:    0.15  1.07  1.73 sub(es17, )
+Rejected SmearedCluster: es17  :3343855403304747025:    0.15  1.07  1.73 sub(es17, )
+Simulating Particle :ps40  :10261393704616984616: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.39, phi = -0.17, mass =  0.00
+Simulating Photon
+Made Cluster: et35  :3352871876230643747:    0.21  0.39 -0.17 sub(et35, )
+Made SmearedCluster: es17  :3343870901123809297:    0.26  0.39 -0.17 sub(es17, )
+Rejected SmearedCluster: es17  :3343870901123809297:    0.26  0.39 -0.17 sub(es17, )
+Simulating Particle :ps41  :10261385020702720041: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.42, phi = -0.63, mass =  0.00
+Simulating Photon
+Made Cluster: et36  :3352863192316379172:    0.15 -0.42 -0.63 sub(et36, )
+Made SmearedCluster: es17  :3343804492228329489:    0.02 -0.42 -0.63 sub(es17, )
+Rejected SmearedCluster: es17  :3343804492228329489:    0.02 -0.42 -0.63 sub(es17, )
+Simulating Particle :ps42  :10261381184061702186: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.64, phi = -2.33, mass =  0.00
+Simulating Photon
+Made Cluster: et37  :3352859355675361317:    0.12 -0.64 -2.33 sub(et37, )
+Made SmearedCluster: es17  :3343846371116449809:    0.10 -0.64 -2.33 sub(es17, )
+Rejected SmearedCluster: es17  :3343846371116449809:    0.10 -0.64 -2.33 sub(es17, )
+Simulating Particle :ps43  :10261380521384738859: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -1.46, phi = -0.74, mass =  0.00
+Simulating Photon
+Made Cluster: et38  :3352858692998397990:    0.12 -1.46 -0.74 sub(et38, )
+Made SmearedCluster: es17  :3343856611211870225:    0.16 -1.46 -0.74 sub(es17, )
+Rejected SmearedCluster: es17  :3343856611211870225:    0.16 -1.46 -0.74 sub(es17, )
+Simulating Particle :ps44  :10261368757460926508: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.57, phi =  1.46, mass =  0.00
+Simulating Photon
+Made Cluster: et39  :3352846929074585639:    0.08  0.57  1.46 sub(et39, )
+Made SmearedCluster: es17  :3343842951542341649:    0.09  0.57  1.46 sub(es17, )
+Rejected SmearedCluster: es17  :3343842951542341649:    0.09  0.57  1.46 sub(es17, )
+Simulating Particle :ps45  :10261368416281559085: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.82, phi = -1.46, mass =  0.00
+Simulating Photon
+Made Cluster: et40  :3352846587895218216:    0.08  0.82 -1.46 sub(et40, )
+Made SmearedCluster: es17  :3343831781108350993:    0.06  0.82 -1.46 sub(es17, )
+Rejected SmearedCluster: es17  :3343831781108350993:    0.06  0.82 -1.46 sub(es17, )
+Simulating Particle :ps46  :10261367043601203246: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.25, phi = -2.22, mass =  0.00
+Simulating Photon
+Made Cluster: et41  :3352845215214862377:    0.07 -0.25 -2.22 sub(et41, )
+Made SmearedCluster: es17  :3343849326787952657:    0.11 -0.25 -2.22 sub(es17, )
+Rejected SmearedCluster: es17  :3343849326787952657:    0.11 -0.25 -2.22 sub(es17, )
+Simulating Particle :ps47  :10261366425794904111: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.98, phi = -1.40, mass =  0.00
+Simulating Photon
+Made Cluster: et42  :3352844597408563242:    0.07  0.98 -1.40 sub(et42, )
+Made SmearedCluster: es17  :3343837685226668049:    0.07  0.98 -1.40 sub(es17, )
+Rejected SmearedCluster: es17  :3343837685226668049:    0.07  0.98 -1.40 sub(es17, )
+Simulating Particle :ps48  :10261366018985164848: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.31, phi =  2.07, mass =  0.00
+Simulating Photon
+Made Cluster: et43  :3352844190598823979:    0.07  0.31  2.07 sub(et43, )
+Made SmearedCluster: es17  :3343816955749466129:    0.03  0.31  2.07 sub(es17, )
+Rejected SmearedCluster: es17  :3343816955749466129:    0.03  0.31  2.07 sub(es17, )
+Simulating Particle :ps49  :10261267717164105777: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.68, phi =  2.44, mass =  0.00
+Simulating Photon
+Made Cluster: et44  :3352745888777764908:    0.00 -0.68  2.44 sub(et44, )
+Made SmearedCluster: es17  :3343799987906543633:    0.02 -0.68  2.44 sub(es17, )
+Rejected SmearedCluster: es17  :3343799987906543633:    0.02 -0.68  2.44 sub(es17, )
+Made MergedCluster: em0   :3289845724014968832:    0.54 -0.72 -1.84 sub(es16, )
+Made MergedCluster: em1   :3289846515935215617:    0.56 -1.02  3.07 sub(es15, )
+Made MergedCluster: em2   :3289848797842112514:    0.63 -0.71 -2.20 sub(es5, )
+Made MergedCluster: em3   :3289851203449520131:    0.69  0.89  0.49 sub(es7, )
+Made MergedCluster: em4   :3289852266638475268:    0.73  0.64  2.62 sub(es14, )
+Made MergedCluster: em5   :3289852395162435589:    0.73  0.78 -1.90 sub(es12, )
+Made MergedCluster: em6   :3289859290208141318:    0.92 -0.48 -2.65 sub(es11, )
+Made MergedCluster: em7   :3289860586388586503:    0.96  0.51  0.29 sub(es4, )
+Made MergedCluster: em8   :3289860783061598216:    0.97  0.38 -0.14 sub(es9, )
+Made MergedCluster: em9   :3289862921827385353:    1.06  0.18  2.57 sub(es2, )
+Made MergedCluster: em10  :3289863863515742218:    1.11 -0.61 -1.58 sub(es13, )
+Made MergedCluster: em11  :3289870226348310539:    1.47  0.26  1.17 sub(es10, )
+Made MergedCluster: em12  :3289873037500874764:    1.63 -0.77 -2.04 sub(es8, )
+Made MergedCluster: em13  :3289880105708421133:    2.07  0.56  0.55 sub(es3, )
+Made MergedCluster: em14  :3289883265212612622:    2.42  0.60  0.57 sub(es6, )
+Made MergedCluster: em15  :3289905553937006607:    5.92 -0.66 -1.80 sub(es1, )
+Made MergedCluster: em16  :3289915722144153616:    8.46  0.15  2.53 sub(es0, )
+Made MergedCluster: hm0   :5595705459563560960:    1.03 -0.49 -2.73 sub(hs13, )
+Made MergedCluster: hm1   :5595779346861129729:   19.67  0.53  0.34 sub(hs3, hs4, hs6, hs8, hs11, hs5, )
+Made MergedCluster: hm2   :5595714509630078978:    1.54  0.48  0.83 sub(hs12, )
+Made MergedCluster: hm3   :5595755081126379523:    7.40  0.16  2.55 sub(hs2, hs10, )
+Made MergedCluster: hm4   :5595715032697536516:    1.57 -0.04  2.14 sub(hs9, )
+Made MergedCluster: hm5   :5595730701205897221:    2.93 -0.66 -1.80 sub(hs1, )
+Made MergedCluster: hm6   :5595743571511607302:    4.78 -0.72 -2.23 sub(hs7, )
+Made MergedCluster: hm7   :5595764875142889479:   11.25 -0.72 -1.63 sub(hs0, )
+Made block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.5 (3289845724014968832)
+
+Made block:E1T1     :br1   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  0.7 (7955580109981745163)
+      e1 = em1       value=  0.6 (3289846515935215617)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1H1T1   :br2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  3.0 (7955617114690158595)
+      h1 = hm6       value=  4.8 (5595743571511607302)
+      e2 = em2       value=  0.6 (3289848797842112514)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.7 (3289851203449520131)
+
+Made block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.7 (3289852266638475268)
+
+Made block:E1T1     :br5   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  1.3 (7955595631362310152)
+      e1 = em5       value=  0.7 (3289852395162435589)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br6   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.9 (3289859290208141318)
+
+Made block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  1.0 (3289860586388586503)
+
+Made block:E1T1     :br8   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts5       value=  1.8 (7955604751960244229)
+      e1 = em8       value=  1.0 (3289860783061598216)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  1.1 (3289862921827385353)
+
+Made block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  1.1 (3289863863515742218)
+
+Made block:E1T1     :br11  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts7       value=  1.5 (7955599911844577287)
+      e1 = em11      value=  1.5 (3289870226348310539)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  1.6 (3289873037500874764)
+
+Made block:E1       :br13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  2.1 (3289880105708421133)
+
+Made block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  2.4 (3289883265212612622)
+
+Made block:E1       :br15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  5.9 (3289905553937006607)
+
+Made block:E1       :br16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  8.5 (3289915722144153616)
+
+Made block:H1       :br17  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm0       value=  1.0 (5595705459563560960)
+
+Made block:H1       :br18  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm2       value=  1.5 (5595714509630078978)
+
+Made block:H1T1     :br19  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  2.1 (7955609552311812100)
+      h1 = hm4       value=  1.6 (5595715032697536516)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1       :br20  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  2.9 (5595730701205897221)
+
+Made block:H1       :br21  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm3       value=  7.4 (5595755081126379523)
+
+Made block:H1T1     :br22  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts0       value= 12.4 (7955653494449373184)
+      h1 = hm7       value= 11.3 (5595764875142889479)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T3     :br23  : ecals = 0 hcals = 1 tracks = 3
+    elements:
+      t0 = ts1       value=  6.9 (7955638976874807297)
+      t1 = ts2       value=  4.1 (7955626820861165570)
+      t2 = ts6       value=  1.7 (7955602730823712774)
+      h3 = hm1       value= 19.7 (5595779346861129729)
+    distances:
+              t0      t1      t2      h3
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      h3  0.0000  0.0000  0.0000       .
+
+Made block:T1       :br24  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  0.4 (7955569949752164365)
+
+Made block:T1       :br25  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  0.6 (7955576424002224140)
+
+Made block:T1       :br26  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  0.8 (7955584208259252233)
+
+Made block:T1       :br27  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  0.9 (7955588572399009802)
+
+Splitting block:H1T3     :br23  : ecals = 0 hcals = 1 tracks = 3
+    elements:
+      t0 = ts1       value=  6.9 (7955638976874807297)
+      t1 = ts2       value=  4.1 (7955626820861165570)
+      t2 = ts6       value=  1.7 (7955602730823712774)
+      h3 = hm1       value= 19.7 (5595779346861129729)
+    distances:
+              t0      t1      t2      h3
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      h3  0.0000  0.0000  0.0000       .
+
+Made block:H1T3     :bs0   : ecals = 0 hcals = 1 tracks = 3
+    elements:
+      t0 = ts1       value=  6.9 (7955638976874807297)
+      t1 = ts2       value=  4.1 (7955626820861165570)
+      t2 = ts6       value=  1.7 (7955602730823712774)
+      h3 = hm1       value= 19.7 (5595779346861129729)
+    distances:
+              t0      t1      t2      h3
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      h3  0.0000  0.0000  0.0000       .
+
+Splitting block:E1H1T1   :br2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  3.0 (7955617114690158595)
+      h1 = hm6       value=  4.8 (5595743571511607302)
+      e2 = em2       value=  0.6 (3289848797842112514)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs1   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  3.0 (7955617114690158595)
+      h1 = hm6       value=  4.8 (5595743571511607302)
+      e2 = em2       value=  0.6 (3289848797842112514)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:H1T1     :br22  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts0       value= 12.4 (7955653494449373184)
+      h1 = hm7       value= 11.3 (5595764875142889479)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs2   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts0       value= 12.4 (7955653494449373184)
+      h1 = hm7       value= 11.3 (5595764875142889479)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br19  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  2.1 (7955609552311812100)
+      h1 = hm4       value=  1.6 (5595715032697536516)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs3   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  2.1 (7955609552311812100)
+      h1 = hm4       value=  1.6 (5595715032697536516)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:E1T1     :br11  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts7       value=  1.5 (7955599911844577287)
+      e1 = em11      value=  1.5 (3289870226348310539)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs4   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts7       value=  1.5 (7955599911844577287)
+      e1 = em11      value=  1.5 (3289870226348310539)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br8   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts5       value=  1.8 (7955604751960244229)
+      e1 = em8       value=  1.0 (3289860783061598216)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs5   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts5       value=  1.8 (7955604751960244229)
+      e1 = em8       value=  1.0 (3289860783061598216)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br5   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  1.3 (7955595631362310152)
+      e1 = em5       value=  0.7 (3289852395162435589)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs6   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  1.3 (7955595631362310152)
+      e1 = em5       value=  0.7 (3289852395162435589)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br1   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  0.7 (7955580109981745163)
+      e1 = em1       value=  0.6 (3289846515935215617)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs7   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  0.7 (7955580109981745163)
+      e1 = em1       value=  0.6 (3289846515935215617)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:T1       :br27  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  0.9 (7955588572399009802)
+
+Made block:T1       :bs8   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  0.9 (7955588572399009802)
+
+Splitting block:T1       :br26  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  0.8 (7955584208259252233)
+
+Made block:T1       :bs9   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  0.8 (7955584208259252233)
+
+Splitting block:T1       :br25  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  0.6 (7955576424002224140)
+
+Made block:T1       :bs10  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  0.6 (7955576424002224140)
+
+Splitting block:T1       :br24  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  0.4 (7955569949752164365)
+
+Made block:T1       :bs11  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  0.4 (7955569949752164365)
+
+Splitting block:H1       :br21  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm3       value=  7.4 (5595755081126379523)
+
+Made block:H1       :bs12  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm3       value=  7.4 (5595755081126379523)
+
+Splitting block:H1       :br20  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  2.9 (5595730701205897221)
+
+Made block:H1       :bs13  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  2.9 (5595730701205897221)
+
+Splitting block:H1       :br18  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm2       value=  1.5 (5595714509630078978)
+
+Made block:H1       :bs14  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm2       value=  1.5 (5595714509630078978)
+
+Splitting block:H1       :br17  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm0       value=  1.0 (5595705459563560960)
+
+Made block:H1       :bs15  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm0       value=  1.0 (5595705459563560960)
+
+Splitting block:E1       :br16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  8.5 (3289915722144153616)
+
+Made block:E1       :bs16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  8.5 (3289915722144153616)
+
+Splitting block:E1       :br15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  5.9 (3289905553937006607)
+
+Made block:E1       :bs17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  5.9 (3289905553937006607)
+
+Splitting block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  2.4 (3289883265212612622)
+
+Made block:E1       :bs18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  2.4 (3289883265212612622)
+
+Splitting block:E1       :br13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  2.1 (3289880105708421133)
+
+Made block:E1       :bs19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  2.1 (3289880105708421133)
+
+Splitting block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  1.6 (3289873037500874764)
+
+Made block:E1       :bs20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  1.6 (3289873037500874764)
+
+Splitting block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  1.1 (3289863863515742218)
+
+Made block:E1       :bs21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  1.1 (3289863863515742218)
+
+Splitting block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  1.1 (3289862921827385353)
+
+Made block:E1       :bs22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  1.1 (3289862921827385353)
+
+Splitting block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  1.0 (3289860586388586503)
+
+Made block:E1       :bs23  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  1.0 (3289860586388586503)
+
+Splitting block:E1       :br6   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.9 (3289859290208141318)
+
+Made block:E1       :bs24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.9 (3289859290208141318)
+
+Splitting block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.7 (3289852266638475268)
+
+Made block:E1       :bs25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.7 (3289852266638475268)
+
+Splitting block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.7 (3289851203449520131)
+
+Made block:E1       :bs26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.7 (3289851203449520131)
+
+Splitting block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.5 (3289845724014968832)
+
+Made block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.5 (3289845724014968832)
+
+Processing block:H1T3     :bs0   : ecals = 0 hcals = 1 tracks = 3
+    elements:
+      t0 = ts1       value=  6.9 (7955638976874807297)
+      t1 = ts2       value=  4.1 (7955626820861165570)
+      t2 = ts6       value=  1.7 (7955602730823712774)
+      h3 = hm1       value= 19.7 (5595779346861129729)
+    distances:
+              t0      t1      t2      h3
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      h3  0.0000  0.0000  0.0000       .
+
+Made Particle :pr0   :10252474793011970048: pdgid =   211, status =   1, q =  1, e =   6.9, theta =  0.52, phi =  0.27, mass =  0.14 from SmearedTrack: ts1   :7955638976874807297:    6.87    5.95  0.52  0.27
+Made Particle :pr1   :10252462641152786433: pdgid =  -211, status =   1, q = -1, e =   4.1, theta =  0.54, phi =  0.42, mass =  0.14 from SmearedTrack: ts2   :7955626820861165570:    4.11    3.52  0.54  0.42
+Made Particle :pr2   :10252438643085934594: pdgid =   211, status =   1, q =  1, e =   1.7, theta =  0.47, phi =  0.58, mass =  0.14 from SmearedTrack: ts6   :7955602730823712774:    1.66    1.48  0.47  0.58
+Made Particle :pr3   :10252475446037839875: pdgid =   130, status =   1, q =  0, e =   7.0, theta =  0.53, phi =  0.34, mass =  0.50 from MergedCluster: hm1   :5595779346861129729:   19.67  0.53  0.34 sub(hs3, hs4, hs6, hs8, hs11, hs5, )
+Finished block
+Processing block:E1H1T1   :bs1   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  3.0 (7955617114690158595)
+      h1 = hm6       value=  4.8 (5595743571511607302)
+      e2 = em2       value=  0.6 (3289848797842112514)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr4   :10252452953419939844: pdgid =   211, status =   1, q =  1, e =   3.0, theta = -0.71, phi = -1.96, mass =  0.14 from SmearedTrack: ts3   :7955617114690158595:    2.95    2.24 -0.71 -1.96
+Made Particle :pr5   :10252441575095271429: pdgid =   130, status =   1, q =  0, e =   1.8, theta = -0.72, phi = -2.23, mass =  0.50 from MergedCluster: hm6   :5595743571511607302:    4.78 -0.72 -2.23 sub(hs7, )
+Made Particle :pr6   :10252413821756899334: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.72, phi = -2.23, mass =  0.00 from MergedCluster: hm6   :5595743571511607302:    4.78 -0.72 -2.23 sub(hs7, )
+Finished block
+Processing block:E1T1     :bs7   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  0.7 (7955580109981745163)
+      e1 = em1       value=  0.6 (3289846515935215617)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr7   :10252416410271612935: pdgid =   211, status =   1, q =  1, e =   0.7, theta = -0.80, phi = -1.62, mass =  0.14 from SmearedTrack: ts11  :7955580109981745163:    0.69    0.48 -0.80 -1.62
+Finished block
+Processing block:E1T1     :bs6   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  1.3 (7955595631362310152)
+      e1 = em5       value=  0.7 (3289852395162435589)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr8   :10252431576352686088: pdgid =   211, status =   1, q =  1, e =   1.3, theta =  0.73, phi = -1.14, mass =  0.14 from SmearedTrack: ts8   :7955595631362310152:    1.25    0.94  0.73 -1.14
+Finished block
+Processing block:E1T1     :bs5   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts5       value=  1.8 (7955604751960244229)
+      e1 = em8       value=  1.0 (3289860783061598216)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr9   :10252440657616437257: pdgid =   211, status =   1, q =  1, e =   1.8, theta =  0.37, phi =  0.26, mass =  0.14 from SmearedTrack: ts5   :7955604751960244229:    1.77    1.65  0.37  0.26
+Finished block
+Processing block:E1T1     :bs4   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts7       value=  1.5 (7955599911844577287)
+      e1 = em11      value=  1.5 (3289870226348310539)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr10  :10252435835005698058: pdgid =  -211, status =   1, q = -1, e =   1.5, theta =  0.25, phi =  0.71, mass =  0.14 from SmearedTrack: ts7   :7955599911844577287:    1.50    1.45  0.25  0.71
+Finished block
+Processing block:H1T1     :bs3   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  2.1 (7955609552311812100)
+      h1 = hm4       value=  1.6 (5595715032697536516)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr11  :10252445402842267659: pdgid =   211, status =   1, q =  1, e =   2.1, theta = -0.04, phi =  2.49, mass =  0.14 from SmearedTrack: ts4   :7955609552311812100:    2.09    2.09 -0.04  2.49
+Finished block
+Processing block:H1T1     :bs2   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts0       value= 12.4 (7955653494449373184)
+      h1 = hm7       value= 11.3 (5595764875142889479)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr12  :10252489306127990796: pdgid =  -211, status =   1, q = -1, e =  12.4, theta = -0.72, phi = -1.71, mass =  0.14 from SmearedTrack: ts0   :7955653494449373184:   12.35    9.29 -0.72 -1.71
+Finished block
+Processing block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.5 (3289845724014968832)
+
+Made Particle :pr13  :10252410747929755661: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.72, phi = -1.84, mass =  0.00 from MergedCluster: em0   :3289845724014968832:    0.54 -0.72 -1.84 sub(es16, )
+Finished block
+Processing block:E1       :bs26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.7 (3289851203449520131)
+
+Made Particle :pr14  :10252416227364306958: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.89, phi =  0.49, mass =  0.00 from MergedCluster: em3   :3289851203449520131:    0.69  0.89  0.49 sub(es7, )
+Finished block
+Processing block:E1       :bs25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.7 (3289852266638475268)
+
+Made Particle :pr15  :10252417290553262095: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.64, phi =  2.62, mass =  0.00 from MergedCluster: em4   :3289852266638475268:    0.73  0.64  2.62 sub(es14, )
+Finished block
+Processing block:E1       :bs24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.9 (3289859290208141318)
+
+Made Particle :pr16  :10252424314122928144: pdgid =    22, status =   1, q =  0, e =   0.9, theta = -0.48, phi = -2.65, mass =  0.00 from MergedCluster: em6   :3289859290208141318:    0.92 -0.48 -2.65 sub(es11, )
+Finished block
+Processing block:E1       :bs23  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  1.0 (3289860586388586503)
+
+Made Particle :pr17  :10252425610303373329: pdgid =    22, status =   1, q =  0, e =   1.0, theta =  0.51, phi =  0.29, mass =  0.00 from MergedCluster: em7   :3289860586388586503:    0.96  0.51  0.29 sub(es4, )
+Finished block
+Processing block:E1       :bs22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  1.1 (3289862921827385353)
+
+Made Particle :pr18  :10252427945742172178: pdgid =    22, status =   1, q =  0, e =   1.1, theta =  0.18, phi =  2.57, mass =  0.00 from MergedCluster: em9   :3289862921827385353:    1.06  0.18  2.57 sub(es2, )
+Finished block
+Processing block:E1       :bs21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  1.1 (3289863863515742218)
+
+Made Particle :pr19  :10252428887430529043: pdgid =    22, status =   1, q =  0, e =   1.1, theta = -0.61, phi = -1.58, mass =  0.00 from MergedCluster: em10  :3289863863515742218:    1.11 -0.61 -1.58 sub(es13, )
+Finished block
+Processing block:E1       :bs20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  1.6 (3289873037500874764)
+
+Made Particle :pr20  :10252438061415661588: pdgid =    22, status =   1, q =  0, e =   1.6, theta = -0.77, phi = -2.04, mass =  0.00 from MergedCluster: em12  :3289873037500874764:    1.63 -0.77 -2.04 sub(es8, )
+Finished block
+Processing block:E1       :bs19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  2.1 (3289880105708421133)
+
+Made Particle :pr21  :10252445129623207957: pdgid =    22, status =   1, q =  0, e =   2.1, theta =  0.56, phi =  0.55, mass =  0.00 from MergedCluster: em13  :3289880105708421133:    2.07  0.56  0.55 sub(es3, )
+Finished block
+Processing block:E1       :bs18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  2.4 (3289883265212612622)
+
+Made Particle :pr22  :10252448289127399446: pdgid =    22, status =   1, q =  0, e =   2.4, theta =  0.60, phi =  0.57, mass =  0.00 from MergedCluster: em14  :3289883265212612622:    2.42  0.60  0.57 sub(es6, )
+Finished block
+Processing block:E1       :bs17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  5.9 (3289905553937006607)
+
+Made Particle :pr23  :10252470577851793431: pdgid =    22, status =   1, q =  0, e =   5.9, theta = -0.66, phi = -1.80, mass =  0.00 from MergedCluster: em15  :3289905553937006607:    5.92 -0.66 -1.80 sub(es1, )
+Finished block
+Processing block:E1       :bs16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  8.5 (3289915722144153616)
+
+Made Particle :pr24  :10252480746058940440: pdgid =    22, status =   1, q =  0, e =   8.5, theta =  0.15, phi =  2.53, mass =  0.00 from MergedCluster: em16  :3289915722144153616:    8.46  0.15  2.53 sub(es0, )
+Finished block
+Processing block:H1       :bs15  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm0       value=  1.0 (5595705459563560960)
+
+Made Particle :pr25  :10252427474264653849: pdgid =   130, status =   1, q =  0, e =   1.0, theta = -0.49, phi = -2.73, mass =  0.50 from MergedCluster: hm0   :5595705459563560960:    1.03 -0.49 -2.73 sub(hs13, )
+Finished block
+Processing block:H1       :bs14  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm2       value=  1.5 (5595714509630078978)
+
+Made Particle :pr26  :10252436524331171866: pdgid =   130, status =   1, q =  0, e =   1.5, theta =  0.48, phi =  0.83, mass =  0.50 from MergedCluster: hm2   :5595714509630078978:    1.54  0.48  0.83 sub(hs12, )
+Finished block
+Processing block:H1       :bs13  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  2.9 (5595730701205897221)
+
+Made Particle :pr27  :10252452715906990107: pdgid =   130, status =   1, q =  0, e =   2.9, theta = -0.66, phi = -1.80, mass =  0.50 from MergedCluster: hm5   :5595730701205897221:    2.93 -0.66 -1.80 sub(hs1, )
+Finished block
+Processing block:H1       :bs12  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm3       value=  7.4 (5595755081126379523)
+
+Made Particle :pr28  :10252477095827472412: pdgid =   130, status =   1, q =  0, e =   7.4, theta =  0.16, phi =  2.55, mass =  0.50 from MergedCluster: hm3   :5595755081126379523:    7.40  0.16  2.55 sub(hs2, hs10, )
+Finished block
+Processing block:T1       :bs11  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  0.4 (7955569949752164365)
+
+Made Particle :pr29  :10252407239943913501: pdgid =  -211, status =   1, q = -1, e =   0.5, theta =  0.19, phi =  0.02, mass =  0.14 from SmearedTrack: ts13  :7955569949752164365:    0.45    0.44  0.19  0.02
+Finished block
+Processing block:T1       :bs10  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  0.6 (7955576424002224140)
+
+Made Particle :pr30  :10252412810386472990: pdgid =  -211, status =   1, q = -1, e =   0.6, theta = -0.56, phi = -1.78, mass =  0.14 from SmearedTrack: ts12  :7955576424002224140:    0.58    0.49 -0.56 -1.78
+Finished block
+Processing block:T1       :bs9   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  0.8 (7955584208259252233)
+
+Made Particle :pr31  :10252420438525214751: pdgid =  -211, status =   1, q = -1, e =   0.8, theta =  0.23, phi =  1.27, mass =  0.14 from SmearedTrack: ts9   :7955584208259252233:    0.80    0.78  0.23  1.27
+Finished block
+Processing block:T1       :bs8   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  0.9 (7955588572399009802)
+
+Made Particle :pr32  :10252424747082055712: pdgid =  -211, status =   1, q = -1, e =   0.9, theta =  0.05, phi = -1.91, mass =  0.14 from SmearedTrack: ts10  :7955588572399009802:    0.93    0.93  0.05 -1.91
+Finished block
+Finished reconstruction
+Event: 2
+Made Particle :ps0   :10261493968225173504: pdgid =   321, status =   1, q =  1, e =  11.2, theta =  0.27, phi = -3.08, mass =  0.49
+Made Particle :ps1   :10261486124335628289: pdgid =    22, status =   1, q =  0, e =   7.8, theta =  0.32, phi = -3.04, mass =  0.00
+Made Particle :ps2   :10261471541833236482: pdgid =  -211, status =   1, q = -1, e =   4.5, theta =  0.23, phi =  0.57, mass =  0.14
+Made Particle :ps3   :10261471488745930755: pdgid =   211, status =   1, q =  1, e =   4.5, theta =  0.18, phi =  0.69, mass =  0.14
+Made Particle :ps4   :10261460417784053764: pdgid =   211, status =   1, q =  1, e =   3.0, theta =  0.03, phi =  0.74, mass =  0.14
+Made Particle :ps5   :10261460143541583877: pdgid = -2112, status =   1, q =  0, e =   3.0, theta = -0.41, phi = -2.34, mass =  0.94
+Made Particle :ps6   :10261459291839922182: pdgid =    22, status =   1, q =  0, e =   2.9, theta =  0.24, phi =  0.50, mass =  0.00
+Made Particle :ps7   :10261459103937200135: pdgid =    22, status =   1, q =  0, e =   2.8, theta =  0.28, phi =  0.47, mass =  0.00
+Made Particle :ps8   :10261458816384106504: pdgid =  -211, status =   1, q = -1, e =   2.8, theta =  0.41, phi =  0.11, mass =  0.14
+Made Particle :ps9   :10261456169631481865: pdgid =  -211, status =   1, q = -1, e =   2.5, theta = -0.74, phi = -2.60, mass =  0.14
+Made Particle :ps10  :10261455401402761226: pdgid =    22, status =   1, q =  0, e =   2.4, theta =  0.22, phi =  0.75, mass =  0.00
+Made Particle :ps11  :10261453538171289611: pdgid =  2112, status =   1, q =  0, e =   2.2, theta = -0.40, phi = -2.55, mass =  0.94
+Made Particle :ps12  :10261452509446930444: pdgid = -2212, status =   1, q = -1, e =   2.1, theta = -0.74, phi = -1.57, mass =  0.94
+Made Particle :ps13  :10261452391012368397: pdgid =    22, status =   1, q =  0, e =   2.1, theta =  0.12, phi =  0.08, mass =  0.00
+Made Particle :ps14  :10261452099512434702: pdgid =  2212, status =   1, q =  1, e =   2.0, theta = -0.47, phi = -0.60, mass =  0.94
+Made Particle :ps15  :10261447428060217359: pdgid =    22, status =   1, q =  0, e =   1.8, theta = -0.20, phi = -0.13, mass =  0.00
+Made Particle :ps16  :10261447198944264208: pdgid =    22, status =   1, q =  0, e =   1.7, theta =  0.31, phi = -3.11, mass =  0.00
+Made Particle :ps17  :10261447097890897937: pdgid =    22, status =   1, q =  0, e =   1.7, theta = -0.12, phi = -2.99, mass =  0.00
+Made Particle :ps18  :10261447065984827410: pdgid = -2112, status =   1, q =  0, e =   1.7, theta = -0.75, phi = -1.07, mass =  0.94
+Made Particle :ps19  :10261445892097703955: pdgid =  -211, status =   1, q = -1, e =   1.7, theta = -0.20, phi =  0.41, mass =  0.14
+Made Particle :ps20  :10261445350462062612: pdgid =    22, status =   1, q =  0, e =   1.6, theta = -0.33, phi = -2.58, mass =  0.00
+Made Particle :ps21  :10261443258794115093: pdgid =    22, status =   1, q =  0, e =   1.5, theta = -0.23, phi = -0.05, mass =  0.00
+Made Particle :ps22  :10261443203735486486: pdgid =  2212, status =   1, q =  1, e =   1.5, theta = -0.51, phi = -0.87, mass =  0.94
+Made Particle :ps23  :10261442738543132695: pdgid =  2212, status =   1, q =  1, e =   1.5, theta = -0.31, phi = -0.44, mass =  0.94
+Made Particle :ps24  :10261442611787071512: pdgid = -2212, status =   1, q = -1, e =   1.5, theta = -0.80, phi = -1.89, mass =  0.94
+Made Particle :ps25  :10261442229862137881: pdgid =  -211, status =   1, q = -1, e =   1.5, theta =  0.10, phi =  0.77, mass =  0.14
+Made Particle :ps26  :10261442189078822938: pdgid =   130, status =   1, q =  0, e =   1.5, theta = -0.00, phi =  2.89, mass =  0.50
+Made Particle :ps27  :10261440883127746587: pdgid =    22, status =   1, q =  0, e =   1.4, theta =  0.10, phi =  0.88, mass =  0.00
+Made Particle :ps28  :10261438674050744348: pdgid =   211, status =   1, q =  1, e =   1.3, theta = -0.06, phi = -2.17, mass =  0.14
+Made Particle :ps29  :10261437841158438941: pdgid =   211, status =   1, q =  1, e =   1.2, theta = -0.14, phi = -2.43, mass =  0.14
+Made Particle :ps30  :10261435992344887326: pdgid =   211, status =   1, q =  1, e =   1.1, theta = -0.15, phi = -2.21, mass =  0.14
+Made Particle :ps31  :10261430972551528479: pdgid =  -211, status =   1, q = -1, e =   0.9, theta = -0.34, phi = -3.12, mass =  0.14
+Made Particle :ps32  :10261430123022516256: pdgid =  -321, status =   1, q = -1, e =   0.9, theta =  0.16, phi = -2.95, mass =  0.49
+Made Particle :ps33  :10261430085001150497: pdgid =   211, status =   1, q =  1, e =   0.9, theta = -0.55, phi = -1.77, mass =  0.14
+Made Particle :ps34  :10261429185381662754: pdgid =  -211, status =   1, q = -1, e =   0.9, theta =  0.00, phi =  0.66, mass =  0.14
+Made Particle :ps35  :10261428154335756323: pdgid =   211, status =   1, q =  1, e =   0.8, theta =  0.18, phi =  0.63, mass =  0.14
+Made Particle :ps36  :10261427686742163492: pdgid =  -211, status =   1, q = -1, e =   0.8, theta =  0.58, phi = -0.98, mass =  0.14
+Made Particle :ps37  :10261418693357469733: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.11, phi =  1.03, mass =  0.00
+Made Particle :ps38  :10261416932729159718: pdgid =   211, status =   1, q =  1, e =   0.5, theta = -0.25, phi = -0.37, mass =  0.14
+Made Particle :ps39  :10261415553503592487: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.18, phi =  0.24, mass =  0.00
+Made Particle :ps40  :10261415411197149224: pdgid =  -211, status =   1, q = -1, e =   0.5, theta =  0.05, phi =  0.59, mass =  0.14
+Made Particle :ps41  :10261411586602172457: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -1.07, phi = -3.00, mass =  0.00
+Made Particle :ps42  :10261410966608543786: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.18, phi =  3.08, mass =  0.00
+Made Particle :ps43  :10261409911906762795: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.39, phi = -3.04, mass =  0.00
+Made Particle :ps44  :10261409092071325740: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.11, phi =  0.83, mass =  0.00
+Made Particle :ps45  :10261407528241856557: pdgid =   211, status =   1, q =  1, e =   0.4, theta = -1.02, phi = -0.13, mass =  0.14
+Made Particle :ps46  :10261403854453080110: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.06, phi = -3.04, mass =  0.00
+Made Particle :ps47  :10261402190065172527: pdgid =  -211, status =   1, q = -1, e =   0.3, theta =  0.01, phi = -1.99, mass =  0.14
+Made Particle :ps48  :10261392178685149232: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.43, phi = -0.98, mass =  0.00
+Made Particle :ps49  :10261391182506491953: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.69, phi = -0.75, mass =  0.00
+Made Particle :ps50  :10261390516214038578: pdgid =  -211, status =   1, q = -1, e =   0.2, theta =  0.16, phi = -0.60, mass =  0.14
+Made Particle :ps51  :10261387902988582963: pdgid =   211, status =   1, q =  1, e =   0.2, theta = -0.48, phi =  0.51, mass =  0.14
+Made Particle :ps52  :10261383203495346228: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.16, phi = -2.11, mass =  0.00
+Made Particle :ps53  :10261374355076284469: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.54, phi = -1.09, mass =  0.00
+Made Particle :ps54  :10261370513452433462: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.85, phi = -0.72, mass =  0.00
+Made Particle :ps55  :10261369273010094135: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.14, phi = -2.90, mass =  0.00
+Made Particle :ps56  :10261354955006804024: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.38, phi =  1.19, mass =  0.00
+Made Particle :ps57  :10261350542812905529: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.96, phi = -0.16, mass =  0.00
+Simulating Particle :ps0   :10261493968225173504: pdgid =   321, status =   1, q =  1, e =  11.2, theta =  0.27, phi = -3.08, mass =  0.49
+Simulating Hadron
+Made Track: tt0   :7964658134325133312:   11.19   10.78  0.27 -3.08
+Made SmearedTrack: ts0   :7955650964386480128:   11.20   10.79  0.27 -3.08
+Made Cluster: ht0   :5658815149052526592:   11.20  0.27  3.13 sub(ht0, )
+Made SmearedCluster: hs0   :5649793624160862208:    6.34  0.27  3.13 sub(hs0, )
+Simulating Particle :ps1   :10261486124335628289: pdgid =    22, status =   1, q =  0, e =   7.8, theta =  0.32, phi = -3.04, mass =  0.00
+Simulating Photon
+Made Cluster: et0   :3352964295949287424:    7.82  0.32 -3.04 sub(et0, )
+Made SmearedCluster: es0   :3343955415445536768:    7.43  0.32 -3.04 sub(es0, )
+Simulating Particle :ps2   :10261471541833236482: pdgid =  -211, status =   1, q = -1, e =   4.5, theta =  0.23, phi =  0.57, mass =  0.14
+Simulating Hadron
+Made Track: tt1   :7964635722353213441:    4.50    4.38  0.23  0.57
+Made SmearedTrack: ts1   :7955628514575646721:    4.50    4.38  0.23  0.57
+Made Cluster: ht1   :5658792722660589569:    4.50  0.23  0.74 sub(ht1, )
+Made SmearedCluster: hs1   :5649789010004934657:    5.29  0.23  0.74 sub(hs1, )
+Simulating Particle :ps3   :10261471488745930755: pdgid =   211, status =   1, q =  1, e =   4.5, theta =  0.18, phi =  0.69, mass =  0.14
+Simulating Hadron
+Made Track: tt2   :7964635669238644738:    4.49    4.41  0.18  0.69
+Made SmearedTrack: ts2   :7955628485045649410:    4.49    4.42  0.18  0.69
+Made Cluster: ht2   :5658792669573283842:    4.49  0.18  0.53 sub(ht2, )
+Made SmearedCluster: hs2   :5649793541986058242:    6.32  0.18  0.53 sub(hs2, )
+Simulating Particle :ps4   :10261460417784053764: pdgid =   211, status =   1, q =  1, e =   3.0, theta =  0.03, phi =  0.74, mass =  0.14
+Simulating Hadron
+Made Track: tt3   :7964624579110895619:    2.98    2.98  0.03  0.74
+Made SmearedTrack: ts3   :7955617372652437507:    2.98    2.98  0.03  0.74
+Made Cluster: ht3   :5658781598611406851:    2.99  0.04  0.49 sub(ht3, )
+Made SmearedCluster: hs3   :5649770523215790083:    2.54  0.04  0.49 sub(hs3, )
+Simulating Particle :ps5   :10261460143541583877: pdgid = -2112, status =   1, q =  0, e =   3.0, theta = -0.41, phi = -2.34, mass =  0.94
+Simulating Hadron
+Made Cluster: et1   :3352880618141646849:    0.30 -0.41 -2.34 sub(et1, )
+Made SmearedCluster: es1   :3343875961027297281:    0.34 -0.41 -2.34 sub(es1, )
+Rejected SmearedCluster: es1   :3343875961027297281:    0.34 -0.41 -2.34 sub(es1, )
+Made Cluster: ht4   :5658778691331686404:    2.65 -0.41 -2.34 sub(ht4, )
+Made SmearedCluster: hs4   :5649779292037447684:    3.54 -0.41 -2.34 sub(hs4, )
+Simulating Particle :ps6   :10261459291839922182: pdgid =    22, status =   1, q =  0, e =   2.9, theta =  0.24, phi =  0.50, mass =  0.00
+Simulating Photon
+Made Cluster: et2   :3352937463453581314:    2.86  0.24  0.50 sub(et2, )
+Made SmearedCluster: es1   :3343930975947063297:    2.94  0.24  0.50 sub(es1, )
+Simulating Particle :ps7   :10261459103937200135: pdgid =    22, status =   1, q =  0, e =   2.8, theta =  0.28, phi =  0.47, mass =  0.00
+Simulating Photon
+Made Cluster: et3   :3352937275550859267:    2.84  0.28  0.47 sub(et3, )
+Made SmearedCluster: es2   :3343928309456044034:    2.64  0.28  0.47 sub(es2, )
+Simulating Particle :ps8   :10261458816384106504: pdgid =  -211, status =   1, q = -1, e =   2.8, theta =  0.41, phi =  0.11, mass =  0.14
+Simulating Hadron
+Made Track: tt4   :7964622975844483076:    2.80    2.56  0.41  0.11
+Made SmearedTrack: ts4   :7955615784703623172:    2.80    2.57  0.41  0.11
+Made Cluster: ht5   :5658779997211459589:    2.80  0.42  0.39 sub(ht5, )
+Made SmearedCluster: hs5   :5649777059627532293:    3.29  0.42  0.39 sub(hs5, )
+Simulating Particle :ps9   :10261456169631481865: pdgid =  -211, status =   1, q = -1, e =   2.5, theta = -0.74, phi = -2.60, mass =  0.14
+Simulating Hadron
+Made Track: tt5   :7964620325409259525:    2.50    1.85 -0.74 -2.60
+Made SmearedTrack: ts5   :7955613032315355141:    2.49    1.84 -0.74 -2.60
+Made Cluster: et4   :3352915778549579780:    1.20 -0.75 -2.25 sub(et4, )
+Made SmearedCluster: es3   :3343917116360228867:    1.68 -0.75 -2.25 sub(es3, )
+Made Cluster: ht6   :5658760728784404486:    1.31 -0.75 -2.20 sub(ht6, )
+Made SmearedCluster: hs6   :5649762761935159302:    1.83 -0.75 -2.20 sub(hs6, )
+Simulating Particle :ps10  :10261455401402761226: pdgid =    22, status =   1, q =  0, e =   2.4, theta =  0.22, phi =  0.75, mass =  0.00
+Simulating Photon
+Made Cluster: et5   :3352933573016420357:    2.42  0.22  0.75 sub(et5, )
+Made SmearedCluster: es4   :3343925445186813956:    2.31  0.22  0.75 sub(es4, )
+Simulating Particle :ps11  :10261453538171289611: pdgid =  2112, status =   1, q =  0, e =   2.2, theta = -0.40, phi = -2.55, mass =  0.94
+Simulating Hadron
+Made Cluster: et6   :3352901264955408390:    0.69 -0.40 -2.55 sub(et6, )
+Made SmearedCluster: es5   :3343901550549401605:    0.90 -0.40 -2.55 sub(es5, )
+Made Cluster: ht7   :5658764446737104903:    1.52 -0.40 -2.55 sub(ht7, )
+Made SmearedCluster: hs7   :5649765637436735495:    1.99 -0.40 -2.55 sub(hs7, )
+Simulating Particle :ps12  :10261452509446930444: pdgid = -2212, status =   1, q = -1, e =   2.1, theta = -0.74, phi = -1.57, mass =  0.94
+Simulating Hadron
+Made Track: tt6   :7964613536703840262:    1.86    1.37 -0.74 -1.57
+Made SmearedTrack: ts6   :7955606793617408006:    1.89    1.39 -0.74 -1.57
+Made Cluster: ht8   :5658773690274283528:    2.09 -0.77 -1.02 sub(ht8, )
+Made SmearedCluster: hs8   :5649770686047059976:    2.56 -0.77 -1.02 sub(hs8, )
+Simulating Particle :ps13  :10261452391012368397: pdgid =    22, status =   1, q =  0, e =   2.1, theta =  0.12, phi =  0.08, mass =  0.00
+Simulating Photon
+Made Cluster: et7   :3352930562626027527:    2.07  0.12  0.08 sub(et7, )
+Made SmearedCluster: es6   :3343920549112840198:    1.88  0.12  0.08 sub(es6, )
+Simulating Particle :ps14  :10261452099512434702: pdgid =  2212, status =   1, q =  1, e =   2.0, theta = -0.47, phi = -0.60, mass =  0.94
+Simulating Hadron
+Made Track: tt7   :7964612616081375239:    1.81    1.61 -0.47 -0.60
+Made SmearedTrack: ts7   :7955605398482845703:    1.81    1.61 -0.47 -0.60
+Made Cluster: ht9   :5658773280339787785:    2.04 -0.49 -1.06 sub(ht9, )
+Made SmearedCluster: hs9   :5649762011821637641:    1.79 -0.49 -1.06 sub(hs9, )
+Simulating Particle :ps15  :10261447428060217359: pdgid =    22, status =   1, q =  0, e =   1.8, theta = -0.20, phi = -0.13, mass =  0.00
+Simulating Photon
+Made Cluster: et8   :3352925599673876488:    1.75 -0.20 -0.13 sub(et8, )
+Made SmearedCluster: es7   :3343916882922045447:    1.67 -0.20 -0.13 sub(es7, )
+Simulating Particle :ps16  :10261447198944264208: pdgid =    22, status =   1, q =  0, e =   1.7, theta =  0.31, phi = -3.11, mass =  0.00
+Simulating Photon
+Made Cluster: et9   :3352925370557923337:    1.74  0.31 -3.10 sub(et9, )
+Made SmearedCluster: es8   :3343907404298321928:    1.13  0.31 -3.10 sub(es8, )
+Simulating Particle :ps17  :10261447097890897937: pdgid =    22, status =   1, q =  0, e =   1.7, theta = -0.12, phi = -2.99, mass =  0.00
+Simulating Photon
+Made Cluster: et10  :3352925269504557066:    1.74 -0.12 -2.99 sub(et10, )
+Made SmearedCluster: es9   :3343919523544694793:    1.82 -0.12 -2.99 sub(es9, )
+Simulating Particle :ps18  :10261447065984827410: pdgid = -2112, status =   1, q =  0, e =   1.7, theta = -0.75, phi = -1.07, mass =  0.94
+Simulating Hadron
+Made Cluster: et11  :3352912351083888651:    1.00 -0.75 -1.08 sub(et11, )
+Made SmearedCluster: es10  :3343896636450406410:    0.76 -0.75 -1.08 sub(es10, )
+Made Cluster: ht10  :5658745928262090762:    0.73 -0.75 -1.08 sub(ht10, )
+Made SmearedCluster: hs10  :5649724409984843786:    0.41 -0.75 -1.08 sub(hs10, )
+Rejected SmearedCluster: hs10  :5649724409984843786:    0.41 -0.75 -1.08 sub(hs10, )
+Simulating Particle :ps19  :10261445892097703955: pdgid =  -211, status =   1, q = -1, e =   1.7, theta = -0.20, phi =  0.41, mass =  0.14
+Simulating Hadron
+Made Track: tt8   :7964609979168587784:    1.66    1.63 -0.20  0.41
+Made SmearedTrack: ts8   :7955602821758320648:    1.66    1.63 -0.20  0.41
+Made Cluster: et12  :3352902581698428940:    0.72 -0.20  0.82 sub(et12, )
+Made SmearedCluster: es11  :3341670923508908043:   -0.44 -0.20  0.82 sub(es11, )
+Rejected SmearedCluster: es11  :3341670923508908043:   -0.44 -0.20  0.82 sub(es11, )
+Made Cluster: ht11  :5658753370565902347:    0.94 -0.21  0.87 sub(ht11, )
+Made SmearedCluster: hs10  :5649741533958635530:    0.81 -0.21  0.87 sub(hs10, )
+Rejected SmearedCluster: hs10  :5649741533958635530:    0.81 -0.21  0.87 sub(hs10, )
+Simulating Particle :ps20  :10261445350462062612: pdgid =    22, status =   1, q =  0, e =   1.6, theta = -0.33, phi = -2.58, mass =  0.00
+Simulating Photon
+Made Cluster: et13  :3352923522075721741:    1.64 -0.33 -2.58 sub(et13, )
+Made SmearedCluster: es11  :3343914749910843403:    1.55 -0.33 -2.58 sub(es11, )
+Simulating Particle :ps21  :10261443258794115093: pdgid =    22, status =   1, q =  0, e =   1.5, theta = -0.23, phi = -0.05, mass =  0.00
+Simulating Photon
+Made Cluster: et14  :3352921430407774222:    1.52 -0.23 -0.05 sub(et14, )
+Made SmearedCluster: es12  :3343917216260161548:    1.69 -0.23 -0.05 sub(es12, )
+Simulating Particle :ps22  :10261443203735486486: pdgid =  2212, status =   1, q =  1, e =   1.5, theta = -0.51, phi = -0.87, mass =  0.94
+Simulating Hadron
+Made Track: tt9   :7964601663140921353:    1.19    1.04 -0.51 -0.87
+Made SmearedTrack: ts9   :7955594459140325385:    1.19    1.04 -0.51 -0.87
+Made Cluster: et15  :3352902802895536143:    0.73 -0.54 -1.52 sub(et15, )
+Made SmearedCluster: es13  :3343911777382432781:    1.38 -0.54 -1.52 sub(es13, )
+Made Cluster: ht12  :5658747772644360204:    0.78 -0.56 -1.62 sub(ht12, )
+Made SmearedCluster: hs10  :5649741753022939146:    0.82 -0.56 -1.62 sub(hs10, )
+Rejected SmearedCluster: hs10  :5649741753022939146:    0.82 -0.56 -1.62 sub(hs10, )
+Simulating Particle :ps23  :10261442738543132695: pdgid =  2212, status =   1, q =  1, e =   1.5, theta = -0.31, phi = -0.44, mass =  0.94
+Simulating Hadron
+Made Track: tt10  :7964601067117740042:    1.15    1.10 -0.31 -0.44
+Made SmearedTrack: ts10  :7955593841952686090:    1.15    1.10 -0.31 -0.44
+Made Cluster: ht13  :5658763919370485773:    1.49 -0.33 -1.15 sub(ht13, )
+Made SmearedCluster: hs10  :5649766431724666890:    2.08 -0.33 -1.15 sub(hs10, )
+Simulating Particle :ps24  :10261442611787071512: pdgid = -2212, status =   1, q = -1, e =   1.5, theta = -0.80, phi = -1.89, mass =  0.94
+Simulating Hadron
+Made Track: tt11  :7964600903516815371:    1.15    0.79 -0.80 -1.89
+Made SmearedTrack: ts11  :7955593577076097035:    1.14    0.79 -0.80 -1.89
+Made Cluster: ht14  :5658763792614424590:    1.48 -0.90 -0.85 sub(ht14, )
+Made SmearedCluster: hs11  :5649762824996519947:    1.83 -0.90 -0.85 sub(hs11, )
+Simulating Particle :ps25  :10261442229862137881: pdgid =  -211, status =   1, q = -1, e =   1.5, theta =  0.10, phi =  0.77, mass =  0.14
+Simulating Hadron
+Made Track: tt12  :7964606302175363084:    1.45    1.44  0.10  0.77
+Made SmearedTrack: ts12  :7955599100649406476:    1.45    1.44  0.10  0.77
+Made Cluster: et16  :3352866265875087376:    0.17  0.11  1.24 sub(et16, )
+Made SmearedCluster: es14  :3343826362520567822:    0.05  0.11  1.24 sub(es14, )
+Rejected SmearedCluster: es14  :3343826362520567822:    0.05  0.11  1.24 sub(es14, )
+Made Cluster: ht15  :5658760372660731919:    1.29  0.11  1.30 sub(ht15, )
+Made SmearedCluster: hs12  :5649771174203228172:    2.62  0.11  1.30 sub(hs12, )
+Simulating Particle :ps26  :10261442189078822938: pdgid =   130, status =   1, q =  0, e =   1.5, theta = -0.00, phi =  2.89, mass =  0.50
+Simulating Hadron
+Made Cluster: ht16  :5658763369906176016:    1.46 -0.00  2.89 sub(ht16, )
+Made SmearedCluster: hs13  :5649763806446878733:    1.89 -0.00  2.89 sub(hs13, )
+Simulating Particle :ps27  :10261440883127746587: pdgid =    22, status =   1, q =  0, e =   1.4, theta =  0.10, phi =  0.88, mass =  0.00
+Simulating Photon
+Made Cluster: et17  :3352919054741405713:    1.38  0.10  0.88 sub(et17, )
+Made SmearedCluster: es14  :3343905371931541518:    1.01  0.10  0.88 sub(es14, )
+Simulating Particle :ps28  :10261438674050744348: pdgid =   211, status =   1, q =  1, e =   1.3, theta = -0.06, phi = -2.17, mass =  0.14
+Simulating Hadron
+Made Track: tt13  :7964602727317635085:    1.25    1.25 -0.06 -2.17
+Made SmearedTrack: ts13  :7955595509920432141:    1.25    1.25 -0.06 -2.17
+Made Cluster: et18  :3352901757366698002:    0.70 -0.06 -2.71 sub(et18, )
+Made SmearedCluster: es15  :3343843946053763087:    0.10 -0.06 -2.71 sub(es15, )
+Rejected SmearedCluster: es15  :3343843946053763087:    0.10 -0.06 -2.71 sub(es15, )
+Made Cluster: ht17  :5658739758803714065:    0.56 -0.06 -2.79 sub(ht17, )
+Made SmearedCluster: hs14  :5649736921990037518:    0.68 -0.06 -2.79 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649736921990037518:    0.68 -0.06 -2.79 sub(hs14, )
+Simulating Particle :ps29  :10261437841158438941: pdgid =   211, status =   1, q =  1, e =   1.2, theta = -0.14, phi = -2.43, mass =  0.14
+Simulating Hadron
+Made Track: tt14  :7964601889035649038:    1.20    1.19 -0.14 -2.43
+Made SmearedTrack: ts14  :7955594686819729422:    1.20    1.19 -0.14 -2.43
+Made Cluster: et19  :3352898362220216339:    0.60 -0.15 -3.00 sub(et19, )
+Made SmearedCluster: es15  :3343873550573371407:    0.30 -0.15 -3.00 sub(es15, )
+Rejected SmearedCluster: es15  :3343873550573371407:    0.30 -0.15 -3.00 sub(es15, )
+Made Cluster: ht18  :5658741488163487762:    0.61 -0.15 -3.08 sub(ht18, )
+Made SmearedCluster: hs14  :5649733557327757326:    0.59 -0.15 -3.08 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649733557327757326:    0.59 -0.15 -3.08 sub(hs14, )
+Simulating Particle :ps30  :10261435992344887326: pdgid =   211, status =   1, q =  1, e =   1.1, theta = -0.15, phi = -2.21, mass =  0.14
+Simulating Hadron
+Made Track: tt15  :7964600026588512271:    1.10    1.08 -0.15 -2.21
+Made SmearedTrack: ts15  :7955592830882152463:    1.10    1.08 -0.15 -2.21
+Made Cluster: et20  :3352901035778637844:    0.68 -0.16 -2.85 sub(et20, )
+Made SmearedCluster: es15  :3341670923508908047:   -0.11 -0.16 -2.85 sub(es15, )
+Rejected SmearedCluster: es15  :3341670923508908047:   -0.11 -0.16 -2.85 sub(es15, )
+Made Cluster: ht19  :5658732486541180947:    0.43 -0.17 -2.94 sub(ht19, )
+Made SmearedCluster: hs14  :5649685841969152014:    0.09 -0.17 -2.94 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649685841969152014:    0.09 -0.17 -2.94 sub(hs14, )
+Simulating Particle :ps31  :10261430972551528479: pdgid =  -211, status =   1, q = -1, e =   0.9, theta = -0.34, phi = -3.12, mass =  0.14
+Simulating Hadron
+Made Track: tt16  :7964594783530254352:    0.90    0.85 -0.34 -3.12
+Made SmearedTrack: ts16  :7955587531131584528:    0.90    0.85 -0.34 -3.12
+Made Cluster: et21  :3352899231642812437:    0.63 -0.38 -2.25 sub(et21, )
+Made SmearedCluster: es15  :3343877325769932815:    0.35 -0.38 -2.25 sub(es15, )
+Rejected SmearedCluster: es15  :3343877325769932815:    0.35 -0.38 -2.25 sub(es15, )
+Made Cluster: ht20  :5658722388089503764:    0.28 -0.40 -2.10 sub(ht20, )
+Made SmearedCluster: hs14  :5649713361301012494:    0.26 -0.40 -2.10 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649713361301012494:    0.26 -0.40 -2.10 sub(hs14, )
+Simulating Particle :ps32  :10261430123022516256: pdgid =  -321, status =   1, q = -1, e =   0.9, theta =  0.16, phi = -2.95, mass =  0.49
+Simulating Hadron
+Made Track: tt17  :7964589020309094417:    0.73    0.73  0.16 -2.95
+Made SmearedTrack: ts17  :7955581813183741969:    0.73    0.73  0.16 -2.95
+Made Cluster: et22  :3352886964993916950:    0.39  0.19 -1.85 sub(et22, )
+Made SmearedCluster: es15  :3343845497801539599:    0.10  0.19 -1.85 sub(es15, )
+Rejected SmearedCluster: es15  :3343845497801539599:    0.10  0.19 -1.85 sub(es15, )
+Made Cluster: ht21  :5658737449120038933:    0.50  0.23 -1.51 sub(ht21, )
+Made SmearedCluster: hs14  :5647513932722601998:   -0.18  0.23 -1.51 sub(hs14, )
+Rejected SmearedCluster: hs14  :5647513932722601998:   -0.18  0.23 -1.51 sub(hs14, )
+Simulating Particle :ps33  :10261430085001150497: pdgid =   211, status =   1, q =  1, e =   0.9, theta = -0.55, phi = -1.77, mass =  0.14
+Simulating Hadron
+Made Track: tt18  :7964593885030645778:    0.87    0.74 -0.55 -1.77
+Made SmearedTrack: ts18  :7955586495612452882:    0.87    0.74 -0.55 -1.77
+Made Cluster: et23  :3352871368145240087:    0.21 -0.64 -2.82 sub(et23, )
+Made SmearedCluster: es15  :3343857524127301647:    0.16 -0.64 -2.82 sub(es15, )
+Rejected SmearedCluster: es15  :3343857524127301647:    0.16 -0.64 -2.82 sub(es15, )
+Made Cluster: ht22  :5658743914203447318:    0.68 -0.70 -3.09 sub(ht22, )
+Made SmearedCluster: hs14  :5649733586534793230:    0.59 -0.70 -3.09 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649733586534793230:    0.59 -0.70 -3.09 sub(hs14, )
+Simulating Particle :ps34  :10261429185381662754: pdgid =  -211, status =   1, q = -1, e =   0.9, theta =  0.00, phi =  0.66, mass =  0.14
+Simulating Hadron
+Made Track: tt19  :7964592973644038163:    0.85    0.85  0.00  0.66
+Made SmearedTrack: ts19  :7955585794857500691:    0.85    0.85  0.00  0.66
+Made Cluster: et24  :3352897743885434904:    0.59  0.00  1.53 sub(et24, )
+Made SmearedCluster: es15  :3343877916596371471:    0.36  0.00  1.53 sub(es15, )
+Rejected SmearedCluster: es15  :3343877916596371471:    0.36  0.00  1.53 sub(es15, )
+Made Cluster: ht23  :5658721789264527383:    0.27  0.00  1.68 sub(ht23, )
+Made SmearedCluster: hs14  :5649741245151445006:    0.80  0.00  1.68 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649741245151445006:    0.80  0.00  1.68 sub(hs14, )
+Simulating Particle :ps35  :10261428154335756323: pdgid =   211, status =   1, q =  1, e =   0.8, theta =  0.18, phi =  0.63, mass =  0.14
+Simulating Hadron
+Made Track: tt20  :7964591928199086100:    0.82    0.80  0.18  0.63
+Made SmearedTrack: ts20  :7955584677706727444:    0.82    0.80  0.18  0.63
+Made Cluster: et25  :3352889227235819545:    0.42  0.21 -0.30 sub(et25, )
+Made SmearedCluster: es15  :3343903157821374479:    0.94  0.21 -0.30 sub(es15, )
+Made Cluster: ht24  :5658731249502519320:    0.41  0.23 -0.48 sub(ht24, )
+Made SmearedCluster: hs14  :5649715876899848206:    0.29  0.23 -0.48 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649715876899848206:    0.29  0.23 -0.48 sub(hs14, )
+Simulating Particle :ps36  :10261427686742163492: pdgid =  -211, status =   1, q = -1, e =   0.8, theta =  0.58, phi = -0.98, mass =  0.14
+Simulating Hadron
+Made Track: tt21  :7964591453726834709:    0.80    0.67  0.58 -0.98
+Made SmearedTrack: ts21  :7955584045990019093:    0.80    0.67  0.58 -0.98
+Made Cluster: et26  :3352886340501897242:    0.38  0.72  0.30 sub(et26, )
+Made SmearedCluster: es16  :3343870950748717072:    0.26  0.72  0.30 sub(es16, )
+Rejected SmearedCluster: es16  :3343870950748717072:    0.26  0.72  0.30 sub(es16, )
+Made Cluster: ht25  :5658733201049255961:    0.44  0.94  0.97 sub(ht25, )
+Made SmearedCluster: hs14  :5649703616190087182:    0.18  0.94  0.97 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649703616190087182:    0.18  0.94  0.97 sub(hs14, )
+Simulating Particle :ps37  :10261418693357469733: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.11, phi =  1.03, mass =  0.00
+Simulating Photon
+Made Cluster: et27  :3352896864971128859:    0.56  0.11  1.03 sub(et27, )
+Made SmearedCluster: es16  :3343891862717988880:    0.62  0.11  1.03 sub(es16, )
+Simulating Particle :ps38  :10261416932729159718: pdgid =   211, status =   1, q =  1, e =   0.5, theta = -0.25, phi = -0.37, mass =  0.14
+Simulating Hadron
+Made Track: tt22  :7964580119998103574:    0.49    0.48 -0.25 -0.37
+Made SmearedTrack: ts22  :7955572966517899286:    0.49    0.48 -0.25 -0.37
+Made Cluster: et28  :3352863398785187868:    0.15 -1.50 -0.48 sub(et28, )
+Made SmearedCluster: es17  :3343882431743655953:    0.43 -1.50 -0.48 sub(es17, )
+Rejected SmearedCluster: es17  :3343882431743655953:    0.43 -1.50 -0.48 sub(es17, )
+Made Cluster: ht26  :5658727761122951194:    0.36 -1.22 -1.10 sub(ht26, )
+Made SmearedCluster: hs14  :5649733996054052878:    0.60 -1.22 -1.10 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649733996054052878:    0.60 -1.22 -1.10 sub(hs14, )
+Simulating Particle :ps39  :10261415553503592487: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.18, phi =  0.24, mass =  0.00
+Simulating Photon
+Made Cluster: et29  :3352893725117251613:    0.49 -0.18  0.24 sub(et29, )
+Made SmearedCluster: es17  :3343891196423438353:    0.60 -0.18  0.24 sub(es17, )
+Simulating Particle :ps40  :10261415411197149224: pdgid =  -211, status =   1, q = -1, e =   0.5, theta =  0.05, phi =  0.59, mass =  0.14
+Simulating Hadron
+Made Track: tt23  :7964578153114894359:    0.46    0.46  0.05  0.59
+Made SmearedTrack: ts23  :7955570910923063319:    0.46    0.46  0.05  0.59
+Made Cluster: et30  :3352880457919234078:    0.30  1.05  1.92 sub(et30, )
+Made SmearedCluster: es18  :3343838414251229202:    0.08  1.05  1.92 sub(es18, )
+Rejected SmearedCluster: es18  :3343838414251229202:    0.08  1.05  1.92 sub(es18, )
+Made Cluster: ht27  :5658711220641857563:    0.19  1.08  2.23 sub(ht27, )
+Made SmearedCluster: hs14  :5649714257644748814:    0.27  1.08  2.23 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649714257644748814:    0.27  1.08  2.23 sub(hs14, )
+Simulating Particle :ps41  :10261411586602172457: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -1.07, phi = -3.00, mass =  0.00
+Simulating Photon
+Made Cluster: et31  :3352889758215831583:    0.43 -1.07 -3.00 sub(et31, )
+Made SmearedCluster: es18  :3343877252533190674:    0.35 -1.07 -3.00 sub(es18, )
+Rejected SmearedCluster: es18  :3343877252533190674:    0.35 -1.07 -3.00 sub(es18, )
+Simulating Particle :ps42  :10261410966608543786: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.18, phi =  3.08, mass =  0.00
+Simulating Photon
+Made Cluster: et32  :3352889138222202912:    0.42  0.19  3.09 sub(et32, )
+Made SmearedCluster: es18  :3343884674586902546:    0.46  0.19  3.09 sub(es18, )
+Rejected SmearedCluster: es18  :3343884674586902546:    0.46  0.19  3.09 sub(es18, )
+Simulating Particle :ps43  :10261409911906762795: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.39, phi = -3.04, mass =  0.00
+Simulating Photon
+Made Cluster: et33  :3352888083520421921:    0.41  0.39 -3.04 sub(et33, )
+Made SmearedCluster: es18  :3343879027757678610:    0.38  0.39 -3.04 sub(es18, )
+Rejected SmearedCluster: es18  :3343879027757678610:    0.38  0.39 -3.04 sub(es18, )
+Simulating Particle :ps44  :10261409092071325740: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.11, phi =  0.83, mass =  0.00
+Simulating Photon
+Made Cluster: et34  :3352887263684984866:    0.39  0.11  0.83 sub(et34, )
+Made SmearedCluster: es18  :3343877763435069458:    0.36  0.11  0.83 sub(es18, )
+Rejected SmearedCluster: es18  :3343877763435069458:    0.36  0.11  0.83 sub(es18, )
+Simulating Particle :ps46  :10261403854453080110: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.06, phi = -3.04, mass =  0.00
+Simulating Photon
+Made Cluster: et35  :3352882026066739235:    0.32  0.06 -3.04 sub(et35, )
+Made SmearedCluster: es18  :3343877271711645714:    0.35  0.06 -3.04 sub(es18, )
+Rejected SmearedCluster: es18  :3343877271711645714:    0.35  0.06 -3.04 sub(es18, )
+Simulating Particle :ps47  :10261402190065172527: pdgid =  -211, status =   1, q = -1, e =   0.3, theta =  0.01, phi = -1.99, mass =  0.14
+Simulating Hadron
+Made Track: tt24  :7964563916393021464:    0.26    0.26  0.01 -1.99
+Made SmearedTrack: ts24  :7955556701864722456:    0.26    0.26  0.01 -1.99
+Rejected SmearedTrack: ts24  :7955556701864722456:    0.26    0.26  0.01 -1.99
+Made Cluster: et36  :3352838417244225572:    0.06  1.47 -1.68 sub(et36, )
+Made SmearedCluster: es18  :3343874362643054610:    0.31  1.47 -1.68 sub(es18, )
+Rejected SmearedCluster: es18  :3343874362643054610:    0.31  1.47 -1.68 sub(es18, )
+Made Cluster: ht28  :5658718676558282780:    0.24  1.28 -0.50 sub(ht28, )
+Made SmearedCluster: hs14  :5649698871394172942:    0.15  1.28 -0.50 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649698871394172942:    0.15  1.28 -0.50 sub(hs14, )
+Simulating Particle :ps48  :10261392178685149232: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.43, phi = -0.98, mass =  0.00
+Simulating Photon
+Made Cluster: et37  :3352870350298808357:    0.20 -0.43 -0.98 sub(et37, )
+Made SmearedCluster: es18  :3343855543222534162:    0.15 -0.43 -0.98 sub(es18, )
+Rejected SmearedCluster: es18  :3343855543222534162:    0.15 -0.43 -0.98 sub(es18, )
+Simulating Particle :ps49  :10261391182506491953: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.69, phi = -0.75, mass =  0.00
+Simulating Photon
+Made Cluster: et38  :3352869354120151078:    0.19 -0.69 -0.75 sub(et38, )
+Made SmearedCluster: es18  :3343857168836198418:    0.16 -0.69 -0.75 sub(es18, )
+Rejected SmearedCluster: es18  :3343857168836198418:    0.16 -0.69 -0.75 sub(es18, )
+Simulating Particle :ps52  :10261383203495346228: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.16, phi = -2.11, mass =  0.00
+Simulating Photon
+Made Cluster: et39  :3352861375109005351:    0.14 -0.18 -2.09 sub(et39, )
+Made SmearedCluster: es18  :3343859717498732562:    0.18 -0.18 -2.09 sub(es18, )
+Rejected SmearedCluster: es18  :3343859717498732562:    0.18 -0.18 -2.09 sub(es18, )
+Simulating Particle :ps53  :10261374355076284469: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.54, phi = -1.09, mass =  0.00
+Simulating Photon
+Made Cluster: et40  :3352852526689943592:    0.10 -0.54 -1.09 sub(et40, )
+Made SmearedCluster: es18  :3343867948663046162:    0.24 -0.54 -1.09 sub(es18, )
+Rejected SmearedCluster: es18  :3343867948663046162:    0.24 -0.54 -1.09 sub(es18, )
+Simulating Particle :ps54  :10261370513452433462: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.85, phi = -0.72, mass =  0.00
+Simulating Photon
+Made Cluster: et41  :3352848685066092585:    0.09 -0.85 -0.73 sub(et41, )
+Made SmearedCluster: es18  :3341670923508908050:   -0.02 -0.85 -0.73 sub(es18, )
+Rejected SmearedCluster: es18  :3341670923508908050:   -0.02 -0.85 -0.73 sub(es18, )
+Simulating Particle :ps55  :10261369273010094135: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.14, phi = -2.90, mass =  0.00
+Simulating Photon
+Made Cluster: et42  :3352847444623753258:    0.08 -0.14 -2.90 sub(et42, )
+Made SmearedCluster: es18  :3343837845683961874:    0.07 -0.14 -2.90 sub(es18, )
+Rejected SmearedCluster: es18  :3343837845683961874:    0.07 -0.14 -2.90 sub(es18, )
+Simulating Particle :ps56  :10261354955006804024: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.38, phi =  1.19, mass =  0.00
+Simulating Photon
+Made Cluster: et43  :3352833126620463147:    0.05 -0.38  1.19 sub(et43, )
+Made SmearedCluster: es18  :3343822110790254610:    0.04 -0.38  1.19 sub(es18, )
+Rejected SmearedCluster: es18  :3343822110790254610:    0.04 -0.38  1.19 sub(es18, )
+Simulating Particle :ps57  :10261350542812905529: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.96, phi = -0.16, mass =  0.00
+Simulating Photon
+Made Cluster: et44  :3352828714426564652:    0.04 -0.96 -0.16 sub(et44, )
+Made SmearedCluster: es18  :3343829113264668690:    0.05 -0.96 -0.16 sub(es18, )
+Rejected SmearedCluster: es18  :3343829113264668690:    0.05 -0.96 -0.16 sub(es18, )
+Made MergedCluster: em0   :3289848000894992384:    0.60 -0.18  0.24 sub(es17, )
+Made MergedCluster: em1   :3289848667189542913:    0.62  0.11  1.03 sub(es16, )
+Made MergedCluster: em2   :3289853440921960450:    0.76 -0.75 -1.08 sub(es10, )
+Made MergedCluster: em3   :3289858355020955651:    0.90 -0.40 -2.55 sub(es5, )
+Made MergedCluster: em4   :3289859962292928516:    0.94  0.21 -0.30 sub(es15, )
+Made MergedCluster: em5   :3289862176403095557:    1.01  0.10  0.88 sub(es14, )
+Made MergedCluster: em6   :3289864208769875974:    1.13  0.31 -3.10 sub(es8, )
+Made MergedCluster: em7   :3289868581853986823:    1.38 -0.54 -1.52 sub(es13, )
+Made MergedCluster: em8   :3289871554382397448:    1.55 -0.33 -2.58 sub(es11, )
+Made MergedCluster: em9   :3289873687393599497:    1.67 -0.20 -0.13 sub(es7, )
+Made MergedCluster: em10  :3289873920831782922:    1.68 -0.75 -2.25 sub(es3, )
+Made MergedCluster: em11  :3289874020731715595:    1.69 -0.23 -0.05 sub(es12, )
+Made MergedCluster: em12  :3289876328016248844:    1.82 -0.12 -2.99 sub(es9, )
+Made MergedCluster: em13  :3289877353584394253:    1.88  0.12  0.08 sub(es6, )
+Made MergedCluster: em14  :3289882249658368014:    2.31  0.22  0.75 sub(es4, )
+Made MergedCluster: em15  :3289885113927598095:    2.64  0.28  0.47 sub(es2, )
+Made MergedCluster: em16  :3289887780418617360:    2.94  0.24  0.50 sub(es1, )
+Made MergedCluster: em17  :3289912219917090833:    7.43  0.32 -3.04 sub(es0, )
+Made MergedCluster: hm0   :5595738968023891968:    3.87 -0.41 -1.11 sub(hs10, hs9, )
+Made MergedCluster: hm1   :5595719566406713345:    1.83 -0.75 -2.20 sub(hs6, )
+Made MergedCluster: hm2   :5595719629468073986:    1.83 -0.90 -0.85 sub(hs11, )
+Made MergedCluster: hm3   :5595720610918432771:    1.89 -0.00  2.89 sub(hs13, )
+Made MergedCluster: hm4   :5595722441908289540:    1.99 -0.40 -2.55 sub(hs7, )
+Made MergedCluster: hm5   :5595759629635158021:    8.87  0.14  0.52 sub(hs2, hs3, )
+Made MergedCluster: hm6   :5595727490518614022:    2.56 -0.77 -1.02 sub(hs8, )
+Made MergedCluster: hm7   :5595727978674782215:    2.62  0.11  1.30 sub(hs12, )
+Made MergedCluster: hm8   :5595733864099086344:    3.29  0.42  0.39 sub(hs5, )
+Made MergedCluster: hm9   :5595736096509001737:    3.54 -0.41 -2.34 sub(hs4, )
+Made MergedCluster: hm10  :5595745814476488714:    5.29  0.23  0.74 sub(hs1, )
+Made MergedCluster: hm11  :5595750428632416267:    6.34  0.27  3.13 sub(hs0, )
+Made block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.6 (3289848000894992384)
+
+Made block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.6 (3289848667189542913)
+
+Made block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.8 (3289853440921960450)
+
+Made block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.9 (3289858355020955651)
+
+Made block:E1T1     :br4   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts20      value=  0.8 (7955584677706727444)
+      e1 = em4       value=  0.9 (3289859962292928516)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  1.0 (3289862176403095557)
+
+Made block:E1       :br6   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  1.1 (3289864208769875974)
+
+Made block:E1T1     :br7   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  1.2 (7955594459140325385)
+      e1 = em7       value=  1.4 (3289868581853986823)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  1.5 (3289871554382397448)
+
+Made block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  1.7 (3289873687393599497)
+
+Made block:E1H1T1   :br10  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  2.5 (7955613032315355141)
+      h1 = hm1       value=  1.8 (5595719566406713345)
+      e2 = em10      value=  1.7 (3289873920831782922)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.7 (3289874020731715595)
+
+Made block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  1.8 (3289876328016248844)
+
+Made block:E1       :br13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  1.9 (3289877353584394253)
+
+Made block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  2.3 (3289882249658368014)
+
+Made block:E1       :br15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  2.6 (3289885113927598095)
+
+Made block:E1       :br16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  2.9 (3289887780418617360)
+
+Made block:E1       :br17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  7.4 (3289912219917090833)
+
+Made block:H1T1     :br18  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts11      value=  1.1 (7955593577076097035)
+      h1 = hm2       value=  1.8 (5595719629468073986)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1       :br19  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm3       value=  1.9 (5595720610918432771)
+
+Made block:H1       :br20  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm4       value=  2.0 (5595722441908289540)
+
+Made block:H1T1     :br21  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  1.9 (7955606793617408006)
+      h1 = hm6       value=  2.6 (5595727490518614022)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br22  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts12      value=  1.5 (7955599100649406476)
+      h1 = hm7       value=  2.6 (5595727978674782215)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br23  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  2.8 (7955615784703623172)
+      h1 = hm8       value=  3.3 (5595733864099086344)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1       :br24  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm9       value=  3.5 (5595736096509001737)
+
+Made block:H1T2     :br25  : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts7       value=  1.8 (7955605398482845703)
+      t1 = ts10      value=  1.2 (7955593841952686090)
+      h2 = hm0       value=  3.9 (5595738968023891968)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+
+Made block:H1T1     :br26  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts1       value=  4.5 (7955628514575646721)
+      h1 = hm10      value=  5.3 (5595745814476488714)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br27  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts0       value= 11.2 (7955650964386480128)
+      h1 = hm11      value=  6.3 (5595750428632416267)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T2     :br28  : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts2       value=  4.5 (7955628485045649410)
+      t1 = ts3       value=  3.0 (7955617372652437507)
+      h2 = hm5       value=  8.9 (5595759629635158021)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+
+Made block:T1       :br29  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts23      value=  0.5 (7955570910923063319)
+
+Made block:T1       :br30  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts22      value=  0.5 (7955572966517899286)
+
+Made block:T1       :br31  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts17      value=  0.7 (7955581813183741969)
+
+Made block:T1       :br32  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts21      value=  0.8 (7955584045990019093)
+
+Made block:T1       :br33  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts19      value=  0.8 (7955585794857500691)
+
+Made block:T1       :br34  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts18      value=  0.9 (7955586495612452882)
+
+Made block:T1       :br35  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  0.9 (7955587531131584528)
+
+Made block:T1       :br36  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  1.1 (7955592830882152463)
+
+Made block:T1       :br37  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.2 (7955594686819729422)
+
+Made block:T1       :br38  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.2 (7955595509920432141)
+
+Made block:T1       :br39  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  1.7 (7955602821758320648)
+
+Splitting block:H1T2     :br28  : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts2       value=  4.5 (7955628485045649410)
+      t1 = ts3       value=  3.0 (7955617372652437507)
+      h2 = hm5       value=  8.9 (5595759629635158021)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+
+Made block:H1T2     :bs0   : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts2       value=  4.5 (7955628485045649410)
+      t1 = ts3       value=  3.0 (7955617372652437507)
+      h2 = hm5       value=  8.9 (5595759629635158021)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+
+Splitting block:H1T2     :br25  : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts7       value=  1.8 (7955605398482845703)
+      t1 = ts10      value=  1.2 (7955593841952686090)
+      h2 = hm0       value=  3.9 (5595738968023891968)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+
+Made block:H1T2     :bs1   : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts7       value=  1.8 (7955605398482845703)
+      t1 = ts10      value=  1.2 (7955593841952686090)
+      h2 = hm0       value=  3.9 (5595738968023891968)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+
+Splitting block:E1H1T1   :br10  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  2.5 (7955613032315355141)
+      h1 = hm1       value=  1.8 (5595719566406713345)
+      e2 = em10      value=  1.7 (3289873920831782922)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  2.5 (7955613032315355141)
+      h1 = hm1       value=  1.8 (5595719566406713345)
+      e2 = em10      value=  1.7 (3289873920831782922)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:H1T1     :br27  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts0       value= 11.2 (7955650964386480128)
+      h1 = hm11      value=  6.3 (5595750428632416267)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs3   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts0       value= 11.2 (7955650964386480128)
+      h1 = hm11      value=  6.3 (5595750428632416267)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br26  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts1       value=  4.5 (7955628514575646721)
+      h1 = hm10      value=  5.3 (5595745814476488714)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs4   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts1       value=  4.5 (7955628514575646721)
+      h1 = hm10      value=  5.3 (5595745814476488714)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br23  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  2.8 (7955615784703623172)
+      h1 = hm8       value=  3.3 (5595733864099086344)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs5   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  2.8 (7955615784703623172)
+      h1 = hm8       value=  3.3 (5595733864099086344)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br22  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts12      value=  1.5 (7955599100649406476)
+      h1 = hm7       value=  2.6 (5595727978674782215)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs6   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts12      value=  1.5 (7955599100649406476)
+      h1 = hm7       value=  2.6 (5595727978674782215)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br21  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  1.9 (7955606793617408006)
+      h1 = hm6       value=  2.6 (5595727490518614022)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs7   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  1.9 (7955606793617408006)
+      h1 = hm6       value=  2.6 (5595727490518614022)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br18  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts11      value=  1.1 (7955593577076097035)
+      h1 = hm2       value=  1.8 (5595719629468073986)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs8   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts11      value=  1.1 (7955593577076097035)
+      h1 = hm2       value=  1.8 (5595719629468073986)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:E1T1     :br7   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  1.2 (7955594459140325385)
+      e1 = em7       value=  1.4 (3289868581853986823)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs9   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  1.2 (7955594459140325385)
+      e1 = em7       value=  1.4 (3289868581853986823)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br4   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts20      value=  0.8 (7955584677706727444)
+      e1 = em4       value=  0.9 (3289859962292928516)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs10  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts20      value=  0.8 (7955584677706727444)
+      e1 = em4       value=  0.9 (3289859962292928516)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:T1       :br39  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  1.7 (7955602821758320648)
+
+Made block:T1       :bs11  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  1.7 (7955602821758320648)
+
+Splitting block:T1       :br38  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.2 (7955595509920432141)
+
+Made block:T1       :bs12  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.2 (7955595509920432141)
+
+Splitting block:T1       :br37  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.2 (7955594686819729422)
+
+Made block:T1       :bs13  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.2 (7955594686819729422)
+
+Splitting block:T1       :br36  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  1.1 (7955592830882152463)
+
+Made block:T1       :bs14  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  1.1 (7955592830882152463)
+
+Splitting block:T1       :br35  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  0.9 (7955587531131584528)
+
+Made block:T1       :bs15  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  0.9 (7955587531131584528)
+
+Splitting block:T1       :br34  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts18      value=  0.9 (7955586495612452882)
+
+Made block:T1       :bs16  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts18      value=  0.9 (7955586495612452882)
+
+Splitting block:T1       :br33  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts19      value=  0.8 (7955585794857500691)
+
+Made block:T1       :bs17  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts19      value=  0.8 (7955585794857500691)
+
+Splitting block:T1       :br32  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts21      value=  0.8 (7955584045990019093)
+
+Made block:T1       :bs18  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts21      value=  0.8 (7955584045990019093)
+
+Splitting block:T1       :br31  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts17      value=  0.7 (7955581813183741969)
+
+Made block:T1       :bs19  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts17      value=  0.7 (7955581813183741969)
+
+Splitting block:T1       :br30  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts22      value=  0.5 (7955572966517899286)
+
+Made block:T1       :bs20  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts22      value=  0.5 (7955572966517899286)
+
+Splitting block:T1       :br29  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts23      value=  0.5 (7955570910923063319)
+
+Made block:T1       :bs21  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts23      value=  0.5 (7955570910923063319)
+
+Splitting block:H1       :br24  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm9       value=  3.5 (5595736096509001737)
+
+Made block:H1       :bs22  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm9       value=  3.5 (5595736096509001737)
+
+Splitting block:H1       :br20  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm4       value=  2.0 (5595722441908289540)
+
+Made block:H1       :bs23  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm4       value=  2.0 (5595722441908289540)
+
+Splitting block:H1       :br19  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm3       value=  1.9 (5595720610918432771)
+
+Made block:H1       :bs24  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm3       value=  1.9 (5595720610918432771)
+
+Splitting block:E1       :br17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  7.4 (3289912219917090833)
+
+Made block:E1       :bs25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  7.4 (3289912219917090833)
+
+Splitting block:E1       :br16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  2.9 (3289887780418617360)
+
+Made block:E1       :bs26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  2.9 (3289887780418617360)
+
+Splitting block:E1       :br15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  2.6 (3289885113927598095)
+
+Made block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  2.6 (3289885113927598095)
+
+Splitting block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  2.3 (3289882249658368014)
+
+Made block:E1       :bs28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  2.3 (3289882249658368014)
+
+Splitting block:E1       :br13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  1.9 (3289877353584394253)
+
+Made block:E1       :bs29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  1.9 (3289877353584394253)
+
+Splitting block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  1.8 (3289876328016248844)
+
+Made block:E1       :bs30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  1.8 (3289876328016248844)
+
+Splitting block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.7 (3289874020731715595)
+
+Made block:E1       :bs31  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.7 (3289874020731715595)
+
+Splitting block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  1.7 (3289873687393599497)
+
+Made block:E1       :bs32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  1.7 (3289873687393599497)
+
+Splitting block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  1.5 (3289871554382397448)
+
+Made block:E1       :bs33  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  1.5 (3289871554382397448)
+
+Splitting block:E1       :br6   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  1.1 (3289864208769875974)
+
+Made block:E1       :bs34  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  1.1 (3289864208769875974)
+
+Splitting block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  1.0 (3289862176403095557)
+
+Made block:E1       :bs35  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  1.0 (3289862176403095557)
+
+Splitting block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.9 (3289858355020955651)
+
+Made block:E1       :bs36  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.9 (3289858355020955651)
+
+Splitting block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.8 (3289853440921960450)
+
+Made block:E1       :bs37  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.8 (3289853440921960450)
+
+Splitting block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.6 (3289848667189542913)
+
+Made block:E1       :bs38  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.6 (3289848667189542913)
+
+Splitting block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.6 (3289848000894992384)
+
+Made block:E1       :bs39  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.6 (3289848000894992384)
+
+Processing block:E1H1T1   :bs2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  2.5 (7955613032315355141)
+      h1 = hm1       value=  1.8 (5595719566406713345)
+      e2 = em10      value=  1.7 (3289873920831782922)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr0   :10252448876405456896: pdgid =  -211, status =   1, q = -1, e =   2.5, theta = -0.74, phi = -2.60, mass =  0.14 from SmearedTrack: ts5   :7955613032315355141:    2.49    1.84 -0.74 -2.60
+Finished block
+Processing block:H1T2     :bs1   : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts7       value=  1.8 (7955605398482845703)
+      t1 = ts10      value=  1.2 (7955593841952686090)
+      h2 = hm0       value=  3.9 (5595738968023891968)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+
+Made Particle :pr1   :10252441302201270273: pdgid =   211, status =   1, q =  1, e =   1.8, theta = -0.47, phi = -0.60, mass =  0.14 from SmearedTrack: ts7   :7955605398482845703:    1.81    1.61 -0.47 -0.60
+Made Particle :pr2   :10252429798773096450: pdgid =   211, status =   1, q =  1, e =   1.2, theta = -0.31, phi = -0.44, mass =  0.14 from SmearedTrack: ts10  :7955593841952686090:    1.15    1.10 -0.31 -0.44
+Finished block
+Processing block:H1T2     :bs0   : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts2       value=  4.5 (7955628485045649410)
+      t1 = ts3       value=  3.0 (7955617372652437507)
+      h2 = hm5       value=  8.9 (5595759629635158021)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+
+Made Particle :pr3   :10252464304466952195: pdgid =   211, status =   1, q =  1, e =   4.5, theta =  0.18, phi =  0.69, mass =  0.14 from SmearedTrack: ts2   :7955628485045649410:    4.49    4.42  0.18  0.69
+Made Particle :pr4   :10252453211099103236: pdgid =   211, status =   1, q =  1, e =   3.0, theta =  0.03, phi =  0.74, mass =  0.14 from SmearedTrack: ts3   :7955617372652437507:    2.98    2.98  0.03  0.74
+Finished block
+Processing block:E1T1     :bs10  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts20      value=  0.8 (7955584677706727444)
+      e1 = em4       value=  0.9 (3289859962292928516)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr5   :10252420901198888965: pdgid =   211, status =   1, q =  1, e =   0.8, theta =  0.18, phi =  0.63, mass =  0.14 from SmearedTrack: ts20  :7955584677706727444:    0.82    0.80  0.18  0.63
+Finished block
+Processing block:E1T1     :bs9   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  1.2 (7955594459140325385)
+      e1 = em7       value=  1.4 (3289868581853986823)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr6   :10252430411651088390: pdgid =   211, status =   1, q =  1, e =   1.2, theta = -0.51, phi = -0.87, mass =  0.14 from SmearedTrack: ts9   :7955594459140325385:    1.19    1.04 -0.51 -0.87
+Finished block
+Processing block:H1T1     :bs8   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts11      value=  1.1 (7955593577076097035)
+      h1 = hm2       value=  1.8 (5595719629468073986)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr7   :10252429535823790087: pdgid =  -211, status =   1, q = -1, e =   1.1, theta = -0.80, phi = -1.89, mass =  0.14 from SmearedTrack: ts11  :7955593577076097035:    1.14    0.79 -0.80 -1.89
+Finished block
+Processing block:H1T1     :bs7   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  1.9 (7955606793617408006)
+      h1 = hm6       value=  2.6 (5595727490518614022)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr8   :10252442693409964040: pdgid =  -211, status =   1, q = -1, e =   1.9, theta = -0.74, phi = -1.57, mass =  0.14 from SmearedTrack: ts6   :7955606793617408006:    1.89    1.39 -0.74 -1.57
+Finished block
+Processing block:H1T1     :bs6   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts12      value=  1.5 (7955599100649406476)
+      h1 = hm7       value=  2.6 (5595727978674782215)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr9   :10252435027388268553: pdgid =  -211, status =   1, q = -1, e =   1.5, theta =  0.10, phi =  0.77, mass =  0.14 from SmearedTrack: ts12  :7955599100649406476:    1.45    1.44  0.10  0.77
+Finished block
+Processing block:H1T1     :bs5   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  2.8 (7955615784703623172)
+      h1 = hm8       value=  3.3 (5595733864099086344)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr10  :10252451624983199754: pdgid =  -211, status =   1, q = -1, e =   2.8, theta =  0.41, phi =  0.11, mass =  0.14 from SmearedTrack: ts4   :7955615784703623172:    2.80    2.57  0.41  0.11
+Finished block
+Processing block:H1T1     :bs4   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts1       value=  4.5 (7955628514575646721)
+      h1 = hm10      value=  5.3 (5595745814476488714)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr11  :10252464333982269451: pdgid =  -211, status =   1, q = -1, e =   4.5, theta =  0.23, phi =  0.57, mass =  0.14 from SmearedTrack: ts1   :7955628514575646721:    4.50    4.38  0.23  0.57
+Finished block
+Processing block:H1T1     :bs3   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts0       value= 11.2 (7955650964386480128)
+      h1 = hm11      value=  6.3 (5595750428632416267)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr12  :10252486776243355660: pdgid =   211, status =   1, q =  1, e =  11.2, theta =  0.27, phi = -3.08, mass =  0.14 from SmearedTrack: ts0   :7955650964386480128:   11.20   10.79  0.27 -3.08
+Finished block
+Processing block:E1       :bs39  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.6 (3289848000894992384)
+
+Made Particle :pr13  :10252413024809779213: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.18, phi =  0.24, mass =  0.00 from MergedCluster: em0   :3289848000894992384:    0.60 -0.18  0.24 sub(es17, )
+Finished block
+Processing block:E1       :bs38  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.6 (3289848667189542913)
+
+Made Particle :pr14  :10252413691104329742: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.11, phi =  1.03, mass =  0.00 from MergedCluster: em1   :3289848667189542913:    0.62  0.11  1.03 sub(es16, )
+Finished block
+Processing block:E1       :bs37  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.8 (3289853440921960450)
+
+Made Particle :pr15  :10252418464836747279: pdgid =    22, status =   1, q =  0, e =   0.8, theta = -0.75, phi = -1.08, mass =  0.00 from MergedCluster: em2   :3289853440921960450:    0.76 -0.75 -1.08 sub(es10, )
+Finished block
+Processing block:E1       :bs36  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.9 (3289858355020955651)
+
+Made Particle :pr16  :10252423378935742480: pdgid =    22, status =   1, q =  0, e =   0.9, theta = -0.40, phi = -2.55, mass =  0.00 from MergedCluster: em3   :3289858355020955651:    0.90 -0.40 -2.55 sub(es5, )
+Finished block
+Processing block:E1       :bs35  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  1.0 (3289862176403095557)
+
+Made Particle :pr17  :10252427200317882385: pdgid =    22, status =   1, q =  0, e =   1.0, theta =  0.10, phi =  0.88, mass =  0.00 from MergedCluster: em5   :3289862176403095557:    1.01  0.10  0.88 sub(es14, )
+Finished block
+Processing block:E1       :bs34  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  1.1 (3289864208769875974)
+
+Made Particle :pr18  :10252429232684662802: pdgid =    22, status =   1, q =  0, e =   1.1, theta =  0.31, phi = -3.10, mass =  0.00 from MergedCluster: em6   :3289864208769875974:    1.13  0.31 -3.10 sub(es8, )
+Finished block
+Processing block:E1       :bs33  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  1.5 (3289871554382397448)
+
+Made Particle :pr19  :10252436578297184275: pdgid =    22, status =   1, q =  0, e =   1.5, theta = -0.33, phi = -2.58, mass =  0.00 from MergedCluster: em8   :3289871554382397448:    1.55 -0.33 -2.58 sub(es11, )
+Finished block
+Processing block:E1       :bs32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  1.7 (3289873687393599497)
+
+Made Particle :pr20  :10252438711308386324: pdgid =    22, status =   1, q =  0, e =   1.7, theta = -0.20, phi = -0.13, mass =  0.00 from MergedCluster: em9   :3289873687393599497:    1.67 -0.20 -0.13 sub(es7, )
+Finished block
+Processing block:E1       :bs31  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.7 (3289874020731715595)
+
+Made Particle :pr21  :10252439044646502421: pdgid =    22, status =   1, q =  0, e =   1.7, theta = -0.23, phi = -0.05, mass =  0.00 from MergedCluster: em11  :3289874020731715595:    1.69 -0.23 -0.05 sub(es12, )
+Finished block
+Processing block:E1       :bs30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  1.8 (3289876328016248844)
+
+Made Particle :pr22  :10252441351931035670: pdgid =    22, status =   1, q =  0, e =   1.8, theta = -0.12, phi = -2.99, mass =  0.00 from MergedCluster: em12  :3289876328016248844:    1.82 -0.12 -2.99 sub(es9, )
+Finished block
+Processing block:E1       :bs29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  1.9 (3289877353584394253)
+
+Made Particle :pr23  :10252442377499181079: pdgid =    22, status =   1, q =  0, e =   1.9, theta =  0.12, phi =  0.08, mass =  0.00 from MergedCluster: em13  :3289877353584394253:    1.88  0.12  0.08 sub(es6, )
+Finished block
+Processing block:E1       :bs28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  2.3 (3289882249658368014)
+
+Made Particle :pr24  :10252447273573154840: pdgid =    22, status =   1, q =  0, e =   2.3, theta =  0.22, phi =  0.75, mass =  0.00 from MergedCluster: em14  :3289882249658368014:    2.31  0.22  0.75 sub(es4, )
+Finished block
+Processing block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  2.6 (3289885113927598095)
+
+Made Particle :pr25  :10252450137842384921: pdgid =    22, status =   1, q =  0, e =   2.6, theta =  0.28, phi =  0.47, mass =  0.00 from MergedCluster: em15  :3289885113927598095:    2.64  0.28  0.47 sub(es2, )
+Finished block
+Processing block:E1       :bs26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  2.9 (3289887780418617360)
+
+Made Particle :pr26  :10252452804333404186: pdgid =    22, status =   1, q =  0, e =   2.9, theta =  0.24, phi =  0.50, mass =  0.00 from MergedCluster: em16  :3289887780418617360:    2.94  0.24  0.50 sub(es1, )
+Finished block
+Processing block:E1       :bs25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  7.4 (3289912219917090833)
+
+Made Particle :pr27  :10252477243831877659: pdgid =    22, status =   1, q =  0, e =   7.4, theta =  0.32, phi = -3.04, mass =  0.00 from MergedCluster: em17  :3289912219917090833:    7.43  0.32 -3.04 sub(es0, )
+Finished block
+Processing block:H1       :bs24  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm3       value=  1.9 (5595720610918432771)
+
+Made Particle :pr28  :10252442625619525660: pdgid =   130, status =   1, q =  0, e =   1.9, theta = -0.00, phi =  2.89, mass =  0.50 from MergedCluster: hm3   :5595720610918432771:    1.89 -0.00  2.89 sub(hs13, )
+Finished block
+Processing block:H1       :bs23  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm4       value=  2.0 (5595722441908289540)
+
+Made Particle :pr29  :10252444456609382429: pdgid =   130, status =   1, q =  0, e =   2.0, theta = -0.40, phi = -2.55, mass =  0.50 from MergedCluster: hm4   :5595722441908289540:    1.99 -0.40 -2.55 sub(hs7, )
+Finished block
+Processing block:H1       :bs22  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm9       value=  3.5 (5595736096509001737)
+
+Made Particle :pr30  :10252458111210094622: pdgid =   130, status =   1, q =  0, e =   3.5, theta = -0.41, phi = -2.34, mass =  0.50 from MergedCluster: hm9   :5595736096509001737:    3.54 -0.41 -2.34 sub(hs4, )
+Finished block
+Processing block:T1       :bs21  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts23      value=  0.5 (7955570910923063319)
+
+Made Particle :pr31  :10252408159264047135: pdgid =  -211, status =   1, q = -1, e =   0.5, theta =  0.05, phi =  0.59, mass =  0.14 from SmearedTrack: ts23  :7955570910923063319:    0.46    0.46  0.05  0.59
+Finished block
+Processing block:T1       :bs20  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts22      value=  0.5 (7955572966517899286)
+
+Made Particle :pr32  :10252409750023045152: pdgid =   211, status =   1, q =  1, e =   0.5, theta = -0.25, phi = -0.37, mass =  0.14 from SmearedTrack: ts22  :7955572966517899286:    0.49    0.48 -0.25 -0.37
+Finished block
+Processing block:T1       :bs19  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts17      value=  0.7 (7955581813183741969)
+
+Made Particle :pr33  :10252418081745797153: pdgid =  -211, status =   1, q = -1, e =   0.7, theta =  0.16, phi = -2.95, mass =  0.14 from SmearedTrack: ts17  :7955581813183741969:    0.73    0.73  0.16 -2.95
+Finished block
+Processing block:T1       :bs18  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts21      value=  0.8 (7955584045990019093)
+
+Made Particle :pr34  :10252420278648832034: pdgid =  -211, status =   1, q = -1, e =   0.8, theta =  0.58, phi = -0.98, mass =  0.14 from SmearedTrack: ts21  :7955584045990019093:    0.80    0.67  0.58 -0.98
+Finished block
+Processing block:T1       :bs17  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts19      value=  0.8 (7955585794857500691)
+
+Made Particle :pr35  :10252422003071909923: pdgid =  -211, status =   1, q = -1, e =   0.9, theta =  0.00, phi =  0.66, mass =  0.14 from SmearedTrack: ts19  :7955585794857500691:    0.85    0.85  0.00  0.66
+Finished block
+Processing block:T1       :bs16  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts18      value=  0.9 (7955586495612452882)
+
+Made Particle :pr36  :10252422694802817060: pdgid =   211, status =   1, q =  1, e =   0.9, theta = -0.55, phi = -1.77, mass =  0.14 from SmearedTrack: ts18  :7955586495612452882:    0.87    0.74 -0.55 -1.77
+Finished block
+Processing block:T1       :bs15  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  0.9 (7955587531131584528)
+
+Made Particle :pr37  :10252423717705482277: pdgid =  -211, status =   1, q = -1, e =   0.9, theta = -0.34, phi = -3.12, mass =  0.14 from SmearedTrack: ts16  :7955587531131584528:    0.90    0.85 -0.34 -3.12
+Finished block
+Processing block:T1       :bs14  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  1.1 (7955592830882152463)
+
+Made Particle :pr38  :10252428795344584742: pdgid =   211, status =   1, q =  1, e =   1.1, theta = -0.15, phi = -2.21, mass =  0.14 from SmearedTrack: ts15  :7955592830882152463:    1.10    1.08 -0.15 -2.21
+Finished block
+Processing block:T1       :bs13  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.2 (7955594686819729422)
+
+Made Particle :pr39  :10252430637805862951: pdgid =   211, status =   1, q =  1, e =   1.2, theta = -0.14, phi = -2.43, mass =  0.14 from SmearedTrack: ts14  :7955594686819729422:    1.20    1.19 -0.14 -2.43
+Finished block
+Processing block:T1       :bs12  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.2 (7955595509920432141)
+
+Made Particle :pr40  :10252431455653199912: pdgid =   211, status =   1, q =  1, e =   1.3, theta = -0.06, phi = -2.17, mass =  0.14 from SmearedTrack: ts13  :7955595509920432141:    1.25    1.25 -0.06 -2.17
+Finished block
+Processing block:T1       :bs11  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  1.7 (7955602821758320648)
+
+Made Particle :pr41  :10252438733705969705: pdgid =  -211, status =   1, q = -1, e =   1.7, theta = -0.20, phi =  0.41, mass =  0.14 from SmearedTrack: ts8   :7955602821758320648:    1.66    1.63 -0.20  0.41
+Finished block
+Finished reconstruction
+Event: 3
+Made Particle :ps0   :10261506297348227072: pdgid =  -211, status =   1, q = -1, e =  17.6, theta =  0.62, phi = -1.03, mass =  0.14
+Made Particle :ps1   :10261484442799308801: pdgid =   211, status =   1, q =  1, e =   7.4, theta = -0.32, phi =  2.17, mass =  0.14
+Made Particle :ps2   :10261477377852833794: pdgid =    22, status =   1, q =  0, e =   5.8, theta =  0.57, phi = -1.13, mass =  0.00
+Made Particle :ps3   :10261476719066087427: pdgid =   211, status =   1, q =  1, e =   5.7, theta =  0.63, phi = -0.88, mass =  0.14
+Made Particle :ps4   :10261476690102321156: pdgid =   211, status =   1, q =  1, e =   5.7, theta = -0.42, phi =  2.07, mass =  0.14
+Made Particle :ps5   :10261472708036395013: pdgid =  -211, status =   1, q = -1, e =   4.8, theta =  0.53, phi = -1.05, mass =  0.14
+Made Particle :ps6   :10261469609217490950: pdgid =  -211, status =   1, q = -1, e =   4.1, theta = -0.43, phi =  2.01, mass =  0.14
+Made Particle :ps7   :10261466156571295751: pdgid =   211, status =   1, q =  1, e =   3.6, theta = -1.08, phi = -2.62, mass =  0.14
+Made Particle :ps8   :10261464319413714952: pdgid =  -321, status =   1, q = -1, e =   3.4, theta = -0.32, phi =  2.05, mass =  0.49
+Made Particle :ps9   :10261462236184707081: pdgid =  -211, status =   1, q = -1, e =   3.2, theta = -0.33, phi =  2.09, mass =  0.14
+Made Particle :ps10  :10261459936980500490: pdgid =   211, status =   1, q =  1, e =   2.9, theta = -0.30, phi =  2.03, mass =  0.14
+Made Particle :ps11  :10261459779387916299: pdgid = -2212, status =   1, q = -1, e =   2.9, theta = -0.39, phi =  1.92, mass =  0.94
+Made Particle :ps12  :10261459417312526348: pdgid =   211, status =   1, q =  1, e =   2.9, theta = -0.42, phi =  2.06, mass =  0.14
+Made Particle :ps13  :10261454690866692109: pdgid =   130, status =   1, q =  0, e =   2.3, theta = -0.87, phi = -2.56, mass =  0.50
+Made Particle :ps14  :10261454427084816398: pdgid =   130, status =   1, q =  0, e =   2.3, theta = -1.05, phi =  1.36, mass =  0.50
+Made Particle :ps15  :10261453338128154639: pdgid =  -211, status =   1, q = -1, e =   2.2, theta =  0.73, phi = -0.68, mass =  0.14
+Made Particle :ps16  :10261452721448026128: pdgid =    22, status =   1, q =  0, e =   2.1, theta =  0.61, phi = -1.12, mass =  0.00
+Made Particle :ps17  :10261451433196912657: pdgid =  2112, status =   1, q =  0, e =   2.0, theta = -1.11, phi =  1.52, mass =  0.94
+Made Particle :ps18  :10261444499926417426: pdgid =  -211, status =   1, q = -1, e =   1.6, theta = -0.23, phi =  2.21, mass =  0.14
+Made Particle :ps19  :10261441973479014419: pdgid =    22, status =   1, q =  0, e =   1.4, theta = -0.48, phi = -1.77, mass =  0.00
+Made Particle :ps20  :10261434845653630996: pdgid =   211, status =   1, q =  1, e =   1.0, theta =  0.84, phi = -0.62, mass =  0.14
+Made Particle :ps21  :10261424200765931541: pdgid =   211, status =   1, q =  1, e =   0.7, theta = -0.49, phi =  2.04, mass =  0.14
+Made Particle :ps22  :10261423878697910294: pdgid =  -211, status =   1, q = -1, e =   0.7, theta = -1.27, phi = -1.47, mass =  0.14
+Made Particle :ps23  :10261423725006028823: pdgid =   211, status =   1, q =  1, e =   0.7, theta = -1.21, phi = -0.93, mass =  0.14
+Made Particle :ps24  :10261422464487653400: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.57, phi = -1.04, mass =  0.00
+Made Particle :ps25  :10261420488915943449: pdgid =  -211, status =   1, q = -1, e =   0.6, theta = -1.02, phi =  2.61, mass =  0.14
+Made Particle :ps26  :10261417976905334810: pdgid =   211, status =   1, q =  1, e =   0.5, theta =  1.36, phi =  0.80, mass =  0.14
+Made Particle :ps27  :10261409781537308699: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.43, phi =  0.46, mass =  0.00
+Made Particle :ps28  :10261408553063415836: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.18, phi = -0.22, mass =  0.00
+Made Particle :ps29  :10261405007412723741: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.79, phi =  1.32, mass =  0.00
+Made Particle :ps30  :10261391829012316190: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -1.19, phi =  2.00, mass =  0.00
+Made Particle :ps31  :10261388575679447071: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  1.29, phi =  0.20, mass =  0.00
+Made Particle :ps32  :10261387232864632864: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.46, phi =  0.26, mass =  0.00
+Made Particle :ps33  :10261385650827690017: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.35, phi = -2.05, mass =  0.00
+Made Particle :ps34  :10261373446233522210: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.73, phi = -0.31, mass =  0.00
+Made Particle :ps35  :10261372625525669923: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.68, phi = -0.38, mass =  0.00
+Made Particle :ps36  :10261351346902925348: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.51, phi =  0.89, mass =  0.00
+Simulating Particle :ps0   :10261506297348227072: pdgid =  -211, status =   1, q = -1, e =  17.6, theta =  0.62, phi = -1.03, mass =  0.14
+Simulating Hadron
+Made Track: tt0   :7964670486781100032:   17.61   14.28  0.62 -1.03
+Made SmearedTrack: ts0   :7955662951937998848:   17.30   14.03  0.62 -1.03
+Made Cluster: ht0   :5658827478175580160:   17.61  0.63 -0.98 sub(ht0, )
+Made SmearedCluster: hs0   :5649823584386809856:   20.62  0.63 -0.98 sub(hs0, )
+Simulating Particle :ps1   :10261484442799308801: pdgid =   211, status =   1, q =  1, e =   7.4, theta = -0.32, phi =  2.17, mass =  0.14
+Simulating Hadron
+Made Track: tt1   :7964648627077382145:    7.43    7.06 -0.32  2.17
+Made SmearedTrack: ts1   :7955641451161845761:    7.44    7.07 -0.32  2.17
+Made Cluster: ht1   :5658805623626661889:    7.43 -0.32  2.06 sub(ht1, )
+Made SmearedCluster: hs1   :5649791076307828737:    5.76 -0.32  2.06 sub(hs1, )
+Simulating Particle :ps2   :10261477377852833794: pdgid =    22, status =   1, q =  0, e =   5.8, theta =  0.57, phi = -1.13, mass =  0.00
+Simulating Photon
+Made Cluster: et0   :3352955549466492928:    5.83  0.57 -1.13 sub(et0, )
+Made SmearedCluster: es0   :3343950602137763840:    6.34  0.57 -1.13 sub(es0, )
+Simulating Particle :ps3   :10261476719066087427: pdgid =   211, status =   1, q =  1, e =   5.7, theta =  0.63, phi = -0.88, mass =  0.14
+Simulating Hadron
+Made Track: tt2   :7964640901559484418:    5.68    4.58  0.63 -0.88
+Made SmearedTrack: ts2   :7955634128857071618:    5.77    4.65  0.63 -0.88
+Made Cluster: et1   :3352942884513906689:    3.47  0.63 -1.02 sub(et1, )
+Made SmearedCluster: es1   :3343942563429089281:    4.51  0.63 -1.02 sub(es1, )
+Made Cluster: ht2   :5658774721685094402:    2.20  0.64 -1.04 sub(ht2, )
+Made SmearedCluster: hs2   :5649685411027484674:    0.09  0.64 -1.04 sub(hs2, )
+Rejected SmearedCluster: hs2   :5649685411027484674:    0.09  0.64 -1.04 sub(hs2, )
+Simulating Particle :ps4   :10261476690102321156: pdgid =   211, status =   1, q =  1, e =   5.7, theta = -0.42, phi =  2.07, mass =  0.14
+Simulating Hadron
+Made Track: tt3   :7964640872587329539:    5.67    5.17 -0.42  2.07
+Made SmearedTrack: ts3   :7955633667588489219:    5.67    5.17 -0.42  2.07
+Made Cluster: et2   :3352887426656763906:    0.40 -0.42  1.96 sub(et2, )
+Made SmearedCluster: es2   :3343893097445588994:    0.66 -0.42  1.96 sub(es2, )
+Made Cluster: ht3   :5658796128877936643:    5.27 -0.42  1.94 sub(ht3, )
+Made SmearedCluster: hs2   :5649785575369080834:    4.51 -0.42  1.94 sub(hs2, )
+Simulating Particle :ps5   :10261472708036395013: pdgid =  -211, status =   1, q = -1, e =   4.8, theta =  0.53, phi = -1.05, mass =  0.14
+Simulating Hadron
+Made Track: tt4   :7964636889084854276:    4.76    4.10  0.53 -1.05
+Made SmearedTrack: ts4   :7955629592228659204:    4.74    4.08  0.53 -1.05
+Made Cluster: et3   :3352904418702917635:    0.78  0.54 -0.89 sub(et3, )
+Made SmearedCluster: es3   :3343909819542142979:    1.27  0.54 -0.89 sub(es3, )
+Made Cluster: ht4   :5658790435577921540:    3.99  0.54 -0.87 sub(ht4, )
+Made SmearedCluster: hs3   :5649791111659520003:    5.77  0.54 -0.87 sub(hs3, )
+Simulating Particle :ps6   :10261469609217490950: pdgid =  -211, status =   1, q = -1, e =   4.1, theta = -0.43, phi =  2.01, mass =  0.14
+Simulating Hadron
+Made Track: tt5   :7964633788705669125:    4.06    3.69 -0.43  2.01
+Made SmearedTrack: ts5   :7955626731935629317:    4.09    3.72 -0.43  2.01
+Made Cluster: ht5   :5658790790044844037:    4.06 -0.43  2.21 sub(ht5, )
+Made SmearedCluster: hs4   :5649773268735885316:    2.86 -0.43  2.21 sub(hs4, )
+Simulating Particle :ps7   :10261466156571295751: pdgid =   211, status =   1, q =  1, e =   3.6, theta = -1.08, phi = -2.62, mass =  0.14
+Simulating Hadron
+Made Track: tt6   :7964630323052937222:    3.64    1.72 -1.08 -2.62
+Made SmearedTrack: ts6   :7955622849431994374:    3.60    1.70 -1.08 -2.62
+Made Cluster: ht6   :5658787337398648838:    3.64 -1.08 -2.88 sub(ht6, )
+Made SmearedCluster: hs5   :5649784452897832965:    4.26 -1.08 -2.88 sub(hs5, )
+Simulating Particle :ps8   :10261464319413714952: pdgid =  -321, status =   1, q = -1, e =   3.4, theta = -0.32, phi =  2.05, mass =  0.49
+Simulating Hadron
+Made Track: tt7   :7964628195209117703:    3.39    3.22 -0.32  2.05
+Made SmearedTrack: ts7   :7955621015338352647:    3.40    3.22 -0.32  2.05
+Made Cluster: ht7   :5658785500241068039:    3.43 -0.32  2.28 sub(ht7, )
+Made SmearedCluster: hs6   :5649775468092588038:    3.11 -0.32  2.28 sub(hs6, )
+Simulating Particle :ps9   :10261462236184707081: pdgid =  -211, status =   1, q = -1, e =   3.2, theta = -0.33, phi =  2.09, mass =  0.14
+Simulating Hadron
+Made Track: tt8   :7964626399373819912:    3.19    3.02 -0.33  2.09
+Made SmearedTrack: ts8   :7955619187487932424:    3.19    3.01 -0.33  2.09
+Made Cluster: et4   :3352863427455352836:    0.15 -0.34  2.28 sub(et4, )
+Made SmearedCluster: es4   :3343877029146656772:    0.35 -0.34  2.28 sub(es4, )
+Rejected SmearedCluster: es4   :3343877029146656772:    0.35 -0.34  2.28 sub(es4, )
+Made Cluster: ht8   :5658782075398914056:    3.04 -0.34  2.31 sub(ht8, )
+Made SmearedCluster: hs7   :5649786301845602311:    4.68 -0.34  2.31 sub(hs7, )
+Simulating Particle :ps10  :10261459936980500490: pdgid =   211, status =   1, q =  1, e =   2.9, theta = -0.30, phi =  2.03, mass =  0.14
+Simulating Hadron
+Made Track: tt9   :7964624097772568585:    2.93    2.80 -0.30  2.03
+Made SmearedTrack: ts9   :7955616836284841993:    2.92    2.79 -0.30  2.03
+Made Cluster: et5   :3352860418677669893:    0.13 -0.30  1.86 sub(et5, )
+Made SmearedCluster: es4   :3343849648063250436:    0.12 -0.30  1.86 sub(es4, )
+Rejected SmearedCluster: es4   :3343849648063250436:    0.12 -0.30  1.86 sub(es4, )
+Made Cluster: ht9   :5658779964244230153:    2.80 -0.30  1.84 sub(ht9, )
+Made SmearedCluster: hs8   :5649775109611716616:    3.07 -0.30  1.84 sub(hs8, )
+Simulating Particle :ps11  :10261459779387916299: pdgid = -2212, status =   1, q = -1, e =   2.9, theta = -0.39, phi =  1.92, mass =  0.94
+Simulating Hadron
+Made Track: tt10  :7964622603753095178:    2.76    2.55 -0.39  1.92
+Made SmearedTrack: ts10  :7955615324059992074:    2.75    2.55 -0.39  1.92
+Made Cluster: ht10  :5658780960215269386:    2.91 -0.39  2.20 sub(ht10, )
+Made SmearedCluster: hs9   :5649780212993359881:    3.65 -0.39  2.20 sub(hs9, )
+Simulating Particle :ps12  :10261459417312526348: pdgid =   211, status =   1, q =  1, e =   2.9, theta = -0.42, phi =  2.06, mass =  0.14
+Simulating Hadron
+Made Track: tt11  :7964623577500614667:    2.87    2.61 -0.42  2.06
+Made SmearedTrack: ts11  :7955616467450331147:    2.88    2.62 -0.42  2.06
+Made Cluster: et6   :3352904100533501958:    0.77 -0.43  1.81 sub(et6, )
+Made SmearedCluster: es4   :3341670923508908036:   -0.25 -0.43  1.81 sub(es4, )
+Rejected SmearedCluster: es4   :3341670923508908036:   -0.25 -0.43  1.81 sub(es4, )
+Made Cluster: ht11  :5658773859510255627:    2.11 -0.43  1.78 sub(ht11, )
+Made SmearedCluster: hs10  :5649757488449323018:    1.53 -0.43  1.78 sub(hs10, )
+Simulating Particle :ps13  :10261454690866692109: pdgid =   130, status =   1, q =  0, e =   2.3, theta = -0.87, phi = -2.56, mass =  0.50
+Simulating Hadron
+Made Cluster: et7   :3352902560485736455:    0.72 -0.87 -2.56 sub(et7, )
+Made SmearedCluster: es4   :3343907864052760580:    1.16 -0.87 -2.56 sub(es4, )
+Made Cluster: ht12  :5658766104361697292:    1.61 -0.87 -2.56 sub(ht12, )
+Made SmearedCluster: hs11  :5649763133193977867:    1.85 -0.87 -2.56 sub(hs11, )
+Simulating Particle :ps14  :10261454427084816398: pdgid =   130, status =   1, q =  0, e =   2.3, theta = -1.05, phi =  1.36, mass =  0.50
+Simulating Hadron
+Made Cluster: et8   :3352892283784527880:    0.47 -1.05  1.36 sub(et8, )
+Made SmearedCluster: es5   :3343782015003525125:    0.01 -1.05  1.36 sub(es5, )
+Rejected SmearedCluster: es5   :3343782015003525125:    0.01 -1.05  1.36 sub(es5, )
+Made Cluster: ht13  :5658770101543895053:    1.84 -1.05  1.36 sub(ht13, )
+Made SmearedCluster: hs12  :5649762503259848716:    1.82 -1.05  1.36 sub(hs12, )
+Simulating Particle :ps15  :10261453338128154639: pdgid =  -211, status =   1, q = -1, e =   2.2, theta =  0.73, phi = -0.68, mass =  0.14
+Simulating Hadron
+Made Track: tt12  :7964617488837115916:    2.18    1.62  0.73 -0.68
+Made SmearedTrack: ts12  :7955610301383049228:    2.18    1.62  0.73 -0.68
+Made Cluster: et9   :3352915938063155209:    1.21  0.74 -0.27 sub(et9, )
+Made SmearedCluster: es5   :3343889919108972549:    0.57  0.74 -0.27 sub(es5, )
+Made Cluster: ht14  :5658754472917073934:    0.98  0.75 -0.22 sub(ht14, )
+Made SmearedCluster: hs13  :5649768770747498509:    2.35  0.75 -0.22 sub(hs13, )
+Simulating Particle :ps16  :10261452721448026128: pdgid =    22, status =   1, q =  0, e =   2.1, theta =  0.61, phi = -1.12, mass =  0.00
+Simulating Photon
+Made Cluster: et10  :3352930893061685258:    2.11  0.61 -1.12 sub(et10, )
+Made SmearedCluster: es6   :3343923797769060358:    2.12  0.61 -1.12 sub(es6, )
+Simulating Particle :ps17  :10261451433196912657: pdgid =  2112, status =   1, q =  0, e =   2.0, theta = -1.11, phi =  1.52, mass =  0.94
+Simulating Hadron
+Made Cluster: ht15  :5658772614024265743:    1.98 -1.11  1.52 sub(ht15, )
+Made SmearedCluster: hs14  :5649768076428705806:    2.27 -1.11  1.52 sub(hs14, )
+Simulating Particle :ps18  :10261444499926417426: pdgid =  -211, status =   1, q = -1, e =   1.6, theta = -0.23, phi =  2.21, mass =  0.14
+Simulating Hadron
+Made Track: tt13  :7964608581846695949:    1.58    1.54 -0.23  2.21
+Made SmearedTrack: ts13  :7955601404368781325:    1.58    1.54 -0.23  2.21
+Made Cluster: et11  :3352869701540642827:    0.20 -0.25  2.52 sub(et11, )
+Made SmearedCluster: es7   :3341670923508908039:   -0.36 -0.25  2.52 sub(es7, )
+Rejected SmearedCluster: es7   :3341670923508908039:   -0.36 -0.25  2.52 sub(es7, )
+Made Cluster: ht16  :5658762213268127760:    1.39 -0.25  2.58 sub(ht16, )
+Made SmearedCluster: hs15  :5649746366272897039:    0.95 -0.25  2.58 sub(hs15, )
+Rejected SmearedCluster: hs15  :5649746366272897039:    0.95 -0.25  2.58 sub(hs15, )
+Simulating Particle :ps19  :10261441973479014419: pdgid =    22, status =   1, q =  0, e =   1.4, theta = -0.48, phi = -1.77, mass =  0.00
+Simulating Photon
+Made Cluster: et12  :3352920145092673548:    1.44 -0.48 -1.77 sub(et12, )
+Made SmearedCluster: es7   :3343914361830768647:    1.52 -0.48 -1.77 sub(es7, )
+Simulating Particle :ps20  :10261434845653630996: pdgid =   211, status =   1, q =  1, e =   1.0, theta =  0.84, phi = -0.62, mass =  0.14
+Simulating Hadron
+Made Track: tt14  :7964598870038544398:    1.03    0.69  0.84 -0.62
+Made SmearedTrack: ts14  :7955591592258043918:    1.03    0.68  0.84 -0.62
+Made Cluster: et13  :3352875083780587533:    0.24  0.93 -1.64 sub(et13, )
+Made SmearedCluster: es8   :3343871809098350600:    0.28  0.93 -1.64 sub(es8, )
+Rejected SmearedCluster: es8   :3343871809098350600:    0.28  0.93 -1.64 sub(es8, )
+Made Cluster: ht17  :5658748432825712657:    0.80  0.95 -1.73 sub(ht17, )
+Made SmearedCluster: hs15  :5649752163428073487:    1.23  0.95 -1.73 sub(hs15, )
+Simulating Particle :ps21  :10261424200765931541: pdgid =   211, status =   1, q =  1, e =   0.7, theta = -0.49, phi =  2.04, mass =  0.14
+Simulating Hadron
+Made Track: tt15  :7964587908222943247:    0.70    0.62 -0.49  2.04
+Made SmearedTrack: ts15  :7955580743363592207:    0.70    0.62 -0.49  2.04
+Made Cluster: et14  :3352887890163007502:    0.40 -1.05 -0.28 sub(et14, )
+Made SmearedCluster: es8   :3343888135254704136:    0.52 -1.05 -0.28 sub(es8, )
+Made Cluster: ht18  :5658724679437778962:    0.31 -1.19 -0.51 sub(ht18, )
+Made SmearedCluster: hs16  :5649666771850887184:    0.04 -1.19 -0.51 sub(hs16, )
+Rejected SmearedCluster: hs16  :5649666771850887184:    0.04 -1.19 -0.51 sub(hs16, )
+Simulating Particle :ps22  :10261423878697910294: pdgid =  -211, status =   1, q = -1, e =   0.7, theta = -1.27, phi = -1.47, mass =  0.14
+Simulating Hadron
+Made Track: tt16  :7964587579787968528:    0.69    0.21 -1.27 -1.47
+Made SmearedTrack: ts16  :7955580726940794896:    0.70    0.21 -1.27 -1.47
+Rejected SmearedTrack: ts16  :7955580726940794896:    0.70    0.21 -1.27 -1.47
+Made Cluster: ht19  :5658745059525263379:    0.71 -1.34 -0.18 sub(ht19, )
+Made SmearedCluster: hs16  :5649741612287262736:    0.81 -1.34 -0.18 sub(hs16, )
+Rejected SmearedCluster: hs16  :5649741612287262736:    0.81 -1.34 -0.18 sub(hs16, )
+Simulating Particle :ps23  :10261423725006028823: pdgid =   211, status =   1, q =  1, e =   0.7, theta = -1.21, phi = -0.93, mass =  0.14
+Simulating Hadron
+Made Track: tt17  :7964587423000690705:    0.69    0.24 -1.21 -0.93
+Made SmearedTrack: ts16  :7955580067260661776:    0.69    0.24 -1.21 -0.93
+Rejected SmearedTrack: ts16  :7955580067260661776:    0.69    0.24 -1.21 -0.93
+Made Cluster: ht20  :5658744905833381908:    0.70 -1.30 -2.26 sub(ht20, )
+Made SmearedCluster: hs16  :5649704456732803088:    0.19 -1.30 -2.26 sub(hs16, )
+Rejected SmearedCluster: hs16  :5649704456732803088:    0.19 -1.30 -2.26 sub(hs16, )
+Simulating Particle :ps24  :10261422464487653400: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.57, phi = -1.04, mass =  0.00
+Simulating Photon
+Made Cluster: et15  :3352900636101312527:    0.67  0.57 -1.04 sub(et15, )
+Made SmearedCluster: es9   :3343893997759234057:    0.68  0.57 -1.04 sub(es9, )
+Simulating Particle :ps25  :10261420488915943449: pdgid =  -211, status =   1, q = -1, e =   0.6, theta = -1.02, phi =  2.61, mass =  0.14
+Simulating Hadron
+Made Track: tt18  :7964584111031451666:    0.60    0.31 -1.02  2.61
+Made SmearedTrack: ts16  :7955576893424533520:    0.59    0.31 -1.02  2.61
+Rejected SmearedTrack: ts16  :7955576893424533520:    0.59    0.31 -1.02  2.61
+Made Cluster: ht21  :5658741669743296533:    0.61 -1.22 -1.98 sub(ht21, )
+Made SmearedCluster: hs16  :5649720723783024656:    0.36 -1.22 -1.98 sub(hs16, )
+Rejected SmearedCluster: hs16  :5649720723783024656:    0.36 -1.22 -1.98 sub(hs16, )
+Simulating Particle :ps27  :10261409781537308699: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.43, phi =  0.46, mass =  0.00
+Simulating Photon
+Made Cluster: et16  :3352887953150967824:    0.40 -0.43  0.46 sub(et16, )
+Made SmearedCluster: es10  :3343889532784214026:    0.56 -0.43  0.46 sub(es10, )
+Simulating Particle :ps28  :10261408553063415836: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.18, phi = -0.22, mass =  0.00
+Simulating Photon
+Made Cluster: et17  :3352886724677074961:    0.39  0.18 -0.22 sub(et17, )
+Made SmearedCluster: es11  :3343881319282114571:    0.41  0.18 -0.22 sub(es11, )
+Rejected SmearedCluster: es11  :3343881319282114571:    0.41  0.18 -0.22 sub(es11, )
+Simulating Particle :ps29  :10261405007412723741: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.79, phi =  1.32, mass =  0.00
+Simulating Photon
+Made Cluster: et18  :3352883179026382866:    0.34 -0.79  1.32 sub(et18, )
+Made SmearedCluster: es11  :3343871566506098699:    0.27 -0.79  1.32 sub(es11, )
+Rejected SmearedCluster: es11  :3343871566506098699:    0.27 -0.79  1.32 sub(es11, )
+Simulating Particle :ps30  :10261391829012316190: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -1.19, phi =  2.00, mass =  0.00
+Simulating Photon
+Made Cluster: et19  :3352870000625975315:    0.20 -1.19  2.00 sub(et19, )
+Made SmearedCluster: es11  :3343869299035996171:    0.25 -1.19  2.00 sub(es11, )
+Rejected SmearedCluster: es11  :3343869299035996171:    0.25 -1.19  2.00 sub(es11, )
+Simulating Particle :ps31  :10261388575679447071: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  1.29, phi =  0.20, mass =  0.00
+Simulating Photon
+Made Cluster: et20  :3352866747293106196:    0.18  1.29  0.20 sub(et20, )
+Made SmearedCluster: es11  :3343870061654835211:    0.25  1.29  0.20 sub(es11, )
+Rejected SmearedCluster: es11  :3343870061654835211:    0.25  1.29  0.20 sub(es11, )
+Simulating Particle :ps32  :10261387232864632864: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.46, phi =  0.26, mass =  0.00
+Simulating Photon
+Made Cluster: et21  :3352865404478291989:    0.17  0.46  0.26 sub(et21, )
+Made SmearedCluster: es11  :3343858248647180299:    0.17  0.46  0.26 sub(es11, )
+Rejected SmearedCluster: es11  :3343858248647180299:    0.17  0.46  0.26 sub(es11, )
+Simulating Particle :ps33  :10261385650827690017: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.35, phi = -2.05, mass =  0.00
+Simulating Photon
+Made Cluster: et22  :3352863822441349142:    0.16 -0.35 -2.05 sub(et22, )
+Made SmearedCluster: es11  :3343859038854053899:    0.17 -0.35 -2.05 sub(es11, )
+Rejected SmearedCluster: es11  :3343859038854053899:    0.17 -0.35 -2.05 sub(es11, )
+Simulating Particle :ps34  :10261373446233522210: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.73, phi = -0.31, mass =  0.00
+Simulating Photon
+Made Cluster: et23  :3352851617847181335:    0.10 -0.73 -0.31 sub(et23, )
+Made SmearedCluster: es11  :3343835766259187723:    0.07 -0.73 -0.31 sub(es11, )
+Rejected SmearedCluster: es11  :3343835766259187723:    0.07 -0.73 -0.31 sub(es11, )
+Simulating Particle :ps35  :10261372625525669923: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.68, phi = -0.38, mass =  0.00
+Simulating Photon
+Made Cluster: et24  :3352850797139329048:    0.09  0.68 -0.38 sub(et24, )
+Made SmearedCluster: es11  :3343846894215364619:    0.11  0.68 -0.38 sub(es11, )
+Rejected SmearedCluster: es11  :3343846894215364619:    0.11  0.68 -0.38 sub(es11, )
+Simulating Particle :ps36  :10261351346902925348: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.51, phi =  0.89, mass =  0.00
+Simulating Photon
+Made Cluster: et25  :3352829518516584473:    0.04 -0.51  0.89 sub(et25, )
+Made SmearedCluster: es11  :3343811328862060555:    0.03 -0.51  0.89 sub(es11, )
+Rejected SmearedCluster: es11  :3343811328862060555:    0.03 -0.51  0.89 sub(es11, )
+Made MergedCluster: em0   :3289844939726258176:    0.52 -1.05 -0.28 sub(es8, )
+Made MergedCluster: em1   :3289846337255768065:    0.56 -0.43  0.46 sub(es10, )
+Made MergedCluster: em2   :3289846723580526594:    0.57  0.74 -0.27 sub(es5, )
+Made MergedCluster: em3   :3289849901917143043:    0.66 -0.42  1.96 sub(es2, )
+Made MergedCluster: em4   :3289850802230788100:    0.68  0.57 -1.04 sub(es9, )
+Made MergedCluster: em5   :3289864668524314629:    1.16 -0.87 -2.56 sub(es4, )
+Made MergedCluster: em6   :3289866624013697030:    1.27  0.54 -0.89 sub(es3, )
+Made MergedCluster: em7   :3289871166302322695:    1.52 -0.48 -1.77 sub(es7, )
+Made MergedCluster: em8   :3289880602240614408:    2.12  0.61 -1.12 sub(es6, )
+Made MergedCluster: em9   :3289899367900643337:    4.51  0.63 -1.02 sub(es1, )
+Made MergedCluster: em10  :3289907406609317898:    6.34  0.57 -1.13 sub(es0, )
+Made MergedCluster: hm0   :5595708967899627520:    1.23  0.95 -1.73 sub(hs15, )
+Made MergedCluster: hm1   :5595789781379317761:   29.16 -0.37  2.10 sub(hs1, hs7, hs2, hs9, hs6, hs8, hs4, hs10, )
+Made MergedCluster: hm2   :5595719307731402754:    1.82 -1.05  1.36 sub(hs12, )
+Made MergedCluster: hm3   :5595719937665531907:    1.85 -0.87 -2.56 sub(hs11, )
+Made MergedCluster: hm4   :5595724880900259844:    2.27 -1.11  1.52 sub(hs14, )
+Made MergedCluster: hm5   :5595725575219052549:    2.35  0.75 -0.22 sub(hs13, )
+Made MergedCluster: hm6   :5595741257369387014:    4.26 -1.08 -2.88 sub(hs5, )
+Made MergedCluster: hm7   :5595786733638647815:   26.39  0.61 -0.96 sub(hs0, hs3, )
+Made block:E1T1     :br0   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  0.7 (7955580743363592207)
+      e1 = em0       value=  0.5 (3289844939726258176)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.6 (3289846337255768065)
+
+Made block:E1H1T1   :br2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts12      value=  2.2 (7955610301383049228)
+      h1 = hm5       value=  2.3 (5595725575219052549)
+      e2 = em2       value=  0.6 (3289846723580526594)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T8   :br3   : ecals = 1 hcals = 1 tracks = 8
+    elements:
+      t0 = ts1       value=  7.4 (7955641451161845761)
+      t1 = ts3       value=  5.7 (7955633667588489219)
+      t2 = ts5       value=  4.1 (7955626731935629317)
+      t3 = ts7       value=  3.4 (7955621015338352647)
+      t4 = ts8       value=  3.2 (7955619187487932424)
+      t5 = ts9       value=  2.9 (7955616836284841993)
+      t6 = ts11      value=  2.9 (7955616467450331147)
+      t7 = ts10      value=  2.7 (7955615324059992074)
+      h8 = hm1       value= 29.2 (5595789781379317761)
+      e9 = em3       value=  0.7 (3289849901917143043)
+    distances:
+              t0      t1      t2      t3      t4      t5      t6      t7      h8      e9
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      t3     ---     ---     ---       .
+      t4     ---     ---     ---     ---       .
+      t5     ---     ---     ---     ---     ---       .
+      t6     ---     ---     ---     ---     ---     ---       .
+      t7     ---     ---     ---     ---     ---     ---     ---       .
+      h8  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000       .
+      e9     ---  0.0000     ---     ---     ---     ---     ---     ---     ---       .
+
+Made block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.7 (3289850802230788100)
+
+Made block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  1.2 (3289864668524314629)
+
+Made block:E2H1T3   :br6   : ecals = 2 hcals = 1 tracks = 3
+    elements:
+      t0 = ts0       value= 17.3 (7955662951937998848)
+      t1 = ts2       value=  5.8 (7955634128857071618)
+      t2 = ts4       value=  4.7 (7955629592228659204)
+      h3 = hm7       value= 26.4 (5595786733638647815)
+      e4 = em9       value=  4.5 (3289899367900643337)
+      e5 = em6       value=  1.3 (3289866624013697030)
+    distances:
+              t0      t1      t2      h3      e4      e5
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      h3  0.0000  0.1353  0.0000       .
+      e4     ---  0.0000     ---     ---       .
+      e5     ---     ---  0.0000     ---     ---       .
+
+Made block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  1.5 (3289871166302322695)
+
+Made block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  2.1 (3289880602240614408)
+
+Made block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  6.3 (3289907406609317898)
+
+Made block:H1T1     :br10  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts14      value=  1.0 (7955591592258043918)
+      h1 = hm0       value=  1.2 (5595708967899627520)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1       :br11  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm2       value=  1.8 (5595719307731402754)
+
+Made block:H1       :br12  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm3       value=  1.9 (5595719937665531907)
+
+Made block:H1       :br13  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm4       value=  2.3 (5595724880900259844)
+
+Made block:H1T1     :br14  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  3.6 (7955622849431994374)
+      h1 = hm6       value=  4.3 (5595741257369387014)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:T1       :br15  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.6 (7955601404368781325)
+
+Splitting block:E1H1T8   :br3   : ecals = 1 hcals = 1 tracks = 8
+    elements:
+      t0 = ts1       value=  7.4 (7955641451161845761)
+      t1 = ts3       value=  5.7 (7955633667588489219)
+      t2 = ts5       value=  4.1 (7955626731935629317)
+      t3 = ts7       value=  3.4 (7955621015338352647)
+      t4 = ts8       value=  3.2 (7955619187487932424)
+      t5 = ts9       value=  2.9 (7955616836284841993)
+      t6 = ts11      value=  2.9 (7955616467450331147)
+      t7 = ts10      value=  2.7 (7955615324059992074)
+      h8 = hm1       value= 29.2 (5595789781379317761)
+      e9 = em3       value=  0.7 (3289849901917143043)
+    distances:
+              t0      t1      t2      t3      t4      t5      t6      t7      h8      e9
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      t3     ---     ---     ---       .
+      t4     ---     ---     ---     ---       .
+      t5     ---     ---     ---     ---     ---       .
+      t6     ---     ---     ---     ---     ---     ---       .
+      t7     ---     ---     ---     ---     ---     ---     ---       .
+      h8  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000       .
+      e9     ---  0.0000     ---     ---     ---     ---     ---     ---     ---       .
+
+Made block:E1H1T8   :bs0   : ecals = 1 hcals = 1 tracks = 8
+    elements:
+      t0 = ts1       value=  7.4 (7955641451161845761)
+      t1 = ts3       value=  5.7 (7955633667588489219)
+      t2 = ts5       value=  4.1 (7955626731935629317)
+      t3 = ts7       value=  3.4 (7955621015338352647)
+      t4 = ts8       value=  3.2 (7955619187487932424)
+      t5 = ts9       value=  2.9 (7955616836284841993)
+      t6 = ts11      value=  2.9 (7955616467450331147)
+      t7 = ts10      value=  2.7 (7955615324059992074)
+      h8 = hm1       value= 29.2 (5595789781379317761)
+      e9 = em3       value=  0.7 (3289849901917143043)
+    distances:
+              t0      t1      t2      t3      t4      t5      t6      t7      h8      e9
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      t3     ---     ---     ---       .
+      t4     ---     ---     ---     ---       .
+      t5     ---     ---     ---     ---     ---       .
+      t6     ---     ---     ---     ---     ---     ---       .
+      t7     ---     ---     ---     ---     ---     ---     ---       .
+      h8  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000       .
+      e9     ---  0.0000     ---     ---     ---     ---     ---     ---     ---       .
+
+Splitting block:E2H1T3   :br6   : ecals = 2 hcals = 1 tracks = 3
+    elements:
+      t0 = ts0       value= 17.3 (7955662951937998848)
+      t1 = ts2       value=  5.8 (7955634128857071618)
+      t2 = ts4       value=  4.7 (7955629592228659204)
+      h3 = hm7       value= 26.4 (5595786733638647815)
+      e4 = em9       value=  4.5 (3289899367900643337)
+      e5 = em6       value=  1.3 (3289866624013697030)
+    distances:
+              t0      t1      t2      h3      e4      e5
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      h3  0.0000  0.1353  0.0000       .
+      e4     ---  0.0000     ---     ---       .
+      e5     ---     ---  0.0000     ---     ---       .
+
+Made block:E2H1T3   :bs1   : ecals = 2 hcals = 1 tracks = 3
+    elements:
+      t0 = ts0       value= 17.3 (7955662951937998848)
+      t1 = ts2       value=  5.8 (7955634128857071618)
+      t2 = ts4       value=  4.7 (7955629592228659204)
+      h3 = hm7       value= 26.4 (5595786733638647815)
+      e4 = em9       value=  4.5 (3289899367900643337)
+      e5 = em6       value=  1.3 (3289866624013697030)
+    distances:
+              t0      t1      t2      h3      e4      e5
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      h3  0.0000  0.1353  0.0000       .
+      e4     ---  0.0000     ---     ---       .
+      e5     ---     ---  0.0000     ---     ---       .
+
+Splitting block:E1H1T1   :br2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts12      value=  2.2 (7955610301383049228)
+      h1 = hm5       value=  2.3 (5595725575219052549)
+      e2 = em2       value=  0.6 (3289846723580526594)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts12      value=  2.2 (7955610301383049228)
+      h1 = hm5       value=  2.3 (5595725575219052549)
+      e2 = em2       value=  0.6 (3289846723580526594)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:H1T1     :br14  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  3.6 (7955622849431994374)
+      h1 = hm6       value=  4.3 (5595741257369387014)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs3   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  3.6 (7955622849431994374)
+      h1 = hm6       value=  4.3 (5595741257369387014)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br10  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts14      value=  1.0 (7955591592258043918)
+      h1 = hm0       value=  1.2 (5595708967899627520)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs4   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts14      value=  1.0 (7955591592258043918)
+      h1 = hm0       value=  1.2 (5595708967899627520)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:E1T1     :br0   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  0.7 (7955580743363592207)
+      e1 = em0       value=  0.5 (3289844939726258176)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs5   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  0.7 (7955580743363592207)
+      e1 = em0       value=  0.5 (3289844939726258176)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:T1       :br15  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.6 (7955601404368781325)
+
+Made block:T1       :bs6   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.6 (7955601404368781325)
+
+Splitting block:H1       :br13  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm4       value=  2.3 (5595724880900259844)
+
+Made block:H1       :bs7   : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm4       value=  2.3 (5595724880900259844)
+
+Splitting block:H1       :br12  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm3       value=  1.9 (5595719937665531907)
+
+Made block:H1       :bs8   : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm3       value=  1.9 (5595719937665531907)
+
+Splitting block:H1       :br11  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm2       value=  1.8 (5595719307731402754)
+
+Made block:H1       :bs9   : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm2       value=  1.8 (5595719307731402754)
+
+Splitting block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  6.3 (3289907406609317898)
+
+Made block:E1       :bs10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  6.3 (3289907406609317898)
+
+Splitting block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  2.1 (3289880602240614408)
+
+Made block:E1       :bs11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  2.1 (3289880602240614408)
+
+Splitting block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  1.5 (3289871166302322695)
+
+Made block:E1       :bs12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  1.5 (3289871166302322695)
+
+Splitting block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  1.2 (3289864668524314629)
+
+Made block:E1       :bs13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  1.2 (3289864668524314629)
+
+Splitting block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.7 (3289850802230788100)
+
+Made block:E1       :bs14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.7 (3289850802230788100)
+
+Splitting block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.6 (3289846337255768065)
+
+Made block:E1       :bs15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.6 (3289846337255768065)
+
+Processing block:E1H1T8   :bs0   : ecals = 1 hcals = 1 tracks = 8
+    elements:
+      t0 = ts1       value=  7.4 (7955641451161845761)
+      t1 = ts3       value=  5.7 (7955633667588489219)
+      t2 = ts5       value=  4.1 (7955626731935629317)
+      t3 = ts7       value=  3.4 (7955621015338352647)
+      t4 = ts8       value=  3.2 (7955619187487932424)
+      t5 = ts9       value=  2.9 (7955616836284841993)
+      t6 = ts11      value=  2.9 (7955616467450331147)
+      t7 = ts10      value=  2.7 (7955615324059992074)
+      h8 = hm1       value= 29.2 (5595789781379317761)
+      e9 = em3       value=  0.7 (3289849901917143043)
+    distances:
+              t0      t1      t2      t3      t4      t5      t6      t7      h8      e9
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      t3     ---     ---     ---       .
+      t4     ---     ---     ---     ---       .
+      t5     ---     ---     ---     ---     ---       .
+      t6     ---     ---     ---     ---     ---     ---       .
+      t7     ---     ---     ---     ---     ---     ---     ---       .
+      h8  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000       .
+      e9     ---  0.0000     ---     ---     ---     ---     ---     ---     ---       .
+
+Made Particle :pr0   :10252477266831343616: pdgid =   211, status =   1, q =  1, e =   7.4, theta = -0.32, phi =  2.17, mass =  0.14 from SmearedTrack: ts1   :7955641451161845761:    7.44    7.07 -0.32  2.17
+Made Particle :pr1   :10252469485044760577: pdgid =   211, status =   1, q =  1, e =   5.7, theta = -0.42, phi =  2.07, mass =  0.14 from SmearedTrack: ts3   :7955633667588489219:    5.67    5.17 -0.42  2.07
+Made Particle :pr2   :10252462552279678978: pdgid =  -211, status =   1, q = -1, e =   4.1, theta = -0.43, phi =  2.01, mass =  0.14 from SmearedTrack: ts5   :7955626731935629317:    4.09    3.72 -0.43  2.01
+Made Particle :pr3   :10252456850314231811: pdgid =  -211, status =   1, q = -1, e =   3.4, theta = -0.32, phi =  2.05, mass =  0.14 from SmearedTrack: ts7   :7955621015338352647:    3.40    3.22 -0.32  2.05
+Made Particle :pr4   :10252455024093298692: pdgid =  -211, status =   1, q = -1, e =   3.2, theta = -0.33, phi =  2.09, mass =  0.14 from SmearedTrack: ts8   :7955619187487932424:    3.19    3.01 -0.33  2.09
+Made Particle :pr5   :10252452675325001733: pdgid =   211, status =   1, q =  1, e =   2.9, theta = -0.30, phi =  2.03, mass =  0.14 from SmearedTrack: ts9   :7955616836284841993:    2.92    2.79 -0.30  2.03
+Made Particle :pr6   :10252452306914115590: pdgid =   211, status =   1, q =  1, e =   2.9, theta = -0.42, phi =  2.06, mass =  0.14 from SmearedTrack: ts11  :7955616467450331147:    2.88    2.62 -0.42  2.06
+Made Particle :pr7   :10252451164918382599: pdgid =  -211, status =   1, q = -1, e =   2.8, theta = -0.39, phi =  1.92, mass =  0.14 from SmearedTrack: ts10  :7955615324059992074:    2.75    2.55 -0.39  1.92
+Finished block
+Processing block:E2H1T3   :bs1   : ecals = 2 hcals = 1 tracks = 3
+    elements:
+      t0 = ts0       value= 17.3 (7955662951937998848)
+      t1 = ts2       value=  5.8 (7955634128857071618)
+      t2 = ts4       value=  4.7 (7955629592228659204)
+      h3 = hm7       value= 26.4 (5595786733638647815)
+      e4 = em9       value=  4.5 (3289899367900643337)
+      e5 = em6       value=  1.3 (3289866624013697030)
+    distances:
+              t0      t1      t2      h3      e4      e5
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      h3  0.0000  0.1353  0.0000       .
+      e4     ---  0.0000     ---     ---       .
+      e5     ---     ---  0.0000     ---     ---       .
+
+Made Particle :pr8   :10252498762509320200: pdgid =  -211, status =   1, q = -1, e =  17.3, theta =  0.62, phi = -1.03, mass =  0.14 from SmearedTrack: ts0   :7955662951937998848:   17.30   14.03  0.62 -1.03
+Made Particle :pr9   :10252469946174930953: pdgid =   211, status =   1, q =  1, e =   5.8, theta =  0.63, phi = -0.88, mass =  0.14 from SmearedTrack: ts2   :7955634128857071618:    5.77    4.65  0.63 -0.88
+Made Particle :pr10  :10252465411146645514: pdgid =  -211, status =   1, q = -1, e =   4.7, theta =  0.53, phi = -1.05, mass =  0.14 from SmearedTrack: ts4   :7955629592228659204:    4.74    4.08  0.53 -1.05
+Finished block
+Processing block:E1H1T1   :bs2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts12      value=  2.2 (7955610301383049228)
+      h1 = hm5       value=  2.3 (5595725575219052549)
+      e2 = em2       value=  0.6 (3289846723580526594)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr11  :10252446150328057867: pdgid =  -211, status =   1, q = -1, e =   2.2, theta =  0.73, phi = -0.68, mass =  0.14 from SmearedTrack: ts12  :7955610301383049228:    2.18    1.62  0.73 -0.68
+Finished block
+Processing block:E1T1     :bs5   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  0.7 (7955580743363592207)
+      e1 = em0       value=  0.5 (3289844939726258176)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr12  :10252417031357857804: pdgid =   211, status =   1, q =  1, e =   0.7, theta = -0.49, phi =  2.04, mass =  0.14 from SmearedTrack: ts15  :7955580743363592207:    0.70    0.62 -0.49  2.04
+Finished block
+Processing block:H1T1     :bs4   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts14      value=  1.0 (7955591592258043918)
+      h1 = hm0       value=  1.2 (5595708967899627520)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr13  :10252427567239790605: pdgid =   211, status =   1, q =  1, e =   1.0, theta =  0.84, phi = -0.62, mass =  0.14 from SmearedTrack: ts14  :7955591592258043918:    1.03    0.68  0.84 -0.62
+Finished block
+Processing block:H1T1     :bs3   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  3.6 (7955622849431994374)
+      h1 = hm6       value=  4.3 (5595741257369387014)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr14  :10252458682960838670: pdgid =   211, status =   1, q =  1, e =   3.6, theta = -1.08, phi = -2.62, mass =  0.14 from SmearedTrack: ts6   :7955622849431994374:    3.60    1.70 -1.08 -2.62
+Finished block
+Processing block:E1       :bs15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.6 (3289846337255768065)
+
+Made Particle :pr15  :10252411361170554895: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.43, phi =  0.46, mass =  0.00 from MergedCluster: em1   :3289846337255768065:    0.56 -0.43  0.46 sub(es10, )
+Finished block
+Processing block:E1       :bs14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.7 (3289850802230788100)
+
+Made Particle :pr16  :10252415826145574928: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.57, phi = -1.04, mass =  0.00 from MergedCluster: em4   :3289850802230788100:    0.68  0.57 -1.04 sub(es9, )
+Finished block
+Processing block:E1       :bs13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  1.2 (3289864668524314629)
+
+Made Particle :pr17  :10252429692439101457: pdgid =    22, status =   1, q =  0, e =   1.2, theta = -0.87, phi = -2.56, mass =  0.00 from MergedCluster: em5   :3289864668524314629:    1.16 -0.87 -2.56 sub(es4, )
+Finished block
+Processing block:E1       :bs12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  1.5 (3289871166302322695)
+
+Made Particle :pr18  :10252436190217109522: pdgid =    22, status =   1, q =  0, e =   1.5, theta = -0.48, phi = -1.77, mass =  0.00 from MergedCluster: em7   :3289871166302322695:    1.52 -0.48 -1.77 sub(es7, )
+Finished block
+Processing block:E1       :bs11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  2.1 (3289880602240614408)
+
+Made Particle :pr19  :10252445626155401235: pdgid =    22, status =   1, q =  0, e =   2.1, theta =  0.61, phi = -1.12, mass =  0.00 from MergedCluster: em8   :3289880602240614408:    2.12  0.61 -1.12 sub(es6, )
+Finished block
+Processing block:E1       :bs10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  6.3 (3289907406609317898)
+
+Made Particle :pr20  :10252472430524104724: pdgid =    22, status =   1, q =  0, e =   6.3, theta =  0.57, phi = -1.13, mass =  0.00 from MergedCluster: em10  :3289907406609317898:    6.34  0.57 -1.13 sub(es0, )
+Finished block
+Processing block:H1       :bs9   : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm2       value=  1.8 (5595719307731402754)
+
+Made Particle :pr21  :10252441322432495637: pdgid =   130, status =   1, q =  0, e =   1.8, theta = -1.05, phi =  1.36, mass =  0.50 from MergedCluster: hm2   :5595719307731402754:    1.82 -1.05  1.36 sub(hs12, )
+Finished block
+Processing block:H1       :bs8   : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm3       value=  1.9 (5595719937665531907)
+
+Made Particle :pr22  :10252441952366624790: pdgid =   130, status =   1, q =  0, e =   1.9, theta = -0.87, phi = -2.56, mass =  0.50 from MergedCluster: hm3   :5595719937665531907:    1.85 -0.87 -2.56 sub(hs11, )
+Finished block
+Processing block:H1       :bs7   : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm4       value=  2.3 (5595724880900259844)
+
+Made Particle :pr23  :10252446895601352727: pdgid =   130, status =   1, q =  0, e =   2.3, theta = -1.11, phi =  1.52, mass =  0.50 from MergedCluster: hm4   :5595724880900259844:    2.27 -1.11  1.52 sub(hs14, )
+Finished block
+Processing block:T1       :bs6   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.6 (7955601404368781325)
+
+Made Particle :pr24  :10252437321485910040: pdgid =  -211, status =   1, q = -1, e =   1.6, theta = -0.23, phi =  2.21, mass =  0.14 from SmearedTrack: ts13  :7955601404368781325:    1.58    1.54 -0.23  2.21
+Finished block
+Finished reconstruction
+Event: 4
+Made Particle :ps0   :10261465339090960384: pdgid = -2212, status =   1, q = -1, e =   3.5, theta = -0.08, phi = -2.36, mass =  0.94
+Made Particle :ps1   :10261464305635426305: pdgid =   321, status =   1, q =  1, e =   3.4, theta =  1.48, phi =  0.39, mass =  0.49
+Made Particle :ps2   :10261464024503812098: pdgid =  2112, status =   1, q =  0, e =   3.4, theta =  0.17, phi = -2.37, mass =  0.94
+Made Particle :ps3   :10261459891189186563: pdgid =    22, status =   1, q =  0, e =   2.9, theta =  0.87, phi =  1.17, mass =  0.00
+Made Particle :ps4   :10261459379624607748: pdgid =  -211, status =   1, q = -1, e =   2.9, theta =  0.74, phi =  1.39, mass =  0.14
+Made Particle :ps5   :10261458887385284613: pdgid =  -211, status =   1, q = -1, e =   2.8, theta =  1.19, phi =  1.33, mass =  0.14
+Made Particle :ps6   :10261458828520325126: pdgid =    22, status =   1, q =  0, e =   2.8, theta =  0.90, phi =  1.36, mass =  0.00
+Made Particle :ps7   :10261458442046668807: pdgid =   211, status =   1, q =  1, e =   2.8, theta =  0.16, phi = -2.57, mass =  0.14
+Made Particle :ps8   :10261456624493264904: pdgid =   211, status =   1, q =  1, e =   2.6, theta = -1.06, phi = -1.24, mass =  0.14
+Made Particle :ps9   :10261456552166686729: pdgid =    22, status =   1, q =  0, e =   2.5, theta = -0.85, phi = -1.05, mass =  0.00
+Made Particle :ps10  :10261456534670147594: pdgid =  -321, status =   1, q = -1, e =   2.5, theta =  0.01, phi = -2.35, mass =  0.49
+Made Particle :ps11  :10261455152003153931: pdgid =    22, status =   1, q =  0, e =   2.4, theta =  0.82, phi =  1.17, mass =  0.00
+Made Particle :ps12  :10261454243175071756: pdgid =  -211, status =   1, q = -1, e =   2.3, theta = -1.08, phi =  1.24, mass =  0.14
+Made Particle :ps13  :10261454189039190029: pdgid =   130, status =   1, q =  0, e =   2.3, theta = -1.07, phi =  0.87, mass =  0.50
+Made Particle :ps14  :10261453882083246094: pdgid =  -321, status =   1, q = -1, e =   2.2, theta = -0.93, phi = -1.08, mass =  0.49
+Made Particle :ps15  :10261453131812438031: pdgid =   130, status =   1, q =  0, e =   2.2, theta = -0.60, phi = -0.89, mass =  0.50
+Made Particle :ps16  :10261452262050103312: pdgid =   211, status =   1, q =  1, e =   2.1, theta = -0.92, phi = -1.32, mass =  0.14
+Made Particle :ps17  :10261450393577848849: pdgid =   211, status =   1, q =  1, e =   1.9, theta =  0.89, phi =  0.80, mass =  0.14
+Made Particle :ps18  :10261449130375118866: pdgid =   211, status =   1, q =  1, e =   1.9, theta =  1.04, phi =  1.26, mass =  0.14
+Made Particle :ps19  :10261448569804292115: pdgid =  -211, status =   1, q = -1, e =   1.8, theta =  0.84, phi =  1.59, mass =  0.14
+Made Particle :ps20  :10261447995228684308: pdgid =    22, status =   1, q =  0, e =   1.8, theta =  0.38, phi =  0.77, mass =  0.00
+Made Particle :ps21  :10261445851899494421: pdgid =   211, status =   1, q =  1, e =   1.7, theta = -0.68, phi = -2.27, mass =  0.14
+Made Particle :ps22  :10261440860514156566: pdgid =  -211, status =   1, q = -1, e =   1.4, theta =  0.15, phi = -2.52, mass =  0.14
+Made Particle :ps23  :10261440574215159831: pdgid =   211, status =   1, q =  1, e =   1.4, theta = -1.52, phi =  0.21, mass =  0.14
+Made Particle :ps24  :10261440152440143896: pdgid =    22, status =   1, q =  0, e =   1.3, theta =  0.89, phi =  1.17, mass =  0.00
+Made Particle :ps25  :10261439711792857113: pdgid =   211, status =   1, q =  1, e =   1.3, theta =  0.01, phi = -2.17, mass =  0.14
+Made Particle :ps26  :10261438512377102362: pdgid =  -211, status =   1, q = -1, e =   1.2, theta = -1.27, phi = -0.93, mass =  0.14
+Made Particle :ps27  :10261438285381369883: pdgid =    22, status =   1, q =  0, e =   1.2, theta = -1.24, phi =  0.84, mass =  0.00
+Made Particle :ps28  :10261437764075520028: pdgid =   211, status =   1, q =  1, e =   1.2, theta = -1.37, phi =  1.42, mass =  0.14
+Made Particle :ps29  :10261437354870833181: pdgid =    22, status =   1, q =  0, e =   1.2, theta = -1.13, phi =  1.30, mass =  0.00
+Made Particle :ps30  :10261435472209248286: pdgid =    22, status =   1, q =  0, e =   1.1, theta =  0.79, phi =  1.11, mass =  0.00
+Made Particle :ps31  :10261433614312931359: pdgid =   211, status =   1, q =  1, e =   1.0, theta = -0.85, phi =  1.44, mass =  0.14
+Made Particle :ps32  :10261433321080750112: pdgid =  -211, status =   1, q = -1, e =   1.0, theta = -0.82, phi = -0.98, mass =  0.14
+Made Particle :ps33  :10261431236037705761: pdgid =  -211, status =   1, q = -1, e =   0.9, theta =  1.14, phi =  0.78, mass =  0.14
+Made Particle :ps34  :10261430086559334434: pdgid =  -211, status =   1, q = -1, e =   0.9, theta = -0.49, phi = -1.99, mass =  0.14
+Made Particle :ps35  :10261429034883743779: pdgid =    22, status =   1, q =  0, e =   0.9, theta = -1.18, phi =  1.17, mass =  0.00
+Made Particle :ps36  :10261428390089195556: pdgid =  -211, status =   1, q = -1, e =   0.8, theta =  1.26, phi =  0.83, mass =  0.14
+Made Particle :ps37  :10261427700237336613: pdgid =  -211, status =   1, q = -1, e =   0.8, theta =  1.01, phi =  2.75, mass =  0.14
+Made Particle :ps38  :10261426995049005094: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.86, phi =  0.82, mass =  0.00
+Made Particle :ps39  :10261426723467821095: pdgid =  -211, status =   1, q = -1, e =   0.8, theta = -0.54, phi = -2.22, mass =  0.14
+Made Particle :ps40  :10261426454086549544: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.29, phi =  0.69, mass =  0.00
+Made Particle :ps41  :10261426394231734313: pdgid =   211, status =   1, q =  1, e =   0.8, theta =  0.08, phi =  1.65, mass =  0.14
+Made Particle :ps42  :10261426122187079722: pdgid =   211, status =   1, q =  1, e =   0.8, theta = -0.04, phi =  0.24, mass =  0.14
+Made Particle :ps43  :10261424710401130539: pdgid =    22, status =   1, q =  0, e =   0.7, theta = -1.18, phi =  0.80, mass =  0.00
+Made Particle :ps44  :10261424252563488812: pdgid =    22, status =   1, q =  0, e =   0.7, theta = -0.87, phi =  1.84, mass =  0.00
+Made Particle :ps45  :10261424061305323565: pdgid =  -211, status =   1, q = -1, e =   0.7, theta = -1.10, phi = -2.35, mass =  0.14
+Made Particle :ps46  :10261422373884395566: pdgid =   211, status =   1, q =  1, e =   0.7, theta =  0.30, phi = -2.36, mass =  0.14
+Made Particle :ps47  :10261421812254507055: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.32, phi = -1.35, mass =  0.00
+Made Particle :ps48  :10261421066884743216: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.33, phi = -2.69, mass =  0.00
+Made Particle :ps49  :10261419782628704305: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.12, phi = -1.26, mass =  0.00
+Made Particle :ps50  :10261418787517497394: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.99, phi =  0.49, mass =  0.00
+Made Particle :ps51  :10261418730078601267: pdgid =   211, status =   1, q =  1, e =   0.6, theta =  0.06, phi = -2.36, mass =  0.14
+Made Particle :ps52  :10261418053212307508: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.63, phi = -1.62, mass =  0.00
+Made Particle :ps53  :10261417770285531189: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  1.16, phi =  2.95, mass =  0.00
+Made Particle :ps54  :10261417722302693430: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -1.12, phi =  1.41, mass =  0.00
+Made Particle :ps55  :10261417695647891511: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  1.38, phi =  1.15, mass =  0.00
+Made Particle :ps56  :10261416930449555512: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -1.30, phi =  1.24, mass =  0.00
+Made Particle :ps57  :10261416524648546361: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.14, phi = -2.35, mass =  0.00
+Made Particle :ps58  :10261415554252275770: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.67, phi =  0.74, mass =  0.00
+Made Particle :ps59  :10261412518456983611: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.94, phi =  0.85, mass =  0.00
+Made Particle :ps60  :10261411941096357948: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  1.43, phi =  2.61, mass =  0.00
+Made Particle :ps61  :10261410997229060157: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.16, phi =  1.45, mass =  0.00
+Made Particle :ps62  :10261409483397791806: pdgid =   211, status =   1, q =  1, e =   0.4, theta =  0.33, phi =  0.84, mass =  0.14
+Made Particle :ps63  :10261409009967824959: pdgid =   211, status =   1, q =  1, e =   0.4, theta = -0.97, phi =  0.82, mass =  0.14
+Made Particle :ps64  :10261405366675832896: pdgid =  -211, status =   1, q = -1, e =   0.3, theta = -0.58, phi = -1.97, mass =  0.14
+Made Particle :ps65  :10261405078363570241: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.91, phi = -1.80, mass =  0.00
+Made Particle :ps66  :10261403136008650818: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.49, phi = -1.80, mass =  0.00
+Made Particle :ps67  :10261399042068054083: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -1.22, phi =  0.46, mass =  0.00
+Made Particle :ps68  :10261397730926526532: pdgid =    11, status =   1, q = -1, e =   0.2, theta =  1.02, phi =  1.12, mass =  0.00
+Made Particle :ps69  :10261392248644042821: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.06, phi =  2.65, mass =  0.00
+Made Particle :ps70  :10261391879339769926: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.82, phi = -1.34, mass =  0.00
+Made Particle :ps71  :10261390042391904327: pdgid =  -211, status =   1, q = -1, e =   0.2, theta = -1.07, phi = -0.19, mass =  0.14
+Made Particle :ps72  :10261389074317181000: pdgid =   -11, status =   1, q =  1, e =   0.2, theta =  1.02, phi =  1.11, mass =  0.00
+Made Particle :ps73  :10261387993294045257: pdgid =   211, status =   1, q =  1, e =   0.2, theta = -0.79, phi = -1.86, mass =  0.14
+Made Particle :ps74  :10261381693856284746: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.99, phi =  1.71, mass =  0.00
+Made Particle :ps75  :10261381537343733835: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.66, phi =  1.45, mass =  0.00
+Made Particle :ps76  :10261376325218467916: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.13, phi =  0.87, mass =  0.00
+Made Particle :ps77  :10261372189276110925: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.60, phi =  1.22, mass =  0.00
+Made Particle :ps78  :10261368849454596174: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.75, phi = -2.99, mass =  0.00
+Made Particle :ps79  :10261367740214280271: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.76, phi = -3.05, mass =  0.00
+Made Particle :ps80  :10261367433736486992: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.35, phi =  0.73, mass =  0.00
+Made Particle :ps81  :10261365843860389969: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -1.32, phi =  1.46, mass =  0.00
+Made Particle :ps82  :10261360712372715602: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.05, phi =  1.30, mass =  0.00
+Made Particle :ps83  :10261349530056261715: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.02, phi =  2.90, mass =  0.00
+Made Particle :ps84  :10261338424130666580: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  0.49, phi = -1.96, mass =  0.00
+Simulating Particle :ps0   :10261465339090960384: pdgid = -2212, status =   1, q = -1, e =   3.5, theta = -0.08, phi = -2.36, mass =  0.94
+Simulating Hadron
+Made Track: tt0   :7964628417041661952:    3.42    3.41 -0.08 -2.36
+Made SmearedTrack: ts0   :7955621218023899136:    3.42    3.41 -0.08 -2.36
+Rejected SmearedTrack: ts0   :7955621218023899136:    3.42    3.41 -0.08 -2.36
+Made Cluster: et0   :3352880126319656960:    0.29 -0.08 -2.17 sub(et0, )
+Made SmearedCluster: es0   :3343857281461649408:    0.16 -0.08 -2.17 sub(es0, )
+Rejected SmearedCluster: es0   :3343857281461649408:    0.16 -0.08 -2.17 sub(es0, )
+Made Cluster: ht0   :5658783948356976640:    3.25 -0.08 -2.15 sub(ht0, )
+Made SmearedCluster: hs0   :5649783403222925312:    4.02 -0.08 -2.15 sub(hs0, )
+Simulating Particle :ps1   :10261464305635426305: pdgid =   321, status =   1, q =  1, e =   3.4, theta =  1.48, phi =  0.39, mass =  0.49
+Simulating Hadron
+Made Track: tt1   :7964628181286125569:    3.39    0.32  1.48  0.39
+Made SmearedTrack: ts0   :7955624341081686016:    3.77    0.36  1.48  0.39
+Rejected SmearedTrack: ts0   :7955624341081686016:    3.77    0.36  1.48  0.39
+Made Cluster: et1   :3352923928723980289:    1.66  1.48  0.16 sub(et1, )
+Made SmearedCluster: es0   :3343907838004035584:    1.15  1.48  0.16 sub(es0, )
+Rejected SmearedCluster: es0   :3343907838004035584:    1.15  1.48  0.16 sub(es0, )
+Made Cluster: ht1   :5658768850615795713:    1.77  1.48  0.14 sub(ht1, )
+Made SmearedCluster: hs1   :5649750790456213505:    1.15  1.48  0.14 sub(hs1, )
+Rejected SmearedCluster: hs1   :5649750790456213505:    1.15  1.48  0.14 sub(hs1, )
+Simulating Particle :ps2   :10261464024503812098: pdgid =  2112, status =   1, q =  0, e =   3.4, theta =  0.17, phi = -2.37, mass =  0.94
+Simulating Hadron
+Made Cluster: et2   :3352931601836146690:    2.19  0.17 -2.37 sub(et2, )
+Made SmearedCluster: es0   :3343925581369573376:    2.32  0.17 -2.37 sub(es0, )
+Made Cluster: ht2   :5658758935983685634:    1.20  0.17 -2.37 sub(ht2, )
+Made SmearedCluster: hs1   :5649749248925761537:    1.06  0.17 -2.37 sub(hs1, )
+Simulating Particle :ps3   :10261459891189186563: pdgid =    22, status =   1, q =  0, e =   2.9, theta =  0.87, phi =  1.17, mass =  0.00
+Simulating Photon
+Made Cluster: et3   :3352938062802845699:    2.93  0.87  1.17 sub(et3, )
+Made SmearedCluster: es1   :3343929802739417089:    2.80  0.87  1.17 sub(es1, )
+Simulating Particle :ps4   :10261459379624607748: pdgid =  -211, status =   1, q = -1, e =   2.9, theta =  0.74, phi =  1.39, mass =  0.14
+Simulating Hadron
+Made Track: tt2   :7964623539768655874:    2.86    2.12  0.74  1.39
+Made SmearedTrack: ts0   :7955616473301385216:    2.88    2.14  0.74  1.39
+Made Cluster: et4   :3352903246365589508:    0.74  0.74  1.70 sub(et4, )
+Made SmearedCluster: es2   :3343881537018920962:    0.41  0.74  1.70 sub(es2, )
+Rejected SmearedCluster: es2   :3343881537018920962:    0.41  0.74  1.70 sub(es2, )
+Made Cluster: ht3   :5658774035364839427:    2.13  0.75  1.74 sub(ht3, )
+Made SmearedCluster: hs2   :5649778159673933826:    3.41  0.75  1.74 sub(hs2, )
+Simulating Particle :ps5   :10261458887385284613: pdgid =  -211, status =   1, q = -1, e =   2.8, theta =  1.19, phi =  1.33, mass =  0.14
+Simulating Hadron
+Made Track: tt3   :7964623046933741571:    2.81    1.05  1.19  1.33
+Made SmearedTrack: ts1   :7955615520242270209:    2.77    1.03  1.19  1.33
+Rejected SmearedTrack: ts1   :7955615520242270209:    2.77    1.03  1.19  1.33
+Made Cluster: et5   :3352896068487479301:    0.54  1.19  1.63 sub(et5, )
+Made SmearedCluster: es2   :3343899695687663618:    0.85  1.19  1.63 sub(es2, )
+Made Cluster: ht4   :5658775337595568132:    2.27  1.19  1.66 sub(ht4, )
+Made SmearedCluster: hs3   :5649771431704133635:    2.65  1.19  1.66 sub(hs3, )
+Simulating Particle :ps6   :10261458828520325126: pdgid =    22, status =   1, q =  0, e =   2.8, theta =  0.90, phi =  1.36, mass =  0.00
+Simulating Photon
+Made Cluster: et6   :3352937000133984262:    2.80  0.90  1.35 sub(et6, )
+Made SmearedCluster: es3   :3343933271074406403:    3.20  0.90  1.35 sub(es3, )
+Simulating Particle :ps7   :10261458442046668807: pdgid =   211, status =   1, q =  1, e =   2.8, theta =  0.16, phi = -2.57, mass =  0.14
+Simulating Hadron
+Made Track: tt4   :7964622601033089028:    2.76    2.72  0.16 -2.57
+Made SmearedTrack: ts1   :7955615389073801217:    2.76    2.72  0.16 -2.57
+Made Cluster: et7   :3352893394494947335:    0.48  0.16 -2.81 sub(et7, )
+Made SmearedCluster: es4   :3343902066081792004:    0.91  0.16 -2.81 sub(es4, )
+Made Cluster: ht5   :5658775392790511621:    2.28  0.16 -2.84 sub(ht5, )
+Made SmearedCluster: hs4   :5649766753666859012:    2.12  0.16 -2.84 sub(hs4, )
+Simulating Particle :ps8   :10261456624493264904: pdgid =   211, status =   1, q =  1, e =   2.6, theta = -1.06, phi = -1.24, mass =  0.14
+Simulating Hadron
+Made Track: tt5   :7964620780965199877:    2.55    1.24 -1.06 -1.24
+Made SmearedTrack: ts2   :7955613483639242754:    2.54    1.23 -1.06 -1.24
+Made Cluster: et8   :3352922183602012168:    1.56 -1.07 -1.59 sub(et8, )
+Made SmearedCluster: es5   :3343914116946329605:    1.51 -1.07 -1.59 sub(es5, )
+Made Cluster: ht6   :5658755127303995398:    0.99 -1.07 -1.62 sub(ht6, )
+Made SmearedCluster: hs5   :5649742565419778053:    0.84 -1.07 -1.62 sub(hs5, )
+Rejected SmearedCluster: hs5   :5649742565419778053:    0.84 -1.07 -1.62 sub(hs5, )
+Simulating Particle :ps9   :10261456552166686729: pdgid =    22, status =   1, q =  0, e =   2.5, theta = -0.85, phi = -1.05, mass =  0.00
+Simulating Photon
+Made Cluster: et9   :3352934723780345865:    2.55 -0.85 -1.05 sub(et9, )
+Made SmearedCluster: es6   :3343926539516379142:    2.43 -0.85 -1.05 sub(es6, )
+Simulating Particle :ps10  :10261456534670147594: pdgid =  -321, status =   1, q = -1, e =   2.5, theta =  0.01, phi = -2.35, mass =  0.49
+Simulating Hadron
+Made Track: tt6   :7964620299299717126:    2.50    2.50  0.01 -2.35
+Made SmearedTrack: ts3   :7955613110702702595:    2.50    2.50  0.01 -2.35
+Made Cluster: ht7   :5658777715497500679:    2.54  0.01 -2.06 sub(ht7, )
+Made SmearedCluster: hs5   :5649766849320058885:    2.13  0.01 -2.06 sub(hs5, )
+Simulating Particle :ps11  :10261455152003153931: pdgid =    22, status =   1, q =  0, e =   2.4, theta =  0.82, phi =  1.17, mass =  0.00
+Simulating Photon
+Made Cluster: et10  :3352933323616813066:    2.39  0.82  1.17 sub(et10, )
+Made SmearedCluster: es7   :3343924599615127559:    2.21  0.82  1.17 sub(es7, )
+Simulating Particle :ps12  :10261454243175071756: pdgid =  -211, status =   1, q = -1, e =   2.3, theta = -1.08, phi =  1.24, mass =  0.14
+Simulating Hadron
+Made Track: tt7   :7964618395660320775:    2.28    1.08 -1.08  1.24
+Made SmearedTrack: ts4   :7955611329417445380:    2.29    1.08 -1.08  1.24
+Made Cluster: et11  :3352903228831301643:    0.74 -1.09  1.62 sub(et11, )
+Made SmearedCluster: es8   :3343892679783088136:    0.65 -1.09  1.62 sub(es8, )
+Made Cluster: ht8   :5658764874807771144:    1.54 -1.09  1.66 sub(ht8, )
+Made SmearedCluster: hs6   :5649755677204152326:    1.43 -1.09  1.66 sub(hs6, )
+Simulating Particle :ps13  :10261454189039190029: pdgid =   130, status =   1, q =  0, e =   2.3, theta = -1.07, phi =  0.87, mass =  0.50
+Simulating Hadron
+Made Cluster: et12  :3352884279911645196:    0.35 -1.07  0.87 sub(et12, )
+Made SmearedCluster: es9   :3343870728714846217:    0.26 -1.07  0.87 sub(es9, )
+Rejected SmearedCluster: es9   :3343870728714846217:    0.26 -1.07  0.87 sub(es9, )
+Made Cluster: ht9   :5658771626420862985:    1.93 -1.07  0.87 sub(ht9, )
+Made SmearedCluster: hs7   :5649764438511714311:    1.93 -1.07  0.87 sub(hs7, )
+Simulating Particle :ps14  :10261453882083246094: pdgid =  -321, status =   1, q = -1, e =   2.2, theta = -0.93, phi = -1.08, mass =  0.49
+Simulating Hadron
+Made Track: tt8   :7964617588149846024:    2.19    1.31 -0.93 -1.08
+Made SmearedTrack: ts5   :7955610562226814981:    2.21    1.32 -0.93 -1.08
+Made Cluster: et13  :3352918052566990861:    1.33 -0.95 -0.64 sub(et13, )
+Made SmearedCluster: es9   :3343911742401937417:    1.38 -0.95 -0.64 sub(es9, )
+Made Cluster: ht10  :5658752419729768458:    0.92 -0.95 -0.60 sub(ht10, )
+Made SmearedCluster: hs8   :5649734406915489800:    0.61 -0.95 -0.60 sub(hs8, )
+Rejected SmearedCluster: hs8   :5649734406915489800:    0.61 -0.95 -0.60 sub(hs8, )
+Simulating Particle :ps15  :10261453131812438031: pdgid =   130, status =   1, q =  0, e =   2.2, theta = -0.60, phi = -0.89, mass =  0.50
+Simulating Hadron
+Made Cluster: et14  :3352883147577491470:    0.34 -0.60 -0.89 sub(et14, )
+Made SmearedCluster: es10  :3343893479982891018:    0.67 -0.60 -0.89 sub(es10, )
+Made Cluster: ht11  :5658769795053518859:    1.82 -0.60 -0.89 sub(ht11, )
+Made SmearedCluster: hs8   :5649768248659410952:    2.29 -0.60 -0.89 sub(hs8, )
+Simulating Particle :ps16  :10261452262050103312: pdgid =   211, status =   1, q =  1, e =   2.1, theta = -0.92, phi = -1.32, mass =  0.14
+Simulating Hadron
+Made Track: tt9   :7964616410414448649:    2.05    1.25 -0.92 -1.32
+Made SmearedTrack: ts6   :7955609229084065798:    2.06    1.25 -0.92 -1.32
+Made Cluster: ht12  :5658773442877456396:    2.06 -0.94 -1.84 sub(ht12, )
+Made SmearedCluster: hs9   :5649753815952392201:    1.32 -0.94 -1.84 sub(hs9, )
+Simulating Particle :ps17  :10261450393577848849: pdgid =   211, status =   1, q =  1, e =   1.9, theta =  0.89, phi =  0.80, mass =  0.14
+Simulating Hadron
+Made Track: tt10  :7964614494389272586:    1.92    1.21  0.89  0.80
+Made SmearedTrack: ts7   :7955607963964538887:    1.96    1.23  0.89  0.80
+Made Cluster: ht13  :5658771574405201933:    1.92  0.92  0.23 sub(ht13, )
+Made SmearedCluster: hs10  :5649767240248066058:    2.17  0.92  0.23 sub(hs10, )
+Simulating Particle :ps18  :10261449130375118866: pdgid =   211, status =   1, q =  1, e =   1.9, theta =  1.04, phi =  1.26, mass =  0.14
+Simulating Hadron
+Made Track: tt11  :7964613227717853195:    1.85    0.93  1.04  1.26
+Made SmearedTrack: ts8   :7955605871996698632:    1.84    0.93  1.04  1.26
+Made Cluster: et15  :3352851755692982287:    0.10  1.06  0.77 sub(et15, )
+Made SmearedCluster: es11  :3343851312314843147:    0.12  1.06  0.77 sub(es11, )
+Rejected SmearedCluster: es11  :3343851312314843147:    0.12  1.06  0.77 sub(es11, )
+Made Cluster: ht14  :5658768599563632654:    1.75  1.06  0.73 sub(ht14, )
+Made SmearedCluster: hs11  :5649769711454388235:    2.45  1.06  0.73 sub(hs11, )
+Simulating Particle :ps19  :10261448569804292115: pdgid =  -211, status =   1, q = -1, e =   1.8, theta =  0.84, phi =  1.59, mass =  0.14
+Simulating Hadron
+Made Track: tt12  :7964612665515442188:    1.81    1.21  0.84  1.59
+Made SmearedTrack: ts9   :7955605815176462345:    1.83    1.22  0.84  1.59
+Made Cluster: ht15  :5658769750631645199:    1.82  0.88  2.22 sub(ht15, )
+Made SmearedCluster: hs12  :5649753345043202060:    1.30  0.88  2.22 sub(hs12, )
+Simulating Particle :ps20  :10261447995228684308: pdgid =    22, status =   1, q =  0, e =   1.8, theta =  0.38, phi =  0.77, mass =  0.00
+Simulating Photon
+Made Cluster: et16  :3352926166842343440:    1.79  0.38  0.77 sub(et16, )
+Made SmearedCluster: es11  :3343914634622009355:    1.54  0.38  0.77 sub(es11, )
+Simulating Particle :ps21  :10261445851899494421: pdgid =   211, status =   1, q =  1, e =   1.7, theta = -0.68, phi = -2.27, mass =  0.14
+Simulating Hadron
+Made Track: tt13  :7964609938829869069:    1.66    1.29 -0.68 -2.27
+Made SmearedTrack: ts10  :7955603034967375882:    1.68    1.31 -0.68 -2.27
+Made Cluster: et17  :3352911570278547473:    0.98 -0.70 -2.79 sub(et17, )
+Made SmearedCluster: es12  :3343903126580101132:    0.94 -0.70 -2.79 sub(es12, )
+Made Cluster: ht16  :5658744301591461904:    0.69 -0.71 -2.86 sub(ht16, )
+Made SmearedCluster: hs13  :5649734576304553997:    0.61 -0.71 -2.86 sub(hs13, )
+Rejected SmearedCluster: hs13  :5649734576304553997:    0.61 -0.71 -2.86 sub(hs13, )
+Simulating Particle :ps22  :10261440860514156566: pdgid =  -211, status =   1, q = -1, e =   1.4, theta =  0.15, phi = -2.52, mass =  0.14
+Simulating Hadron
+Made Track: tt14  :7964604926158438414:    1.37    1.36  0.15 -2.52
+Made SmearedTrack: ts11  :7955597739142676491:    1.37    1.36  0.15 -2.52
+Made Cluster: et18  :3352882012663840786:    0.32  0.15 -2.03 sub(et18, )
+Made SmearedCluster: es13  :3343897589283029005:    0.79  0.15 -2.03 sub(es13, )
+Made Cluster: ht17  :5658756426634362897:    1.06  0.15 -1.97 sub(ht17, )
+Made SmearedCluster: hs13  :5649741771714854925:    0.82  0.15 -1.97 sub(hs13, )
+Rejected SmearedCluster: hs13  :5649741771714854925:    0.82  0.15 -1.97 sub(hs13, )
+Simulating Particle :ps24  :10261440152440143896: pdgid =    22, status =   1, q =  0, e =   1.3, theta =  0.89, phi =  1.17, mass =  0.00
+Simulating Photon
+Made Cluster: et19  :3352918324053803027:    1.34  0.89  1.17 sub(et19, )
+Made SmearedCluster: es14  :3343907474219466766:    1.13  0.89  1.17 sub(es14, )
+Simulating Particle :ps25  :10261439711792857113: pdgid =   211, status =   1, q =  1, e =   1.3, theta =  0.01, phi = -2.17, mass =  0.14
+Simulating Hadron
+Made Track: tt15  :7964603771229569039:    1.31    1.31  0.01 -2.17
+Made SmearedTrack: ts12  :7955596590849196044:    1.31    1.31  0.01 -2.17
+Made Cluster: et20  :3352809923323887636:    0.02  0.01 -2.68 sub(et20, )
+Made SmearedCluster: es15  :3341670923508908047:   -0.01  0.01 -2.68 sub(es15, )
+Rejected SmearedCluster: es15  :3341670923508908047:   -0.01  0.01 -2.68 sub(es15, )
+Made Cluster: ht18  :5658760568585060370:    1.30  0.01 -2.75 sub(ht18, )
+Made SmearedCluster: hs13  :5649739218587484173:    0.75  0.01 -2.75 sub(hs13, )
+Rejected SmearedCluster: hs13  :5649739218587484173:    0.75  0.01 -2.75 sub(hs13, )
+Simulating Particle :ps26  :10261438512377102362: pdgid =  -211, status =   1, q = -1, e =   1.2, theta = -1.27, phi = -0.93, mass =  0.14
+Simulating Hadron
+Made Track: tt16  :7964602564631068688:    1.24    0.37 -1.27 -0.93
+Made SmearedTrack: ts13  :7955595342305558541:    1.24    0.37 -1.27 -0.93
+Rejected SmearedTrack: ts13  :7955595342305558541:    1.24    0.37 -1.27 -0.93
+Made Cluster: ht19  :5658759693204455443:    1.25 -1.29 -0.21 sub(ht19, )
+Made SmearedCluster: hs13  :5649768828119285773:    2.35 -1.29 -0.21 sub(hs13, )
+Simulating Particle :ps27  :10261438285381369883: pdgid =    22, status =   1, q =  0, e =   1.2, theta = -1.24, phi =  0.84, mass =  0.00
+Simulating Photon
+Made Cluster: et21  :3352916456995029013:    1.23 -1.24  0.84 sub(et21, )
+Made SmearedCluster: es15  :3343909552169943055:    1.25 -1.24  0.84 sub(es15, )
+Simulating Particle :ps28  :10261437764075520028: pdgid =   211, status =   1, q =  1, e =   1.2, theta = -1.37, phi =  1.42, mass =  0.14
+Simulating Hadron
+Made Track: tt17  :7964601811432636433:    1.20    0.24 -1.37  1.42
+Made SmearedTrack: ts13  :7955594836648656909:    1.21    0.24 -1.37  1.42
+Rejected SmearedTrack: ts13  :7955594836648656909:    1.21    0.24 -1.37  1.42
+Made Cluster: et22  :3352902359427579926:    0.72 -1.38  0.75 sub(et22, )
+Made SmearedCluster: es16  :3343906243327557648:    1.06 -1.38  0.75 sub(es16, )
+Made Cluster: ht20  :5658736926167924756:    0.49 -1.39  0.69 sub(ht20, )
+Made SmearedCluster: hs14  :5649755188672593934:    1.40 -1.39  0.69 sub(hs14, )
+Simulating Particle :ps29  :10261437354870833181: pdgid =    22, status =   1, q =  0, e =   1.2, theta = -1.13, phi =  1.30, mass =  0.00
+Simulating Photon
+Made Cluster: et23  :3352915526484492311:    1.18 -1.13  1.30 sub(et23, )
+Made SmearedCluster: es17  :3343910910338007057:    1.33 -1.13  1.30 sub(es17, )
+Simulating Particle :ps30  :10261435472209248286: pdgid =    22, status =   1, q =  0, e =   1.1, theta =  0.79, phi =  1.11, mass =  0.00
+Simulating Photon
+Made Cluster: et24  :3352913643822907416:    1.07  0.79  1.11 sub(et24, )
+Made SmearedCluster: es18  :3343911322698907666:    1.35  0.79  1.11 sub(es18, )
+Simulating Particle :ps31  :10261433614312931359: pdgid =   211, status =   1, q =  1, e =   1.0, theta = -0.85, phi =  1.44, mass =  0.14
+Simulating Hadron
+Made Track: tt18  :7964597454509178898:    0.97    0.64 -0.85  1.44
+Made SmearedTrack: ts13  :7955590404791861261:    0.98    0.64 -0.85  1.44
+Made Cluster: et25  :3352860483811016729:    0.13 -0.95  0.38 sub(et25, )
+Made SmearedCluster: es19  :3343886861931118611:    0.49 -0.95  0.38 sub(es19, )
+Rejected SmearedCluster: es19  :3343886861931118611:    0.49 -0.95  0.38 sub(es19, )
+Made Cluster: ht21  :5658750164599308309:    0.85 -0.97  0.27 sub(ht21, )
+Made SmearedCluster: hs15  :5649740859313225743:    0.79 -0.97  0.27 sub(hs15, )
+Rejected SmearedCluster: hs15  :5649740859313225743:    0.79 -0.97  0.27 sub(hs15, )
+Simulating Particle :ps32  :10261433321080750112: pdgid =  -211, status =   1, q = -1, e =   1.0, theta = -0.82, phi = -0.98, mass =  0.14
+Simulating Hadron
+Made Track: tt19  :7964597158259195923:    0.97    0.66 -0.82 -0.98
+Made SmearedTrack: ts14  :7955589488223191054:    0.95    0.65 -0.82 -0.98
+Made Cluster: et26  :3352899675249180698:    0.64 -0.93  0.12 sub(et26, )
+Made SmearedCluster: es19  :3343905496640782355:    1.02 -0.93  0.12 sub(es19, )
+Made Cluster: ht22  :5658726197937307670:    0.34 -0.95  0.23 sub(ht22, )
+Made SmearedCluster: hs15  :5649739895483138063:    0.77 -0.95  0.23 sub(hs15, )
+Rejected SmearedCluster: hs15  :5649739895483138063:    0.77 -0.95  0.23 sub(hs15, )
+Simulating Particle :ps33  :10261431236037705761: pdgid =  -211, status =   1, q = -1, e =   0.9, theta =  1.14, phi =  0.78, mass =  0.14
+Simulating Hadron
+Made Track: tt20  :7964595050149576724:    0.91    0.38  1.14  0.78
+Made SmearedTrack: ts15  :7955587395720577039:    0.89    0.38  1.14  0.78
+Rejected SmearedTrack: ts15  :7955587395720577039:    0.89    0.38  1.14  0.78
+Made Cluster: et27  :3352898499864690715:    0.61  1.19  1.72 sub(et27, )
+Made SmearedCluster: es20  :3343909382107693076:    1.24  1.19  1.72 sub(es20, )
+Made Cluster: ht23  :5658724378620198935:    0.31  1.20  1.82 sub(ht23, )
+Made SmearedCluster: hs15  :5649707339628937231:    0.21  1.20  1.82 sub(hs15, )
+Rejected SmearedCluster: hs15  :5649707339628937231:    0.21  1.20  1.82 sub(hs15, )
+Simulating Particle :ps34  :10261430086559334434: pdgid =  -211, status =   1, q = -1, e =   0.9, theta = -0.49, phi = -1.99, mass =  0.14
+Simulating Hadron
+Made Track: tt21  :7964593886609801237:    0.87    0.77 -0.49 -1.99
+Made SmearedTrack: ts15  :7955586786959294479:    0.88    0.77 -0.49 -1.99
+Made Cluster: et28  :3352884435692290076:    0.35 -0.56 -1.00 sub(et28, )
+Made SmearedCluster: es21  :3341670923508908053:   -0.24 -0.56 -1.00 sub(es21, )
+Rejected SmearedCluster: es21  :3341670923508908053:   -0.24 -0.56 -1.00 sub(es21, )
+Made Cluster: ht24  :5658738826456072216:    0.53 -0.60 -0.79 sub(ht24, )
+Made SmearedCluster: hs15  :5649743861482782735:    0.88 -0.60 -0.79 sub(hs15, )
+Rejected SmearedCluster: hs15  :5649743861482782735:    0.88 -0.60 -0.79 sub(hs15, )
+Simulating Particle :ps35  :10261429034883743779: pdgid =    22, status =   1, q =  0, e =   0.9, theta = -1.18, phi =  1.17, mass =  0.00
+Simulating Photon
+Made Cluster: et29  :3352907206497402909:    0.85 -1.18  1.17 sub(et29, )
+Made SmearedCluster: es21  :3343895703112908821:    0.73 -1.18  1.17 sub(es21, )
+Simulating Particle :ps36  :10261428390089195556: pdgid =  -211, status =   1, q = -1, e =   0.8, theta =  1.26, phi =  0.83, mass =  0.14
+Simulating Hadron
+Made Track: tt22  :7964592167337328662:    0.82    0.25  1.26  0.83
+Made SmearedTrack: ts16  :7955585038614003728:    0.83    0.25  1.26  0.83
+Rejected SmearedTrack: ts16  :7955585038614003728:    0.83    0.25  1.26  0.83
+Made Cluster: et30  :3352870346096115742:    0.20  1.30  1.83 sub(et30, )
+Made SmearedCluster: es22  :3343891541241364502:    0.61  1.30  1.83 sub(es22, )
+Made Cluster: ht25  :5658742474804297753:    0.63  1.31  1.92 sub(ht25, )
+Made SmearedCluster: hs15  :5649733046308438031:    0.57  1.31  1.92 sub(hs15, )
+Rejected SmearedCluster: hs15  :5649733046308438031:    0.57  1.31  1.92 sub(hs15, )
+Simulating Particle :ps37  :10261427700237336613: pdgid =  -211, status =   1, q = -1, e =   0.8, theta =  1.01, phi =  2.75, mass =  0.14
+Simulating Hadron
+Made Track: tt23  :7964591467425431575:    0.80    0.43  1.01  2.75
+Made SmearedTrack: ts16  :7955584299776868368:    0.81    0.43  1.01  2.75
+Made Cluster: et31  :3352888836026794015:    0.42  1.11 -2.39 sub(et31, )
+Made SmearedCluster: es23  :3341670923508908055:   -0.01  1.11 -2.39 sub(es23, )
+Rejected SmearedCluster: es23  :3341670923508908055:   -0.01  1.11 -2.39 sub(es23, )
+Made Cluster: ht26  :5658730732516802586:    0.40  1.13 -2.28 sub(ht26, )
+Made SmearedCluster: hs15  :5649740988325822479:    0.80  1.13 -2.28 sub(hs15, )
+Rejected SmearedCluster: hs15  :5649740988325822479:    0.80  1.13 -2.28 sub(hs15, )
+Simulating Particle :ps38  :10261426995049005094: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.86, phi =  0.82, mass =  0.00
+Simulating Photon
+Made Cluster: et32  :3352905166662664224:    0.80  0.86  0.82 sub(et32, )
+Made SmearedCluster: es23  :3343899418320437271:    0.84  0.86  0.82 sub(es23, )
+Simulating Particle :ps39  :10261426723467821095: pdgid =  -211, status =   1, q = -1, e =   0.8, theta = -0.54, phi = -2.22, mass =  0.14
+Simulating Hadron
+Made Track: tt24  :7964590475537547288:    0.78    0.67 -0.54 -2.22
+Made SmearedTrack: ts17  :7955583179752996881:    0.77    0.67 -0.54 -2.22
+Made Cluster: et33  :3352871810514288673:    0.21 -0.68 -0.91 sub(et33, )
+Made SmearedCluster: es24  :3343889616015982616:    0.56 -0.68 -0.91 sub(es24, )
+Made Cluster: ht27  :5658740442078904347:    0.58 -0.99 -0.06 sub(ht27, )
+Made SmearedCluster: hs15  :5649751676593111055:    1.20 -0.99 -0.06 sub(hs15, )
+Simulating Particle :ps40  :10261426454086549544: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.29, phi =  0.69, mass =  0.00
+Simulating Photon
+Made Cluster: et34  :3352904625700208674:    0.78  0.29  0.69 sub(et34, )
+Made SmearedCluster: es25  :3343892058323550233:    0.63  0.29  0.69 sub(es25, )
+Simulating Particle :ps41  :10261426394231734313: pdgid =   211, status =   1, q =  1, e =   0.8, theta =  0.08, phi =  1.65, mass =  0.14
+Simulating Hadron
+Made Track: tt25  :7964590140955820057:    0.77    0.76  0.08  1.65
+Made SmearedTrack: ts18  :7955582924252774418:    0.77    0.76  0.08  1.65
+Made Cluster: et35  :3352881537648427043:    0.31  0.10  0.65 sub(et35, )
+Made SmearedCluster: es26  :3343871071446106138:    0.27  0.10  0.65 sub(es26, )
+Rejected SmearedCluster: es26  :3343871071446106138:    0.27  0.10  0.65 sub(es26, )
+Made Cluster: ht28  :5658735418886062108:    0.47  0.11  0.42 sub(ht28, )
+Made SmearedCluster: hs16  :5649749606320308240:    1.08  0.11  0.42 sub(hs16, )
+Simulating Particle :ps42  :10261426122187079722: pdgid =   211, status =   1, q =  1, e =   0.8, theta = -0.04, phi =  0.24, mass =  0.14
+Simulating Hadron
+Made Track: tt26  :7964589864395997210:    0.76    0.76 -0.04  0.24
+Made SmearedTrack: ts19  :7955582677671739411:    0.76    0.76 -0.04  0.24
+Made Cluster: et36  :3352872873896181796:    0.22 -0.05 -0.78 sub(et36, )
+Made SmearedCluster: es26  :3343896190149197850:    0.75 -0.05 -0.78 sub(es26, )
+Made Cluster: ht29  :5658739574952689693:    0.55 -0.06 -1.01 sub(ht29, )
+Made SmearedCluster: hs17  :5649745742674264081:    0.93 -0.06 -1.01 sub(hs17, )
+Rejected SmearedCluster: hs17  :5649745742674264081:    0.93 -0.06 -1.01 sub(hs17, )
+Simulating Particle :ps43  :10261424710401130539: pdgid =    22, status =   1, q =  0, e =   0.7, theta = -1.18, phi =  0.80, mass =  0.00
+Simulating Photon
+Made Cluster: et37  :3352902882014789669:    0.73 -1.18  0.80 sub(et37, )
+Made SmearedCluster: es27  :3343892251794210843:    0.63 -1.18  0.80 sub(es27, )
+Simulating Particle :ps44  :10261424252563488812: pdgid =    22, status =   1, q =  0, e =   0.7, theta = -0.87, phi =  1.84, mass =  0.00
+Simulating Photon
+Made Cluster: et38  :3352902424177147942:    0.72 -0.87  1.84 sub(et38, )
+Made SmearedCluster: es28  :3343896820167213084:    0.76 -0.87  1.84 sub(es28, )
+Simulating Particle :ps45  :10261424061305323565: pdgid =  -211, status =   1, q = -1, e =   0.7, theta = -1.10, phi = -2.35, mass =  0.14
+Simulating Hadron
+Made Track: tt27  :7964587766025551899:    0.70    0.32 -1.10 -2.35
+Made SmearedTrack: ts20  :7955580018560598036:    0.68    0.31 -1.10 -2.35
+Rejected SmearedTrack: ts20  :7955580018560598036:    0.68    0.31 -1.10 -2.35
+Made Cluster: et39  :3352878674740248615:    0.27 -1.20 -1.09 sub(et39, )
+Made SmearedCluster: es29  :3343889290481369117:    0.55 -1.20 -1.09 sub(es29, )
+Made Cluster: ht30  :5658733615937224734:    0.44 -1.22 -0.97 sub(ht30, )
+Made SmearedCluster: hs17  :5649721431938826257:    0.37 -1.22 -0.97 sub(hs17, )
+Rejected SmearedCluster: hs17  :5649721431938826257:    0.37 -1.22 -0.97 sub(hs17, )
+Simulating Particle :ps46  :10261422373884395566: pdgid =   211, status =   1, q =  1, e =   0.7, theta =  0.30, phi = -2.36, mass =  0.14
+Simulating Hadron
+Made Track: tt28  :7964586042839793692:    0.65    0.62  0.30 -2.36
+Made SmearedTrack: ts20  :7955578815346901012:    0.65    0.62  0.30 -2.36
+Made Cluster: et40  :3352844920699224104:    0.07  1.02  3.04 sub(et40, )
+Made SmearedCluster: es30  :3343851254242607134:    0.12  1.02  3.04 sub(es30, )
+Rejected SmearedCluster: es30  :3343851254242607134:    0.12  1.02  3.04 sub(es30, )
+Made Cluster: ht31  :5658740985807503391:    0.59  0.97  2.66 sub(ht31, )
+Made SmearedCluster: hs17  :5649734603554947089:    0.62  0.97  2.66 sub(hs17, )
+Rejected SmearedCluster: hs17  :5649734603554947089:    0.62  0.97  2.66 sub(hs17, )
+Simulating Particle :ps47  :10261421812254507055: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.32, phi = -1.35, mass =  0.00
+Simulating Photon
+Made Cluster: et41  :3352899983868166185:    0.65 -0.32 -1.35 sub(et41, )
+Made SmearedCluster: es30  :3343899806658461726:    0.85 -0.32 -1.35 sub(es30, )
+Simulating Particle :ps48  :10261421066884743216: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.33, phi = -2.69, mass =  0.00
+Simulating Photon
+Made Cluster: et42  :3352899238498402346:    0.63 -0.33 -2.69 sub(et42, )
+Made SmearedCluster: es31  :3343887002278821919:    0.49 -0.33 -2.69 sub(es31, )
+Rejected SmearedCluster: es31  :3343887002278821919:    0.49 -0.33 -2.69 sub(es31, )
+Simulating Particle :ps49  :10261419782628704305: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.12, phi = -1.26, mass =  0.00
+Simulating Photon
+Made Cluster: et43  :3352897954242363435:    0.59 -0.12 -1.26 sub(et43, )
+Made SmearedCluster: es31  :3343893045463482399:    0.66 -0.12 -1.26 sub(es31, )
+Simulating Particle :ps50  :10261418787517497394: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.99, phi =  0.49, mass =  0.00
+Simulating Photon
+Made Cluster: et44  :3352896959131156524:    0.56  0.99  0.49 sub(et44, )
+Made SmearedCluster: es32  :3343888658370396192:    0.53  0.99  0.49 sub(es32, )
+Simulating Particle :ps51  :10261418730078601267: pdgid =   211, status =   1, q =  1, e =   0.6, theta =  0.06, phi = -2.36, mass =  0.14
+Simulating Hadron
+Made Track: tt29  :7964582300063105053:    0.54    0.54  0.06 -2.36
+Made SmearedTrack: ts21  :7955575129830850581:    0.54    0.54  0.06 -2.36
+Made Cluster: et45  :3352843110097879085:    0.07  1.03  1.80 sub(et45, )
+Made SmearedCluster: es33  :3343835159114809377:    0.06  1.03  1.80 sub(es33, )
+Rejected SmearedCluster: es33  :3343835159114809377:    0.06  1.03  1.80 sub(es33, )
+Made Cluster: ht32  :5658737389233766432:    0.49  1.02  2.62 sub(ht32, )
+Made SmearedCluster: hs17  :5647513932722602001:   -0.04  1.02  2.62 sub(hs17, )
+Rejected SmearedCluster: hs17  :5647513932722602001:   -0.04  1.02  2.62 sub(hs17, )
+Simulating Particle :ps52  :10261418053212307508: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.63, phi = -1.62, mass =  0.00
+Simulating Photon
+Made Cluster: et46  :3352896224825966638:    0.54 -0.63 -1.62 sub(et46, )
+Made SmearedCluster: es33  :3343891010548662305:    0.60 -0.63 -1.62 sub(es33, )
+Simulating Particle :ps53  :10261417770285531189: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  1.16, phi =  2.95, mass =  0.00
+Simulating Photon
+Made Cluster: et47  :3352895941899190319:    0.53  1.16  2.95 sub(et47, )
+Made SmearedCluster: es34  :3343887928953667618:    0.51  1.16  2.95 sub(es34, )
+Simulating Particle :ps54  :10261417722302693430: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -1.12, phi =  1.41, mass =  0.00
+Simulating Photon
+Made Cluster: et48  :3352895893916352560:    0.53 -1.12  1.41 sub(et48, )
+Made SmearedCluster: es35  :3343888680912683043:    0.53 -1.12  1.41 sub(es35, )
+Simulating Particle :ps55  :10261417695647891511: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  1.38, phi =  1.15, mass =  0.00
+Simulating Photon
+Made Cluster: et49  :3352895867261550641:    0.53  1.38  1.15 sub(et49, )
+Made SmearedCluster: es36  :3343888109281476644:    0.52  1.38  1.15 sub(es36, )
+Simulating Particle :ps56  :10261416930449555512: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -1.30, phi =  1.24, mass =  0.00
+Simulating Photon
+Made Cluster: et50  :3352895102063214642:    0.51 -1.30  1.24 sub(et50, )
+Made SmearedCluster: es37  :3343891621065261093:    0.62 -1.30  1.24 sub(es37, )
+Simulating Particle :ps57  :10261416524648546361: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.14, phi = -2.35, mass =  0.00
+Simulating Photon
+Made Cluster: et51  :3352894696262205491:    0.50 -0.14 -2.35 sub(et51, )
+Made SmearedCluster: es38  :3343889614027882534:    0.56 -0.14 -2.35 sub(es38, )
+Simulating Particle :ps58  :10261415554252275770: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.67, phi =  0.74, mass =  0.00
+Simulating Photon
+Made Cluster: et52  :3352893725865934900:    0.49 -0.67  0.74 sub(et52, )
+Made SmearedCluster: es39  :3343878228417708071:    0.37 -0.67  0.74 sub(es39, )
+Rejected SmearedCluster: es39  :3343878228417708071:    0.37 -0.67  0.74 sub(es39, )
+Simulating Particle :ps59  :10261412518456983611: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.94, phi =  0.85, mass =  0.00
+Simulating Photon
+Made Cluster: et53  :3352890690070642741:    0.44 -0.94  0.85 sub(et53, )
+Made SmearedCluster: es39  :3343887973851594791:    0.51 -0.94  0.85 sub(es39, )
+Simulating Particle :ps60  :10261411941096357948: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  1.43, phi =  2.61, mass =  0.00
+Simulating Photon
+Made Cluster: et54  :3352890112710017078:    0.43  1.43  2.61 sub(et54, )
+Made SmearedCluster: es40  :3343887646039474216:    0.50  1.43  2.61 sub(es40, )
+Simulating Particle :ps61  :10261410997229060157: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.16, phi =  1.45, mass =  0.00
+Simulating Photon
+Made Cluster: et55  :3352889168842719287:    0.42  0.16  1.45 sub(et55, )
+Made SmearedCluster: es41  :3343888815451275305:    0.54  0.16  1.45 sub(es41, )
+Simulating Particle :ps62  :10261409483397791806: pdgid =   211, status =   1, q =  1, e =   0.4, theta =  0.33, phi =  0.84, mass =  0.14
+Simulating Hadron
+Made Track: tt30  :7964571901274095646:    0.37    0.35  0.33  0.84
+Made SmearedTrack: ts22  :7955564726079979542:    0.37    0.35  0.33  0.84
+Rejected SmearedTrack: ts22  :7955564726079979542:    0.37    0.35  0.33  0.84
+Made Cluster: et56  :3352863792691150904:    0.16  1.51  0.69 sub(et56, )
+Made SmearedCluster: es42  :3341670923508908074:   -0.11  1.51  0.69 sub(es42, )
+Rejected SmearedCluster: es42  :3341670923508908074:   -0.11  1.51  0.69 sub(es42, )
+Made Cluster: ht33  :5658719342173356065:    0.24  1.29  0.08 sub(ht33, )
+Made SmearedCluster: hs17  :5649723277717798929:    0.40  1.29  0.08 sub(hs17, )
+Rejected SmearedCluster: hs17  :5649723277717798929:    0.40  1.29  0.08 sub(hs17, )
+Simulating Particle :ps63  :10261409009967824959: pdgid =   211, status =   1, q =  1, e =   0.4, theta = -0.97, phi =  0.82, mass =  0.14
+Simulating Hadron
+Made Track: tt31  :7964571395376021535:    0.37    0.21 -0.97  0.82
+Made SmearedTrack: ts22  :7955563947858329622:    0.36    0.21 -0.97  0.82
+Rejected SmearedTrack: ts22  :7955563947858329622:    0.36    0.21 -0.97  0.82
+Made Cluster: et57  :3352862569871179833:    0.15 -1.43 -1.77 sub(et57, )
+Made SmearedCluster: es42  :3343876289204322346:    0.34 -1.43 -1.77 sub(es42, )
+Rejected SmearedCluster: es42  :3343876289204322346:    0.34 -1.43 -1.77 sub(es42, )
+Made Cluster: ht34  :5658719618135490594:    0.25 -1.50 -2.02 sub(ht34, )
+Made SmearedCluster: hs17  :5649702258768609297:    0.17 -1.50 -2.02 sub(hs17, )
+Rejected SmearedCluster: hs17  :5649702258768609297:    0.17 -1.50 -2.02 sub(hs17, )
+Simulating Particle :ps64  :10261405366675832896: pdgid =  -211, status =   1, q = -1, e =   0.3, theta = -0.58, phi = -1.97, mass =  0.14
+Simulating Hadron
+Made Track: tt32  :7964567453644619808:    0.31    0.26 -0.58 -1.97
+Made SmearedTrack: ts22  :7955560069494472726:    0.31    0.26 -0.58 -1.97
+Rejected SmearedTrack: ts22  :7955560069494472726:    0.31    0.26 -0.58 -1.97
+Made Cluster: et58  :3352873884511633466:    0.23 -1.25 -0.52 sub(et58, )
+Made SmearedCluster: es42  :3343865595119534122:    0.22 -1.25 -0.52 sub(es42, )
+Rejected SmearedCluster: es42  :3343865595119534122:    0.22 -1.25 -0.52 sub(es42, )
+Made Cluster: ht35  :5658699470775255075:    0.11 -1.29 -0.08 sub(ht35, )
+Made SmearedCluster: hs17  :5647513932722602001:   -0.43 -1.29 -0.08 sub(hs17, )
+Rejected SmearedCluster: hs17  :5647513932722602001:   -0.43 -1.29 -0.08 sub(hs17, )
+Simulating Particle :ps65  :10261405078363570241: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.91, phi = -1.80, mass =  0.00
+Simulating Photon
+Made Cluster: et59  :3352883249977229371:    0.34  0.91 -1.80 sub(et59, )
+Made SmearedCluster: es42  :3343880313255231530:    0.40  0.91 -1.80 sub(es42, )
+Rejected SmearedCluster: es42  :3343880313255231530:    0.40  0.91 -1.80 sub(es42, )
+Simulating Particle :ps66  :10261403136008650818: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.49, phi = -1.80, mass =  0.00
+Simulating Photon
+Made Cluster: et60  :3352881307622309948:    0.31  0.49 -1.80 sub(et60, )
+Made SmearedCluster: es42  :3343872071313653802:    0.28  0.49 -1.80 sub(es42, )
+Rejected SmearedCluster: es42  :3343872071313653802:    0.28  0.49 -1.80 sub(es42, )
+Simulating Particle :ps67  :10261399042068054083: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -1.22, phi =  0.46, mass =  0.00
+Simulating Photon
+Made Cluster: et61  :3352877213681713213:    0.25 -1.22  0.46 sub(et61, )
+Made SmearedCluster: es42  :3343874322652463146:    0.31 -1.22  0.46 sub(es42, )
+Rejected SmearedCluster: es42  :3343874322652463146:    0.31 -1.22  0.46 sub(es42, )
+Simulating Particle :ps68  :10261397730926526532: pdgid =    11, status =   1, q = -1, e =   0.2, theta =  1.02, phi =  1.12, mass =  0.00
+Simulating Electron
+Made Track: tt33  :7964561920892076065:    0.24    0.13  1.02  1.12
+Made SmearedTrack: ts22  :7955552256491782166:    0.22    0.12  1.02  1.12
+Rejected SmearedTrack: ts22  :7955552256491782166:    0.22    0.12  1.02  1.12
+Simulating Particle :ps69  :10261392248644042821: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.06, phi =  2.65, mass =  0.00
+Simulating Photon
+Made Cluster: et62  :3352870420257701950:    0.20  0.06  2.65 sub(et62, )
+Made SmearedCluster: es42  :3343866260615069738:    0.22  0.06  2.65 sub(es42, )
+Rejected SmearedCluster: es42  :3343866260615069738:    0.22  0.06  2.65 sub(es42, )
+Simulating Particle :ps70  :10261391879339769926: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.82, phi = -1.34, mass =  0.00
+Simulating Photon
+Made Cluster: et63  :3352870050953429055:    0.20 -0.82 -1.34 sub(et63, )
+Made SmearedCluster: es42  :3343869224964587562:    0.24 -0.82 -1.34 sub(es42, )
+Rejected SmearedCluster: es42  :3343869224964587562:    0.24 -0.82 -1.34 sub(es42, )
+Simulating Particle :ps72  :10261389074317181000: pdgid =   -11, status =   1, q =  1, e =   0.2, theta =  1.02, phi =  1.11, mass =  0.00
+Simulating Electron
+Made Track: tt34  :7964553264255467554:    0.18    0.09  1.02  1.11
+Made SmearedTrack: ts22  :7955529343174705174:    0.09    0.05  1.02  1.11
+Rejected SmearedTrack: ts22  :7955529343174705174:    0.09    0.05  1.02  1.11
+Simulating Particle :ps74  :10261381693856284746: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.99, phi =  1.71, mass =  0.00
+Simulating Photon
+Made Cluster: et64  :3352859865469943872:    0.13  0.99  1.71 sub(et64, )
+Made SmearedCluster: es42  :3343840119848173610:    0.08  0.99  1.71 sub(es42, )
+Rejected SmearedCluster: es42  :3343840119848173610:    0.08  0.99  1.71 sub(es42, )
+Simulating Particle :ps75  :10261381537343733835: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.66, phi =  1.45, mass =  0.00
+Simulating Photon
+Made Cluster: et65  :3352859708957392961:    0.13 -0.66  1.45 sub(et65, )
+Made SmearedCluster: es42  :3343837029914902570:    0.07 -0.66  1.45 sub(es42, )
+Rejected SmearedCluster: es42  :3343837029914902570:    0.07 -0.66  1.45 sub(es42, )
+Simulating Particle :ps76  :10261376325218467916: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.13, phi =  0.87, mass =  0.00
+Simulating Photon
+Made Cluster: et66  :3352854496832127042:    0.11 -0.13  0.87 sub(et66, )
+Made SmearedCluster: es42  :3343842501101355050:    0.09 -0.13  0.87 sub(es42, )
+Rejected SmearedCluster: es42  :3343842501101355050:    0.09 -0.13  0.87 sub(es42, )
+Simulating Particle :ps77  :10261372189276110925: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.60, phi =  1.22, mass =  0.00
+Simulating Photon
+Made Cluster: et67  :3352850360889770051:    0.09 -0.60  1.22 sub(et67, )
+Made SmearedCluster: es42  :3343838469620236330:    0.08 -0.60  1.22 sub(es42, )
+Rejected SmearedCluster: es42  :3343838469620236330:    0.08 -0.60  1.22 sub(es42, )
+Simulating Particle :ps78  :10261368849454596174: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.75, phi = -2.99, mass =  0.00
+Simulating Photon
+Made Cluster: et68  :3352847021068255300:    0.08 -0.75 -2.99 sub(et68, )
+Made SmearedCluster: es42  :3343828967072202794:    0.05 -0.75 -2.99 sub(es42, )
+Rejected SmearedCluster: es42  :3343828967072202794:    0.05 -0.75 -2.99 sub(es42, )
+Simulating Particle :ps79  :10261367740214280271: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.76, phi = -3.05, mass =  0.00
+Simulating Photon
+Made Cluster: et69  :3352845911827939397:    0.08  0.76 -3.05 sub(et69, )
+Made SmearedCluster: es42  :3343845673777758250:    0.10  0.76 -3.05 sub(es42, )
+Rejected SmearedCluster: es42  :3343845673777758250:    0.10  0.76 -3.05 sub(es42, )
+Simulating Particle :ps80  :10261367433736486992: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.35, phi =  0.73, mass =  0.00
+Simulating Photon
+Made Cluster: et70  :3352845605350146118:    0.08  0.35  0.73 sub(et70, )
+Made SmearedCluster: es42  :3343845134069399594:    0.10  0.35  0.73 sub(es42, )
+Rejected SmearedCluster: es42  :3343845134069399594:    0.10  0.35  0.73 sub(es42, )
+Simulating Particle :ps81  :10261365843860389969: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -1.32, phi =  1.46, mass =  0.00
+Simulating Photon
+Made Cluster: et71  :3352844015474049095:    0.07 -1.32  1.46 sub(et71, )
+Made SmearedCluster: es42  :3343782172476571690:    0.01 -1.32  1.46 sub(es42, )
+Rejected SmearedCluster: es42  :3343782172476571690:    0.01 -1.32  1.46 sub(es42, )
+Simulating Particle :ps82  :10261360712372715602: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.05, phi =  1.30, mass =  0.00
+Simulating Photon
+Made Cluster: et72  :3352838883986374728:    0.06 -0.05  1.30 sub(et72, )
+Made SmearedCluster: es42  :3343845766283132970:    0.10 -0.05  1.30 sub(es42, )
+Rejected SmearedCluster: es42  :3343845766283132970:    0.10 -0.05  1.30 sub(es42, )
+Simulating Particle :ps83  :10261349530056261715: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.02, phi =  2.90, mass =  0.00
+Simulating Photon
+Made Cluster: et73  :3352827701669920841:    0.04 -0.02  2.90 sub(et73, )
+Made SmearedCluster: es42  :3343802077926129706:    0.02 -0.02  2.90 sub(es42, )
+Rejected SmearedCluster: es42  :3343802077926129706:    0.02 -0.02  2.90 sub(es42, )
+Simulating Particle :ps84  :10261338424130666580: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  0.49, phi = -1.96, mass =  0.00
+Simulating Photon
+Made Cluster: et74  :3352816595744325706:    0.02  0.49 -1.96 sub(et74, )
+Made SmearedCluster: es42  :3343804397302841386:    0.02  0.49 -1.96 sub(es42, )
+Rejected SmearedCluster: es42  :3343804397302841386:    0.02  0.49 -1.96 sub(es42, )
+Made MergedCluster: em0   :3289844450511028224:    0.50  1.43  2.61 sub(es40, )
+Made MergedCluster: em1   :3289844733425221633:    0.51  1.16  2.95 sub(es34, )
+Made MergedCluster: em2   :3289844778323148802:    0.51 -0.94  0.85 sub(es39, )
+Made MergedCluster: em3   :3289844913753030659:    0.52  1.38  1.15 sub(es36, )
+Made MergedCluster: em4   :3289845462841950212:    0.53  0.99  0.49 sub(es32, )
+Made MergedCluster: em5   :3289845485384237061:    0.53 -1.12  1.41 sub(es35, )
+Made MergedCluster: em6   :3289845619922829318:    0.54  0.16  1.45 sub(es41, )
+Made MergedCluster: em7   :3289846094952923143:    0.55 -1.20 -1.09 sub(es29, )
+Made MergedCluster: em8   :3289846418499436552:    0.56 -0.14 -2.35 sub(es38, )
+Made MergedCluster: em9   :3289846420487536649:    0.56 -0.68 -0.91 sub(es24, )
+Made MergedCluster: em10  :3289847815020216330:    0.60 -0.63 -1.62 sub(es33, )
+Made MergedCluster: em11  :3289848345712918539:    0.61  1.30  1.83 sub(es22, )
+Made MergedCluster: em12  :3289848425536815116:    0.62 -1.30  1.24 sub(es37, )
+Made MergedCluster: em13  :3289848862795104269:    0.63  0.29  0.69 sub(es25, )
+Made MergedCluster: em14  :3289849056265764878:    0.63 -1.18  0.80 sub(es27, )
+Made MergedCluster: em15  :3289849484254642191:    0.65 -1.09  1.62 sub(es8, )
+Made MergedCluster: em16  :3289849849935036432:    0.66 -0.12 -1.26 sub(es31, )
+Made MergedCluster: em17  :3289850284454445073:    0.67 -0.60 -0.89 sub(es10, )
+Made MergedCluster: em18  :3289852507584462866:    0.73 -1.18  1.17 sub(es21, )
+Made MergedCluster: em19  :3289852994620751891:    0.75 -0.05 -0.78 sub(es26, )
+Made MergedCluster: em20  :3289853624638767124:    0.76 -0.87  1.84 sub(es28, )
+Made MergedCluster: em21  :3289854393754583061:    0.79  0.15 -2.03 sub(es13, )
+Made MergedCluster: em22  :3289856222791991318:    0.84  0.86  0.82 sub(es23, )
+Made MergedCluster: em23  :3289856500159217687:    0.85  1.19  1.63 sub(es2, )
+Made MergedCluster: em24  :3289856611130015768:    0.85 -0.32 -1.35 sub(es30, )
+Made MergedCluster: em25  :3289858870553346073:    0.91  0.16 -2.81 sub(es4, )
+Made MergedCluster: em26  :3289859931051655194:    0.94 -0.70 -2.79 sub(es12, )
+Made MergedCluster: em27  :3289862301112336411:    1.02 -0.93  0.12 sub(es19, )
+Made MergedCluster: em28  :3289863047799111708:    1.06 -1.38  0.75 sub(es16, )
+Made MergedCluster: em29  :3289864278691020829:    1.13  0.89  1.17 sub(es14, )
+Made MergedCluster: em30  :3289866186579247134:    1.24  1.19  1.72 sub(es20, )
+Made MergedCluster: em31  :3289866356641497119:    1.25 -1.24  0.84 sub(es15, )
+Made MergedCluster: em32  :3289867714809561120:    1.33 -1.13  1.30 sub(es17, )
+Made MergedCluster: em33  :3289868127170461729:    1.35  0.79  1.11 sub(es18, )
+Made MergedCluster: em34  :3289868546873491490:    1.38 -0.95 -0.64 sub(es9, )
+Made MergedCluster: em35  :3289870921417883683:    1.51 -1.07 -1.59 sub(es5, )
+Made MergedCluster: em36  :3289871439093563428:    1.54  0.38  0.77 sub(es11, )
+Made MergedCluster: em37  :3289881404086681637:    2.21  0.82  1.17 sub(es7, )
+Made MergedCluster: em38  :3289882385841127462:    2.32  0.17 -2.37 sub(es0, )
+Made MergedCluster: em39  :3289883343987933223:    2.43 -0.85 -1.05 sub(es6, )
+Made MergedCluster: em40  :3289886607210971176:    2.80  0.87  1.17 sub(es1, )
+Made MergedCluster: em41  :3289890075545960489:    3.20  0.90  1.35 sub(es3, )
+Made MergedCluster: hm0   :5595706053397315584:    1.06  0.17 -2.37 sub(hs1, )
+Made MergedCluster: hm1   :5595706410791862273:    1.08  0.11  0.42 sub(hs16, )
+Made MergedCluster: hm2   :5595708481064665090:    1.20 -0.99 -0.06 sub(hs15, )
+Made MergedCluster: hm3   :5595710149514756099:    1.30  0.88  2.22 sub(hs12, )
+Made MergedCluster: hm4   :5595710620423946244:    1.32 -0.94 -1.84 sub(hs9, )
+Made MergedCluster: hm5   :5595711993144147973:    1.40 -1.39  0.69 sub(hs14, )
+Made MergedCluster: hm6   :5595712481675706374:    1.43 -1.09  1.66 sub(hs6, )
+Made MergedCluster: hm7   :5595721242983268359:    1.93 -1.07  0.87 sub(hs7, )
+Made MergedCluster: hm8   :5595723558138413064:    2.12  0.16 -2.84 sub(hs4, )
+Made MergedCluster: hm9   :5595749562179387401:    6.14 -0.05 -2.12 sub(hs0, hs5, )
+Made MergedCluster: hm10  :5595724044719620106:    2.17  0.92  0.23 sub(hs10, )
+Made MergedCluster: hm11  :5595725053130965003:    2.29 -0.60 -0.89 sub(hs8, )
+Made MergedCluster: hm12  :5595725632590839820:    2.35 -1.29 -0.21 sub(hs13, )
+Made MergedCluster: hm13  :5595726515925942285:    2.45  1.06  0.73 sub(hs11, )
+Made MergedCluster: hm14  :5595728236175687694:    2.65  1.19  1.66 sub(hs3, )
+Made MergedCluster: hm15  :5595734964145487887:    3.41  0.75  1.74 sub(hs2, )
+Made block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.5 (3289844450511028224)
+
+Made block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.5 (3289844733425221633)
+
+Made block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.5 (3289844778323148802)
+
+Made block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.5 (3289844913753030659)
+
+Made block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.5 (3289845462841950212)
+
+Made block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.5 (3289845485384237061)
+
+Made block:E1       :br6   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.5 (3289845619922829318)
+
+Made block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.5 (3289846094952923143)
+
+Made block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.6 (3289846418499436552)
+
+Made block:E1H1T1   :br9   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts17      value=  0.8 (7955583179752996881)
+      h1 = hm2       value=  1.2 (5595708481064665090)
+      e2 = em9       value=  0.6 (3289846420487536649)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  0.6 (3289847815020216330)
+
+Made block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  0.6 (3289848345712918539)
+
+Made block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  0.6 (3289848425536815116)
+
+Made block:E1       :br13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  0.6 (3289848862795104269)
+
+Made block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  0.6 (3289849056265764878)
+
+Made block:E1H1T1   :br15  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  2.3 (7955611329417445380)
+      h1 = hm6       value=  1.4 (5595712481675706374)
+      e2 = em15      value=  0.6 (3289849484254642191)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1       :br16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  0.7 (3289849849935036432)
+
+Made block:E1       :br17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  0.7 (3289850284454445073)
+
+Made block:E1       :br18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em18      value=  0.7 (3289852507584462866)
+
+Made block:E1T1     :br19  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts19      value=  0.8 (7955582677671739411)
+      e1 = em19      value=  0.7 (3289852994620751891)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em20      value=  0.8 (3289853624638767124)
+
+Made block:E1T1     :br21  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  1.4 (7955597739142676491)
+      e1 = em21      value=  0.8 (3289854393754583061)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  0.8 (3289856222791991318)
+
+Made block:E1       :br23  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  0.8 (3289856500159217687)
+
+Made block:E1       :br24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em24      value=  0.8 (3289856611130015768)
+
+Made block:E1H1T1   :br25  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts1       value=  2.8 (7955615389073801217)
+      h1 = hm8       value=  2.1 (5595723558138413064)
+      e2 = em25      value=  0.9 (3289858870553346073)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1T1     :br26  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  1.7 (7955603034967375882)
+      e1 = em26      value=  0.9 (3289859931051655194)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :br27  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.0 (7955589488223191054)
+      e1 = em27      value=  1.0 (3289862301112336411)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em28      value=  1.1 (3289863047799111708)
+
+Made block:E1       :br29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em29      value=  1.1 (3289864278691020829)
+
+Made block:E1       :br30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em30      value=  1.2 (3289866186579247134)
+
+Made block:E1       :br31  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em31      value=  1.3 (3289866356641497119)
+
+Made block:E1       :br32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em32      value=  1.3 (3289867714809561120)
+
+Made block:E1       :br33  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em33      value=  1.4 (3289868127170461729)
+
+Made block:E1T1     :br34  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts5       value=  2.2 (7955610562226814981)
+      e1 = em34      value=  1.4 (3289868546873491490)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :br35  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts2       value=  2.5 (7955613483639242754)
+      e1 = em35      value=  1.5 (3289870921417883683)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br36  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em36      value=  1.5 (3289871439093563428)
+
+Made block:E1       :br37  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em37      value=  2.2 (3289881404086681637)
+
+Made block:E1       :br38  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em38      value=  2.3 (3289882385841127462)
+
+Made block:E1       :br39  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em39      value=  2.4 (3289883343987933223)
+
+Made block:E1       :br40  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em40      value=  2.8 (3289886607210971176)
+
+Made block:E1       :br41  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em41      value=  3.2 (3289890075545960489)
+
+Made block:H1       :br42  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm0       value=  1.1 (5595706053397315584)
+
+Made block:H1T1     :br43  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts18      value=  0.8 (7955582924252774418)
+      h1 = hm1       value=  1.1 (5595706410791862273)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br44  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  1.8 (7955605815176462345)
+      h1 = hm3       value=  1.3 (5595710149514756099)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br45  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  2.1 (7955609229084065798)
+      h1 = hm4       value=  1.3 (5595710620423946244)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1       :br46  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  1.4 (5595711993144147973)
+
+Made block:H1       :br47  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm7       value=  1.9 (5595721242983268359)
+
+Made block:H1T1     :br48  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  2.0 (7955607963964538887)
+      h1 = hm10      value=  2.2 (5595724044719620106)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br49  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts15      value=  0.9 (7955586786959294479)
+      h1 = hm11      value=  2.3 (5595725053130965003)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.2277       .
+
+Made block:H1       :br50  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm12      value=  2.4 (5595725632590839820)
+
+Made block:H1T1     :br51  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts8       value=  1.8 (7955605871996698632)
+      h1 = hm13      value=  2.5 (5595726515925942285)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1       :br52  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm14      value=  2.6 (5595728236175687694)
+
+Made block:H1T1     :br53  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts0       value=  2.9 (7955616473301385216)
+      h1 = hm15      value=  3.4 (5595734964145487887)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br54  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  2.5 (7955613110702702595)
+      h1 = hm9       value=  6.1 (5595749562179387401)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:T1       :br55  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts21      value=  0.5 (7955575129830850581)
+
+Made block:T1       :br56  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts20      value=  0.6 (7955578815346901012)
+
+Made block:T1       :br57  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  0.8 (7955584299776868368)
+
+Made block:T1       :br58  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.0 (7955590404791861261)
+
+Made block:T1       :br59  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.3 (7955596590849196044)
+
+Splitting block:E1H1T1   :br25  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts1       value=  2.8 (7955615389073801217)
+      h1 = hm8       value=  2.1 (5595723558138413064)
+      e2 = em25      value=  0.9 (3289858870553346073)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs0   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts1       value=  2.8 (7955615389073801217)
+      h1 = hm8       value=  2.1 (5595723558138413064)
+      e2 = em25      value=  0.9 (3289858870553346073)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:E1H1T1   :br15  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  2.3 (7955611329417445380)
+      h1 = hm6       value=  1.4 (5595712481675706374)
+      e2 = em15      value=  0.6 (3289849484254642191)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs1   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  2.3 (7955611329417445380)
+      h1 = hm6       value=  1.4 (5595712481675706374)
+      e2 = em15      value=  0.6 (3289849484254642191)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:E1H1T1   :br9   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts17      value=  0.8 (7955583179752996881)
+      h1 = hm2       value=  1.2 (5595708481064665090)
+      e2 = em9       value=  0.6 (3289846420487536649)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts17      value=  0.8 (7955583179752996881)
+      h1 = hm2       value=  1.2 (5595708481064665090)
+      e2 = em9       value=  0.6 (3289846420487536649)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:H1T1     :br54  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  2.5 (7955613110702702595)
+      h1 = hm9       value=  6.1 (5595749562179387401)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs3   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  2.5 (7955613110702702595)
+      h1 = hm9       value=  6.1 (5595749562179387401)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br53  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts0       value=  2.9 (7955616473301385216)
+      h1 = hm15      value=  3.4 (5595734964145487887)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs4   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts0       value=  2.9 (7955616473301385216)
+      h1 = hm15      value=  3.4 (5595734964145487887)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br51  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts8       value=  1.8 (7955605871996698632)
+      h1 = hm13      value=  2.5 (5595726515925942285)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs5   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts8       value=  1.8 (7955605871996698632)
+      h1 = hm13      value=  2.5 (5595726515925942285)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br49  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts15      value=  0.9 (7955586786959294479)
+      h1 = hm11      value=  2.3 (5595725053130965003)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.2277       .
+
+Made block:H1T1     :bs6   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts15      value=  0.9 (7955586786959294479)
+      h1 = hm11      value=  2.3 (5595725053130965003)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.2277       .
+
+Splitting block:H1T1     :br48  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  2.0 (7955607963964538887)
+      h1 = hm10      value=  2.2 (5595724044719620106)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs7   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  2.0 (7955607963964538887)
+      h1 = hm10      value=  2.2 (5595724044719620106)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br45  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  2.1 (7955609229084065798)
+      h1 = hm4       value=  1.3 (5595710620423946244)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs8   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  2.1 (7955609229084065798)
+      h1 = hm4       value=  1.3 (5595710620423946244)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br44  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  1.8 (7955605815176462345)
+      h1 = hm3       value=  1.3 (5595710149514756099)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs9   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  1.8 (7955605815176462345)
+      h1 = hm3       value=  1.3 (5595710149514756099)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br43  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts18      value=  0.8 (7955582924252774418)
+      h1 = hm1       value=  1.1 (5595706410791862273)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs10  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts18      value=  0.8 (7955582924252774418)
+      h1 = hm1       value=  1.1 (5595706410791862273)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:E1T1     :br35  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts2       value=  2.5 (7955613483639242754)
+      e1 = em35      value=  1.5 (3289870921417883683)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs11  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts2       value=  2.5 (7955613483639242754)
+      e1 = em35      value=  1.5 (3289870921417883683)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br34  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts5       value=  2.2 (7955610562226814981)
+      e1 = em34      value=  1.4 (3289868546873491490)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs12  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts5       value=  2.2 (7955610562226814981)
+      e1 = em34      value=  1.4 (3289868546873491490)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br27  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.0 (7955589488223191054)
+      e1 = em27      value=  1.0 (3289862301112336411)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs13  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.0 (7955589488223191054)
+      e1 = em27      value=  1.0 (3289862301112336411)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br26  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  1.7 (7955603034967375882)
+      e1 = em26      value=  0.9 (3289859931051655194)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs14  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  1.7 (7955603034967375882)
+      e1 = em26      value=  0.9 (3289859931051655194)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br21  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  1.4 (7955597739142676491)
+      e1 = em21      value=  0.8 (3289854393754583061)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs15  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  1.4 (7955597739142676491)
+      e1 = em21      value=  0.8 (3289854393754583061)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br19  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts19      value=  0.8 (7955582677671739411)
+      e1 = em19      value=  0.7 (3289852994620751891)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs16  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts19      value=  0.8 (7955582677671739411)
+      e1 = em19      value=  0.7 (3289852994620751891)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:T1       :br59  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.3 (7955596590849196044)
+
+Made block:T1       :bs17  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.3 (7955596590849196044)
+
+Splitting block:T1       :br58  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.0 (7955590404791861261)
+
+Made block:T1       :bs18  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.0 (7955590404791861261)
+
+Splitting block:T1       :br57  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  0.8 (7955584299776868368)
+
+Made block:T1       :bs19  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  0.8 (7955584299776868368)
+
+Splitting block:T1       :br56  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts20      value=  0.6 (7955578815346901012)
+
+Made block:T1       :bs20  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts20      value=  0.6 (7955578815346901012)
+
+Splitting block:T1       :br55  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts21      value=  0.5 (7955575129830850581)
+
+Made block:T1       :bs21  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts21      value=  0.5 (7955575129830850581)
+
+Splitting block:H1       :br52  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm14      value=  2.6 (5595728236175687694)
+
+Made block:H1       :bs22  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm14      value=  2.6 (5595728236175687694)
+
+Splitting block:H1       :br50  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm12      value=  2.4 (5595725632590839820)
+
+Made block:H1       :bs23  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm12      value=  2.4 (5595725632590839820)
+
+Splitting block:H1       :br47  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm7       value=  1.9 (5595721242983268359)
+
+Made block:H1       :bs24  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm7       value=  1.9 (5595721242983268359)
+
+Splitting block:H1       :br46  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  1.4 (5595711993144147973)
+
+Made block:H1       :bs25  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  1.4 (5595711993144147973)
+
+Splitting block:H1       :br42  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm0       value=  1.1 (5595706053397315584)
+
+Made block:H1       :bs26  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm0       value=  1.1 (5595706053397315584)
+
+Splitting block:E1       :br41  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em41      value=  3.2 (3289890075545960489)
+
+Made block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em41      value=  3.2 (3289890075545960489)
+
+Splitting block:E1       :br40  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em40      value=  2.8 (3289886607210971176)
+
+Made block:E1       :bs28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em40      value=  2.8 (3289886607210971176)
+
+Splitting block:E1       :br39  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em39      value=  2.4 (3289883343987933223)
+
+Made block:E1       :bs29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em39      value=  2.4 (3289883343987933223)
+
+Splitting block:E1       :br38  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em38      value=  2.3 (3289882385841127462)
+
+Made block:E1       :bs30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em38      value=  2.3 (3289882385841127462)
+
+Splitting block:E1       :br37  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em37      value=  2.2 (3289881404086681637)
+
+Made block:E1       :bs31  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em37      value=  2.2 (3289881404086681637)
+
+Splitting block:E1       :br36  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em36      value=  1.5 (3289871439093563428)
+
+Made block:E1       :bs32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em36      value=  1.5 (3289871439093563428)
+
+Splitting block:E1       :br33  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em33      value=  1.4 (3289868127170461729)
+
+Made block:E1       :bs33  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em33      value=  1.4 (3289868127170461729)
+
+Splitting block:E1       :br32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em32      value=  1.3 (3289867714809561120)
+
+Made block:E1       :bs34  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em32      value=  1.3 (3289867714809561120)
+
+Splitting block:E1       :br31  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em31      value=  1.3 (3289866356641497119)
+
+Made block:E1       :bs35  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em31      value=  1.3 (3289866356641497119)
+
+Splitting block:E1       :br30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em30      value=  1.2 (3289866186579247134)
+
+Made block:E1       :bs36  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em30      value=  1.2 (3289866186579247134)
+
+Splitting block:E1       :br29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em29      value=  1.1 (3289864278691020829)
+
+Made block:E1       :bs37  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em29      value=  1.1 (3289864278691020829)
+
+Splitting block:E1       :br28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em28      value=  1.1 (3289863047799111708)
+
+Made block:E1       :bs38  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em28      value=  1.1 (3289863047799111708)
+
+Splitting block:E1       :br24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em24      value=  0.8 (3289856611130015768)
+
+Made block:E1       :bs39  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em24      value=  0.8 (3289856611130015768)
+
+Splitting block:E1       :br23  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  0.8 (3289856500159217687)
+
+Made block:E1       :bs40  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  0.8 (3289856500159217687)
+
+Splitting block:E1       :br22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  0.8 (3289856222791991318)
+
+Made block:E1       :bs41  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  0.8 (3289856222791991318)
+
+Splitting block:E1       :br20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em20      value=  0.8 (3289853624638767124)
+
+Made block:E1       :bs42  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em20      value=  0.8 (3289853624638767124)
+
+Splitting block:E1       :br18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em18      value=  0.7 (3289852507584462866)
+
+Made block:E1       :bs43  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em18      value=  0.7 (3289852507584462866)
+
+Splitting block:E1       :br17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  0.7 (3289850284454445073)
+
+Made block:E1       :bs44  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  0.7 (3289850284454445073)
+
+Splitting block:E1       :br16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  0.7 (3289849849935036432)
+
+Made block:E1       :bs45  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  0.7 (3289849849935036432)
+
+Splitting block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  0.6 (3289849056265764878)
+
+Made block:E1       :bs46  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  0.6 (3289849056265764878)
+
+Splitting block:E1       :br13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  0.6 (3289848862795104269)
+
+Made block:E1       :bs47  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  0.6 (3289848862795104269)
+
+Splitting block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  0.6 (3289848425536815116)
+
+Made block:E1       :bs48  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  0.6 (3289848425536815116)
+
+Splitting block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  0.6 (3289848345712918539)
+
+Made block:E1       :bs49  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  0.6 (3289848345712918539)
+
+Splitting block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  0.6 (3289847815020216330)
+
+Made block:E1       :bs50  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  0.6 (3289847815020216330)
+
+Splitting block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.6 (3289846418499436552)
+
+Made block:E1       :bs51  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.6 (3289846418499436552)
+
+Splitting block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.5 (3289846094952923143)
+
+Made block:E1       :bs52  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.5 (3289846094952923143)
+
+Splitting block:E1       :br6   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.5 (3289845619922829318)
+
+Made block:E1       :bs53  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.5 (3289845619922829318)
+
+Splitting block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.5 (3289845485384237061)
+
+Made block:E1       :bs54  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.5 (3289845485384237061)
+
+Splitting block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.5 (3289845462841950212)
+
+Made block:E1       :bs55  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.5 (3289845462841950212)
+
+Splitting block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.5 (3289844913753030659)
+
+Made block:E1       :bs56  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.5 (3289844913753030659)
+
+Splitting block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.5 (3289844778323148802)
+
+Made block:E1       :bs57  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.5 (3289844778323148802)
+
+Splitting block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.5 (3289844733425221633)
+
+Made block:E1       :bs58  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.5 (3289844733425221633)
+
+Splitting block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.5 (3289844450511028224)
+
+Made block:E1       :bs59  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.5 (3289844450511028224)
+
+Processing block:E1H1T1   :bs2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts17      value=  0.8 (7955583179752996881)
+      h1 = hm2       value=  1.2 (5595708481064665090)
+      e2 = em9       value=  0.6 (3289846420487536649)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr0   :10252419425659518976: pdgid =  -211, status =   1, q = -1, e =   0.8, theta = -0.54, phi = -2.22, mass =  0.14 from SmearedTrack: ts17  :7955583179752996881:    0.77    0.67 -0.54 -2.22
+Finished block
+Processing block:E1H1T1   :bs1   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  2.3 (7955611329417445380)
+      h1 = hm6       value=  1.4 (5595712481675706374)
+      e2 = em15      value=  0.6 (3289849484254642191)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr1   :10252447176382742529: pdgid =  -211, status =   1, q = -1, e =   2.3, theta = -1.08, phi =  1.24, mass =  0.14 from SmearedTrack: ts4   :7955611329417445380:    2.29    1.08 -1.08  1.24
+Finished block
+Processing block:E1H1T1   :bs0   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts1       value=  2.8 (7955615389073801217)
+      h1 = hm8       value=  2.1 (5595723558138413064)
+      e2 = em25      value=  0.9 (3289858870553346073)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr2   :10252451229848305666: pdgid =   211, status =   1, q =  1, e =   2.8, theta =  0.16, phi = -2.57, mass =  0.14 from SmearedTrack: ts1   :7955615389073801217:    2.76    2.72  0.16 -2.57
+Finished block
+Processing block:E1T1     :bs16  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts19      value=  0.8 (7955582677671739411)
+      e1 = em19      value=  0.7 (3289852994620751891)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr3   :10252418931637616643: pdgid =   211, status =   1, q =  1, e =   0.8, theta = -0.04, phi =  0.24, mass =  0.14 from SmearedTrack: ts19  :7955582677671739411:    0.76    0.76 -0.04  0.24
+Finished block
+Processing block:E1T1     :bs15  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  1.4 (7955597739142676491)
+      e1 = em21      value=  0.8 (3289854393754583061)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr4   :10252433672426749956: pdgid =  -211, status =   1, q = -1, e =   1.4, theta =  0.15, phi = -2.52, mass =  0.14 from SmearedTrack: ts11  :7955597739142676491:    1.37    1.36  0.15 -2.52
+Finished block
+Processing block:E1T1     :bs14  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  1.7 (7955603034967375882)
+      e1 = em26      value=  0.9 (3289859931051655194)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr5   :10252438946178924549: pdgid =   211, status =   1, q =  1, e =   1.7, theta = -0.68, phi = -2.27, mass =  0.14 from SmearedTrack: ts10  :7955603034967375882:    1.68    1.31 -0.68 -2.27
+Finished block
+Processing block:E1T1     :bs13  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.0 (7955589488223191054)
+      e1 = em27      value=  1.0 (3289862301112336411)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr6   :10252425653045428230: pdgid =  -211, status =   1, q = -1, e =   1.0, theta = -0.82, phi = -0.98, mass =  0.14 from SmearedTrack: ts14  :7955589488223191054:    0.95    0.65 -0.82 -0.98
+Finished block
+Processing block:E1T1     :bs12  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts5       value=  2.2 (7955610562226814981)
+      e1 = em34      value=  1.4 (3289868546873491490)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr7   :10252446410649632775: pdgid =  -211, status =   1, q = -1, e =   2.2, theta = -0.93, phi = -1.08, mass =  0.14 from SmearedTrack: ts5   :7955610562226814981:    2.21    1.32 -0.93 -1.08
+Finished block
+Processing block:E1T1     :bs11  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts2       value=  2.5 (7955613483639242754)
+      e1 = em35      value=  1.5 (3289870921417883683)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr8   :10252449327039381512: pdgid =   211, status =   1, q =  1, e =   2.5, theta = -1.06, phi = -1.24, mass =  0.14 from SmearedTrack: ts2   :7955613483639242754:    2.54    1.23 -1.06 -1.24
+Finished block
+Processing block:H1T1     :bs10  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts18      value=  0.8 (7955582924252774418)
+      h1 = hm1       value=  1.1 (5595706410791862273)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr9   :10252419174223577097: pdgid =   211, status =   1, q =  1, e =   0.8, theta =  0.08, phi =  1.65, mass =  0.14 from SmearedTrack: ts18  :7955582924252774418:    0.77    0.76  0.08  1.65
+Finished block
+Processing block:H1T1     :bs9   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  1.8 (7955605815176462345)
+      h1 = hm3       value=  1.3 (5595710149514756099)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr10  :10252441717684830218: pdgid =  -211, status =   1, q = -1, e =   1.8, theta =  0.84, phi =  1.59, mass =  0.14 from SmearedTrack: ts9   :7955605815176462345:    1.83    1.22  0.84  1.59
+Finished block
+Processing block:H1T1     :bs8   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  2.1 (7955609229084065798)
+      h1 = hm4       value=  1.3 (5595710620423946244)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr11  :10252445080338038795: pdgid =   211, status =   1, q =  1, e =   2.1, theta = -0.92, phi = -1.32, mass =  0.14 from SmearedTrack: ts6   :7955609229084065798:    2.06    1.25 -0.92 -1.32
+Finished block
+Processing block:H1T1     :bs7   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  2.0 (7955607963964538887)
+      h1 = hm10      value=  2.2 (5595724044719620106)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr12  :10252443860709933068: pdgid =   211, status =   1, q =  1, e =   2.0, theta =  0.89, phi =  0.80, mass =  0.14 from SmearedTrack: ts7   :7955607963964538887:    1.96    1.23  0.89  0.80
+Finished block
+Processing block:H1T1     :bs6   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts15      value=  0.9 (7955586786959294479)
+      h1 = hm11      value=  2.3 (5595725053130965003)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.2277       .
+
+Made Particle :pr13  :10252422982515294221: pdgid =  -211, status =   1, q = -1, e =   0.9, theta = -0.49, phi = -1.99, mass =  0.14 from SmearedTrack: ts15  :7955586786959294479:    0.88    0.77 -0.49 -1.99
+Made Particle :pr14  :10252434173069361166: pdgid =   130, status =   1, q =  0, e =   1.4, theta = -0.60, phi = -0.89, mass =  0.50 from MergedCluster: hm11  :5595725053130965003:    2.29 -0.60 -0.89 sub(hs8, )
+Finished block
+Processing block:H1T1     :bs5   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts8       value=  1.8 (7955605871996698632)
+      h1 = hm13      value=  2.5 (5595726515925942285)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr15  :10252441774345682959: pdgid =   211, status =   1, q =  1, e =   1.8, theta =  1.04, phi =  1.26, mass =  0.14 from SmearedTrack: ts8   :7955605871996698632:    1.84    0.93  1.04  1.26
+Finished block
+Processing block:H1T1     :bs4   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts0       value=  2.9 (7955616473301385216)
+      h1 = hm15      value=  3.4 (5595734964145487887)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr16  :10252452312758878224: pdgid =  -211, status =   1, q = -1, e =   2.9, theta =  0.74, phi =  1.39, mass =  0.14 from SmearedTrack: ts0   :7955616473301385216:    2.88    2.14  0.74  1.39
+Finished block
+Processing block:H1T1     :bs3   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  2.5 (7955613110702702595)
+      h1 = hm9       value=  6.1 (5595749562179387401)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr17  :10252448954671169553: pdgid =  -211, status =   1, q = -1, e =   2.5, theta =  0.01, phi = -2.35, mass =  0.14 from SmearedTrack: ts3   :7955613110702702595:    2.50    2.50  0.01 -2.35
+Made Particle :pr18  :10252459048727216146: pdgid =   130, status =   1, q =  0, e =   3.6, theta = -0.05, phi = -2.12, mass =  0.50 from MergedCluster: hm9   :5595749562179387401:    6.14 -0.05 -2.12 sub(hs0, hs5, )
+Finished block
+Processing block:E1       :bs59  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.5 (3289844450511028224)
+
+Made Particle :pr19  :10252409474425815059: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  1.43, phi =  2.61, mass =  0.00 from MergedCluster: em0   :3289844450511028224:    0.50  1.43  2.61 sub(es40, )
+Finished block
+Processing block:E1       :bs58  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.5 (3289844733425221633)
+
+Made Particle :pr20  :10252409757340008468: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  1.16, phi =  2.95, mass =  0.00 from MergedCluster: em1   :3289844733425221633:    0.51  1.16  2.95 sub(es34, )
+Finished block
+Processing block:E1       :bs57  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.5 (3289844778323148802)
+
+Made Particle :pr21  :10252409802237935637: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.94, phi =  0.85, mass =  0.00 from MergedCluster: em2   :3289844778323148802:    0.51 -0.94  0.85 sub(es39, )
+Finished block
+Processing block:E1       :bs56  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.5 (3289844913753030659)
+
+Made Particle :pr22  :10252409937667817494: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  1.38, phi =  1.15, mass =  0.00 from MergedCluster: em3   :3289844913753030659:    0.52  1.38  1.15 sub(es36, )
+Finished block
+Processing block:E1       :bs55  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.5 (3289845462841950212)
+
+Made Particle :pr23  :10252410486756737047: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.99, phi =  0.49, mass =  0.00 from MergedCluster: em4   :3289845462841950212:    0.53  0.99  0.49 sub(es32, )
+Finished block
+Processing block:E1       :bs54  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.5 (3289845485384237061)
+
+Made Particle :pr24  :10252410509299023896: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -1.12, phi =  1.41, mass =  0.00 from MergedCluster: em5   :3289845485384237061:    0.53 -1.12  1.41 sub(es35, )
+Finished block
+Processing block:E1       :bs53  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.5 (3289845619922829318)
+
+Made Particle :pr25  :10252410643837616153: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.16, phi =  1.45, mass =  0.00 from MergedCluster: em6   :3289845619922829318:    0.54  0.16  1.45 sub(es41, )
+Finished block
+Processing block:E1       :bs52  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.5 (3289846094952923143)
+
+Made Particle :pr26  :10252411118867709978: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -1.20, phi = -1.09, mass =  0.00 from MergedCluster: em7   :3289846094952923143:    0.55 -1.20 -1.09 sub(es29, )
+Finished block
+Processing block:E1       :bs51  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.6 (3289846418499436552)
+
+Made Particle :pr27  :10252411442414223387: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.14, phi = -2.35, mass =  0.00 from MergedCluster: em8   :3289846418499436552:    0.56 -0.14 -2.35 sub(es38, )
+Finished block
+Processing block:E1       :bs50  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  0.6 (3289847815020216330)
+
+Made Particle :pr28  :10252412838935003164: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.63, phi = -1.62, mass =  0.00 from MergedCluster: em10  :3289847815020216330:    0.60 -0.63 -1.62 sub(es33, )
+Finished block
+Processing block:E1       :bs49  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  0.6 (3289848345712918539)
+
+Made Particle :pr29  :10252413369627705373: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  1.30, phi =  1.83, mass =  0.00 from MergedCluster: em11  :3289848345712918539:    0.61  1.30  1.83 sub(es22, )
+Finished block
+Processing block:E1       :bs48  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  0.6 (3289848425536815116)
+
+Made Particle :pr30  :10252413449451601950: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -1.30, phi =  1.24, mass =  0.00 from MergedCluster: em12  :3289848425536815116:    0.62 -1.30  1.24 sub(es37, )
+Finished block
+Processing block:E1       :bs47  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  0.6 (3289848862795104269)
+
+Made Particle :pr31  :10252413886709891103: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.29, phi =  0.69, mass =  0.00 from MergedCluster: em13  :3289848862795104269:    0.63  0.29  0.69 sub(es25, )
+Finished block
+Processing block:E1       :bs46  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  0.6 (3289849056265764878)
+
+Made Particle :pr32  :10252414080180551712: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -1.18, phi =  0.80, mass =  0.00 from MergedCluster: em14  :3289849056265764878:    0.63 -1.18  0.80 sub(es27, )
+Finished block
+Processing block:E1       :bs45  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  0.7 (3289849849935036432)
+
+Made Particle :pr33  :10252414873849823265: pdgid =    22, status =   1, q =  0, e =   0.7, theta = -0.12, phi = -1.26, mass =  0.00 from MergedCluster: em16  :3289849849935036432:    0.66 -0.12 -1.26 sub(es31, )
+Finished block
+Processing block:E1       :bs44  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  0.7 (3289850284454445073)
+
+Made Particle :pr34  :10252415308369231906: pdgid =    22, status =   1, q =  0, e =   0.7, theta = -0.60, phi = -0.89, mass =  0.00 from MergedCluster: em17  :3289850284454445073:    0.67 -0.60 -0.89 sub(es10, )
+Finished block
+Processing block:E1       :bs43  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em18      value=  0.7 (3289852507584462866)
+
+Made Particle :pr35  :10252417531499249699: pdgid =    22, status =   1, q =  0, e =   0.7, theta = -1.18, phi =  1.17, mass =  0.00 from MergedCluster: em18  :3289852507584462866:    0.73 -1.18  1.17 sub(es21, )
+Finished block
+Processing block:E1       :bs42  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em20      value=  0.8 (3289853624638767124)
+
+Made Particle :pr36  :10252418648553553956: pdgid =    22, status =   1, q =  0, e =   0.8, theta = -0.87, phi =  1.84, mass =  0.00 from MergedCluster: em20  :3289853624638767124:    0.76 -0.87  1.84 sub(es28, )
+Finished block
+Processing block:E1       :bs41  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  0.8 (3289856222791991318)
+
+Made Particle :pr37  :10252421246706778149: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.86, phi =  0.82, mass =  0.00 from MergedCluster: em22  :3289856222791991318:    0.84  0.86  0.82 sub(es23, )
+Finished block
+Processing block:E1       :bs40  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  0.8 (3289856500159217687)
+
+Made Particle :pr38  :10252421524074004518: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  1.19, phi =  1.63, mass =  0.00 from MergedCluster: em23  :3289856500159217687:    0.85  1.19  1.63 sub(es2, )
+Finished block
+Processing block:E1       :bs39  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em24      value=  0.8 (3289856611130015768)
+
+Made Particle :pr39  :10252421635044802599: pdgid =    22, status =   1, q =  0, e =   0.8, theta = -0.32, phi = -1.35, mass =  0.00 from MergedCluster: em24  :3289856611130015768:    0.85 -0.32 -1.35 sub(es30, )
+Finished block
+Processing block:E1       :bs38  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em28      value=  1.1 (3289863047799111708)
+
+Made Particle :pr40  :10252428071713898536: pdgid =    22, status =   1, q =  0, e =   1.1, theta = -1.38, phi =  0.75, mass =  0.00 from MergedCluster: em28  :3289863047799111708:    1.06 -1.38  0.75 sub(es16, )
+Finished block
+Processing block:E1       :bs37  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em29      value=  1.1 (3289864278691020829)
+
+Made Particle :pr41  :10252429302605807657: pdgid =    22, status =   1, q =  0, e =   1.1, theta =  0.89, phi =  1.17, mass =  0.00 from MergedCluster: em29  :3289864278691020829:    1.13  0.89  1.17 sub(es14, )
+Finished block
+Processing block:E1       :bs36  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em30      value=  1.2 (3289866186579247134)
+
+Made Particle :pr42  :10252431210494033962: pdgid =    22, status =   1, q =  0, e =   1.2, theta =  1.19, phi =  1.72, mass =  0.00 from MergedCluster: em30  :3289866186579247134:    1.24  1.19  1.72 sub(es20, )
+Finished block
+Processing block:E1       :bs35  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em31      value=  1.3 (3289866356641497119)
+
+Made Particle :pr43  :10252431380556283947: pdgid =    22, status =   1, q =  0, e =   1.3, theta = -1.24, phi =  0.84, mass =  0.00 from MergedCluster: em31  :3289866356641497119:    1.25 -1.24  0.84 sub(es15, )
+Finished block
+Processing block:E1       :bs34  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em32      value=  1.3 (3289867714809561120)
+
+Made Particle :pr44  :10252432738724347948: pdgid =    22, status =   1, q =  0, e =   1.3, theta = -1.13, phi =  1.30, mass =  0.00 from MergedCluster: em32  :3289867714809561120:    1.33 -1.13  1.30 sub(es17, )
+Finished block
+Processing block:E1       :bs33  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em33      value=  1.4 (3289868127170461729)
+
+Made Particle :pr45  :10252433151085248557: pdgid =    22, status =   1, q =  0, e =   1.4, theta =  0.79, phi =  1.11, mass =  0.00 from MergedCluster: em33  :3289868127170461729:    1.35  0.79  1.11 sub(es18, )
+Finished block
+Processing block:E1       :bs32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em36      value=  1.5 (3289871439093563428)
+
+Made Particle :pr46  :10252436463008350254: pdgid =    22, status =   1, q =  0, e =   1.5, theta =  0.38, phi =  0.77, mass =  0.00 from MergedCluster: em36  :3289871439093563428:    1.54  0.38  0.77 sub(es11, )
+Finished block
+Processing block:E1       :bs31  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em37      value=  2.2 (3289881404086681637)
+
+Made Particle :pr47  :10252446428001468463: pdgid =    22, status =   1, q =  0, e =   2.2, theta =  0.82, phi =  1.17, mass =  0.00 from MergedCluster: em37  :3289881404086681637:    2.21  0.82  1.17 sub(es7, )
+Finished block
+Processing block:E1       :bs30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em38      value=  2.3 (3289882385841127462)
+
+Made Particle :pr48  :10252447409755914288: pdgid =    22, status =   1, q =  0, e =   2.3, theta =  0.17, phi = -2.37, mass =  0.00 from MergedCluster: em38  :3289882385841127462:    2.32  0.17 -2.37 sub(es0, )
+Finished block
+Processing block:E1       :bs29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em39      value=  2.4 (3289883343987933223)
+
+Made Particle :pr49  :10252448367902720049: pdgid =    22, status =   1, q =  0, e =   2.4, theta = -0.85, phi = -1.05, mass =  0.00 from MergedCluster: em39  :3289883343987933223:    2.43 -0.85 -1.05 sub(es6, )
+Finished block
+Processing block:E1       :bs28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em40      value=  2.8 (3289886607210971176)
+
+Made Particle :pr50  :10252451631125758002: pdgid =    22, status =   1, q =  0, e =   2.8, theta =  0.87, phi =  1.17, mass =  0.00 from MergedCluster: em40  :3289886607210971176:    2.80  0.87  1.17 sub(es1, )
+Finished block
+Processing block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em41      value=  3.2 (3289890075545960489)
+
+Made Particle :pr51  :10252455099460747315: pdgid =    22, status =   1, q =  0, e =   3.2, theta =  0.90, phi =  1.35, mass =  0.00 from MergedCluster: em41  :3289890075545960489:    3.20  0.90  1.35 sub(es3, )
+Finished block
+Processing block:H1       :bs26  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm0       value=  1.1 (5595706053397315584)
+
+Made Particle :pr52  :10252428068098408500: pdgid =   130, status =   1, q =  0, e =   1.1, theta =  0.17, phi = -2.37, mass =  0.50 from MergedCluster: hm0   :5595706053397315584:    1.06  0.17 -2.37 sub(hs1, )
+Finished block
+Processing block:H1       :bs25  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  1.4 (5595711993144147973)
+
+Made Particle :pr53  :10252434007845240885: pdgid =   130, status =   1, q =  0, e =   1.4, theta = -1.39, phi =  0.69, mass =  0.50 from MergedCluster: hm5   :5595711993144147973:    1.40 -1.39  0.69 sub(hs14, )
+Finished block
+Processing block:H1       :bs24  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm7       value=  1.9 (5595721242983268359)
+
+Made Particle :pr54  :10252443257684361270: pdgid =   130, status =   1, q =  0, e =   1.9, theta = -1.07, phi =  0.87, mass =  0.50 from MergedCluster: hm7   :5595721242983268359:    1.93 -1.07  0.87 sub(hs7, )
+Finished block
+Processing block:H1       :bs23  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm12      value=  2.4 (5595725632590839820)
+
+Made Particle :pr55  :10252447647291932727: pdgid =   130, status =   1, q =  0, e =   2.4, theta = -1.29, phi = -0.21, mass =  0.50 from MergedCluster: hm12  :5595725632590839820:    2.35 -1.29 -0.21 sub(hs13, )
+Finished block
+Processing block:H1       :bs22  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm14      value=  2.6 (5595728236175687694)
+
+Made Particle :pr56  :10252450250876780600: pdgid =   130, status =   1, q =  0, e =   2.6, theta =  1.19, phi =  1.66, mass =  0.50 from MergedCluster: hm14  :5595728236175687694:    2.65  1.19  1.66 sub(hs3, )
+Finished block
+Processing block:T1       :bs21  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts21      value=  0.5 (7955575129830850581)
+
+Made Particle :pr57  :10252411553968029753: pdgid =   211, status =   1, q =  1, e =   0.6, theta =  0.06, phi = -2.36, mass =  0.14 from SmearedTrack: ts21  :7955575129830850581:    0.54    0.54  0.06 -2.36
+Finished block
+Processing block:T1       :bs20  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts20      value=  0.6 (7955578815346901012)
+
+Made Particle :pr58  :10252415142817955898: pdgid =   211, status =   1, q =  1, e =   0.7, theta =  0.30, phi = -2.36, mass =  0.14 from SmearedTrack: ts20  :7955578815346901012:    0.65    0.62  0.30 -2.36
+Finished block
+Processing block:T1       :bs19  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  0.8 (7955584299776868368)
+
+Made Particle :pr59  :10252420528704847931: pdgid =  -211, status =   1, q = -1, e =   0.8, theta =  1.01, phi =  2.75, mass =  0.14 from SmearedTrack: ts16  :7955584299776868368:    0.81    0.43  1.01  2.75
+Finished block
+Processing block:T1       :bs18  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.0 (7955590404791861261)
+
+Made Particle :pr60  :10252426560267092028: pdgid =   211, status =   1, q =  1, e =   1.0, theta = -0.85, phi =  1.44, mass =  0.14 from SmearedTrack: ts13  :7955590404791861261:    0.98    0.64 -0.85  1.44
+Finished block
+Processing block:T1       :bs17  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.3 (7955596590849196044)
+
+Made Particle :pr61  :10252432530244370493: pdgid =   211, status =   1, q =  1, e =   1.3, theta =  0.01, phi = -2.17, mass =  0.14 from SmearedTrack: ts12  :7955596590849196044:    1.31    1.31  0.01 -2.17
+Finished block
+Finished reconstruction
+Event: 5
+Made Particle :ps0   :10261496002135457792: pdgid =   321, status =   1, q =  1, e =  12.1, theta =  0.59, phi = -0.23, mass =  0.49
+Made Particle :ps1   :10261495425783562241: pdgid =    22, status =   1, q =  0, e =  11.9, theta = -0.47, phi =  2.89, mass =  0.00
+Made Particle :ps2   :10261487869451304962: pdgid =   211, status =   1, q =  1, e =   8.4, theta = -0.54, phi =  2.87, mass =  0.14
+Made Particle :ps3   :10261480533299036163: pdgid =   211, status =   1, q =  1, e =   6.5, theta = -0.50, phi =  2.97, mass =  0.14
+Made Particle :ps4   :10261480135240712196: pdgid =    22, status =   1, q =  0, e =   6.5, theta =  0.59, phi = -0.16, mass =  0.00
+Made Particle :ps5   :10261478167130669061: pdgid =  -321, status =   1, q = -1, e =   6.0, theta =  0.52, phi = -0.26, mass =  0.49
+Made Particle :ps6   :10261476957604544518: pdgid =  2212, status =   1, q =  1, e =   5.7, theta =  0.36, phi = -0.30, mass =  0.94
+Made Particle :ps7   :10261476059880882183: pdgid =    22, status =   1, q =  0, e =   5.5, theta = -0.47, phi =  2.89, mass =  0.00
+Made Particle :ps8   :10261469507885203464: pdgid = -2212, status =   1, q = -1, e =   4.0, theta =  0.43, phi = -0.32, mass =  0.94
+Made Particle :ps9   :10261464445490298889: pdgid =    22, status =   1, q =  0, e =   3.4, theta = -0.56, phi =  2.80, mass =  0.00
+Made Particle :ps10  :10261459361041743882: pdgid =    22, status =   1, q =  0, e =   2.9, theta = -0.48, phi =  2.92, mass =  0.00
+Made Particle :ps11  :10261457914803781643: pdgid =  -211, status =   1, q = -1, e =   2.7, theta = -0.35, phi =  2.74, mass =  0.14
+Made Particle :ps12  :10261453119296634892: pdgid =    22, status =   1, q =  0, e =   2.2, theta =  0.50, phi = -0.34, mass =  0.00
+Made Particle :ps13  :10261452067713318925: pdgid =  -211, status =   1, q = -1, e =   2.0, theta =  0.49, phi = -0.35, mass =  0.14
+Made Particle :ps14  :10261441313287176206: pdgid =   321, status =   1, q =  1, e =   1.4, theta = -0.45, phi = -0.83, mass =  0.49
+Made Particle :ps15  :10261437509003116559: pdgid =  -211, status =   1, q = -1, e =   1.2, theta =  0.37, phi = -0.05, mass =  0.14
+Made Particle :ps16  :10261433368291835920: pdgid =    22, status =   1, q =  0, e =   1.0, theta =  0.43, phi = -0.41, mass =  0.00
+Made Particle :ps17  :10261432543886704657: pdgid =   211, status =   1, q =  1, e =   1.0, theta = -0.87, phi =  2.34, mass =  0.14
+Made Particle :ps18  :10261429297233264658: pdgid =  -321, status =   1, q = -1, e =   0.9, theta = -0.95, phi =  2.41, mass =  0.49
+Made Particle :ps19  :10261428816710729747: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.64, phi = -0.13, mass =  0.00
+Made Particle :ps20  :10261427488546619412: pdgid =    22, status =   1, q =  0, e =   0.8, theta = -0.50, phi =  2.86, mass =  0.00
+Made Particle :ps21  :10261424404548288533: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.60, phi = -1.28, mass =  0.00
+Made Particle :ps22  :10261424226277785622: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.90, phi = -0.89, mass =  0.00
+Made Particle :ps23  :10261421671363641367: pdgid =  -211, status =   1, q = -1, e =   0.6, theta = -0.23, phi =  2.05, mass =  0.14
+Made Particle :ps24  :10261421113212928024: pdgid =   211, status =   1, q =  1, e =   0.6, theta =  0.75, phi =  0.10, mass =  0.14
+Made Particle :ps25  :10261418422527066137: pdgid =   211, status =   1, q =  1, e =   0.6, theta = -0.25, phi =  0.54, mass =  0.14
+Made Particle :ps26  :10261410238550769690: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.82, phi = -1.25, mass =  0.00
+Made Particle :ps27  :10261387785634054171: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.97, phi = -1.41, mass =  0.00
+Made Particle :ps28  :10261386880010420252: pdgid =  -211, status =   1, q = -1, e =   0.2, theta =  0.40, phi = -2.64, mass =  0.14
+Made Particle :ps29  :10261343164795191325: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -1.54, phi = -0.37, mass =  0.00
+Simulating Particle :ps0   :10261496002135457792: pdgid =   321, status =   1, q =  1, e =  12.1, theta =  0.59, phi = -0.23, mass =  0.49
+Simulating Hadron
+Made Track: tt0   :7964660170064134144:   12.11   10.07  0.59 -0.23
+Made SmearedTrack: ts0   :7955652551630651392:   11.92    9.91  0.59 -0.23
+Made Cluster: et0   :3352938957665992704:    3.03  0.59 -0.29 sub(et0, )
+Made SmearedCluster: es0   :3343931361141456896:    2.98  0.59 -0.29 sub(es0, )
+Made Cluster: ht0   :5658810526145183744:    9.10  0.59 -0.30 sub(ht0, )
+Made SmearedCluster: hs0   :5649797645667926016:    7.26  0.59 -0.30 sub(hs0, )
+Simulating Particle :ps1   :10261495425783562241: pdgid =    22, status =   1, q =  0, e =  11.9, theta = -0.47, phi =  2.89, mass =  0.00
+Simulating Photon
+Made Cluster: et1   :3352973597397221377:   11.86 -0.47  2.89 sub(et1, )
+Made SmearedCluster: es1   :3343968507718008833:   12.82 -0.47  2.89 sub(es1, )
+Simulating Particle :ps2   :10261487869451304962: pdgid =   211, status =   1, q =  1, e =   8.4, theta = -0.54, phi =  2.87, mass =  0.14
+Simulating Hadron
+Made Track: tt1   :7964652056950603777:    8.42    7.20 -0.54  2.87
+Made SmearedTrack: ts1   :7955644628502315009:    8.32    7.11 -0.54  2.87
+Made Cluster: et2   :3352912370537070594:    1.00 -0.55  2.78 sub(et2, )
+Made SmearedCluster: es2   :3343888953886375938:    0.54 -0.55  2.78 sub(es2, )
+Made Cluster: ht1   :5658805576310718465:    7.42 -0.55  2.77 sub(ht1, )
+Made SmearedCluster: hs1   :5649803823470870529:    9.32 -0.55  2.77 sub(hs1, )
+Simulating Particle :ps3   :10261480533299036163: pdgid =   211, status =   1, q =  1, e =   6.5, theta = -0.50, phi =  2.97, mass =  0.14
+Simulating Hadron
+Made Track: tt2   :7964644716794871810:    6.54    5.74 -0.50  2.97
+Made SmearedTrack: ts2   :7955637503124307970:    6.54    5.73 -0.50  2.97
+Made Cluster: ht2   :5658801714126389250:    6.54 -0.50  2.84 sub(ht2, )
+Made SmearedCluster: hs2   :5649783228985245698:    3.99 -0.50  2.84 sub(hs2, )
+Simulating Particle :ps4   :10261480135240712196: pdgid =    22, status =   1, q =  0, e =   6.5, theta =  0.59, phi = -0.16, mass =  0.00
+Simulating Photon
+Made Cluster: et3   :3352958306854371331:    6.45  0.59 -0.16 sub(et3, )
+Made SmearedCluster: es3   :3343952888496914435:    6.86  0.59 -0.16 sub(es3, )
+Simulating Particle :ps5   :10261478167130669061: pdgid =  -321, status =   1, q = -1, e =   6.0, theta =  0.52, phi = -0.26, mass =  0.49
+Simulating Hadron
+Made Track: tt3   :7964642267791097859:    5.99    5.21  0.52 -0.26
+Made SmearedTrack: ts3   :7955635072049086467:    5.99    5.21  0.52 -0.26
+Made Cluster: et4   :3352938643147718660:    2.99  0.52 -0.14 sub(et4, )
+Made SmearedCluster: es4   :3343926493685219332:    2.43  0.52 -0.14 sub(es4, )
+Made Cluster: ht3   :5658781859182542851:    3.01  0.52 -0.12 sub(ht3, )
+Made SmearedCluster: hs3   :5649783871003164675:    4.12  0.52 -0.12 sub(hs3, )
+Simulating Particle :ps6   :10261476957604544518: pdgid =  2212, status =   1, q =  1, e =   5.7, theta =  0.36, phi = -0.30, mass =  0.94
+Simulating Hadron
+Made Track: tt4   :7964640807575617540:    5.65    5.29  0.36 -0.30
+Made SmearedTrack: ts4   :7955633638882672644:    5.66    5.30  0.36 -0.30
+Made Cluster: ht4   :5658798138431897604:    5.73  0.36 -0.44 sub(ht4, )
+Made SmearedCluster: hs4   :5649786741490450436:    4.78  0.36 -0.44 sub(hs4, )
+Simulating Particle :ps7   :10261476059880882183: pdgid =    22, status =   1, q =  0, e =   5.5, theta = -0.47, phi =  2.89, mass =  0.00
+Simulating Photon
+Made Cluster: et5   :3352954231494541317:    5.53 -0.47  2.89 sub(et5, )
+Made SmearedCluster: es5   :3343948187701346309:    5.79 -0.47  2.89 sub(es5, )
+Simulating Particle :ps8   :10261469507885203464: pdgid = -2212, status =   1, q = -1, e =   4.0, theta =  0.43, phi = -0.32, mass =  0.94
+Simulating Hadron
+Made Track: tt5   :7964632890378027013:    3.93    3.58  0.43 -0.32
+Made SmearedTrack: ts5   :7955625839310143493:    3.94    3.59  0.43 -0.32
+Made Cluster: ht5   :5658790688712556549:    4.04  0.43 -0.11 sub(ht5, )
+Made SmearedCluster: hs5   :5649784455391346693:    4.26  0.43 -0.11 sub(hs5, )
+Simulating Particle :ps9   :10261464445490298889: pdgid =    22, status =   1, q =  0, e =   3.4, theta = -0.56, phi =  2.80, mass =  0.00
+Simulating Photon
+Made Cluster: et6   :3352942617103958022:    3.44 -0.56  2.80 sub(et6, )
+Made SmearedCluster: es6   :3343936100000333830:    3.52 -0.56  2.80 sub(es6, )
+Simulating Particle :ps10  :10261459361041743882: pdgid =    22, status =   1, q =  0, e =   2.9, theta = -0.48, phi =  2.92, mass =  0.00
+Simulating Photon
+Made Cluster: et7   :3352937532655403015:    2.87 -0.48  2.92 sub(et7, )
+Made SmearedCluster: es7   :3343933264959111175:    3.20 -0.48  2.92 sub(es7, )
+Simulating Particle :ps11  :10261457914803781643: pdgid =  -211, status =   1, q = -1, e =   2.7, theta = -0.35, phi =  2.74, mass =  0.14
+Simulating Hadron
+Made Track: tt6   :7964622073102336006:    2.70    2.53 -0.35  2.74
+Made SmearedTrack: ts6   :7955614760106459142:    2.68    2.52 -0.35  2.74
+Made Cluster: ht6   :5658779095631134726:    2.70 -0.36  3.03 sub(ht6, )
+Made SmearedCluster: hs6   :5649766810023624710:    2.12 -0.36  3.03 sub(hs6, )
+Simulating Particle :ps12  :10261453119296634892: pdgid =    22, status =   1, q =  0, e =   2.2, theta =  0.50, phi = -0.34, mass =  0.00
+Simulating Photon
+Made Cluster: et8   :3352931290910294024:    2.16  0.50 -0.34 sub(et8, )
+Made SmearedCluster: es8   :3343927460310810632:    2.54  0.50 -0.34 sub(es8, )
+Simulating Particle :ps13  :10261452067713318925: pdgid =  -211, status =   1, q = -1, e =   2.0, theta =  0.49, phi = -0.35, mass =  0.14
+Simulating Hadron
+Made Track: tt7   :7964616215624679431:    2.03    1.79  0.49 -0.35
+Made SmearedTrack: ts7   :7955608990417682439:    2.03    1.79  0.49 -0.35
+Made Cluster: ht7   :5658773248540672007:    2.04  0.50  0.06 sub(ht7, )
+Made SmearedCluster: hs7   :5649765141617573895:    1.97  0.50  0.06 sub(hs7, )
+Simulating Particle :ps14  :10261441313287176206: pdgid =   321, status =   1, q =  1, e =   1.4, theta = -0.45, phi = -0.83, mass =  0.49
+Simulating Hadron
+Made Track: tt8   :7964603929273040904:    1.32    1.18 -0.45 -0.83
+Made SmearedTrack: ts8   :7955596710374277128:    1.32    1.18 -0.45 -0.83
+Made Cluster: et9   :3352909681063362569:    0.92 -0.48 -1.40 sub(et9, )
+Made SmearedCluster: es9   :3343890817568735241:    0.59 -0.48 -1.40 sub(es9, )
+Made Cluster: ht8   :5658736479742984200:    0.48 -0.48 -1.48 sub(ht8, )
+Made SmearedCluster: hs8   :5649747465119727624:    0.98 -0.48 -1.48 sub(hs8, )
+Rejected SmearedCluster: hs8   :5649747465119727624:    0.98 -0.48 -1.48 sub(hs8, )
+Simulating Particle :ps15  :10261437509003116559: pdgid =  -211, status =   1, q = -1, e =   1.2, theta =  0.37, phi = -0.05, mass =  0.14
+Simulating Hadron
+Made Track: tt9   :7964601554609111049:    1.18    1.10  0.37 -0.05
+Made SmearedTrack: ts9   :7955594309745508361:    1.18    1.10  0.37 -0.05
+Made Cluster: et10  :3352905274777141258:    0.80  0.39  0.57 sub(et10, )
+Made SmearedCluster: es10  :3343910676973223946:    1.32  0.39  0.57 sub(es10, )
+Made Cluster: ht9   :5658730075174993929:    0.39  0.40  0.66 sub(ht9, )
+Made SmearedCluster: hs8   :5649733185771143176:    0.57  0.40  0.66 sub(hs8, )
+Rejected SmearedCluster: hs8   :5649733185771143176:    0.57  0.40  0.66 sub(hs8, )
+Simulating Particle :ps16  :10261433368291835920: pdgid =    22, status =   1, q =  0, e =   1.0, theta =  0.43, phi = -0.41, mass =  0.00
+Simulating Photon
+Made Cluster: et11  :3352911539905495051:    0.98  0.43 -0.41 sub(et11, )
+Made SmearedCluster: es11  :3343890165671133195:    0.57  0.43 -0.41 sub(es11, )
+Simulating Particle :ps17  :10261432543886704657: pdgid =   211, status =   1, q =  1, e =   1.0, theta = -0.87, phi =  2.34, mass =  0.14
+Simulating Hadron
+Made Track: tt10  :7964596372806565898:    0.94    0.61 -0.87  2.34
+Made SmearedTrack: ts10  :7955589263261696010:    0.95    0.61 -0.87  2.34
+Made Cluster: ht10  :5658753724714057738:    0.95 -0.99  1.15 sub(ht10, )
+Made SmearedCluster: hs8   :5649761222839500808:    1.74 -0.99  1.15 sub(hs8, )
+Simulating Particle :ps18  :10261429297233264658: pdgid =  -321, status =   1, q = -1, e =   0.9, theta = -0.95, phi =  2.41, mass =  0.49
+Simulating Hadron
+Made Track: tt11  :7964588019290210315:    0.71    0.41 -0.95  2.41
+Made SmearedTrack: ts11  :7955580762183434251:    0.70    0.41 -0.95  2.41
+Made Cluster: et12  :3352812805186125836:    0.02 -1.10 -2.52 sub(et12, )
+Made SmearedCluster: es12  :3341670923508908044:   -0.01 -1.10 -2.52 sub(es12, )
+Rejected SmearedCluster: es12  :3341670923508908044:   -0.01 -1.10 -2.52 sub(es12, )
+Made Cluster: ht11  :5658749739932319755:    0.84 -1.12 -2.39 sub(ht11, )
+Made SmearedCluster: hs9   :5649755809976942601:    1.44 -1.12 -2.39 sub(hs9, )
+Simulating Particle :ps19  :10261428816710729747: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.64, phi = -0.13, mass =  0.00
+Simulating Photon
+Made Cluster: et13  :3352906988324388877:    0.85  0.64 -0.13 sub(et13, )
+Made SmearedCluster: es12  :3343903201265975308:    0.95  0.64 -0.13 sub(es12, )
+Simulating Particle :ps20  :10261427488546619412: pdgid =    22, status =   1, q =  0, e =   0.8, theta = -0.50, phi =  2.86, mass =  0.00
+Simulating Photon
+Made Cluster: et14  :3352905660160278542:    0.81 -0.50  2.86 sub(et14, )
+Made SmearedCluster: es13  :3343900536138104845:    0.87 -0.50  2.86 sub(es13, )
+Simulating Particle :ps21  :10261424404548288533: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.60, phi = -1.28, mass =  0.00
+Simulating Photon
+Made Cluster: et15  :3352902576161947663:    0.72  0.60 -1.28 sub(et15, )
+Made SmearedCluster: es14  :3343889139616448526:    0.55  0.60 -1.28 sub(es14, )
+Simulating Particle :ps22  :10261424226277785622: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.90, phi = -0.89, mass =  0.00
+Simulating Photon
+Made Cluster: et16  :3352902397891444752:    0.72  0.90 -0.89 sub(et16, )
+Made SmearedCluster: es15  :3343887747501785103:    0.51  0.90 -0.89 sub(es15, )
+Simulating Particle :ps23  :10261421671363641367: pdgid =  -211, status =   1, q = -1, e =   0.6, theta = -0.23, phi =  2.05, mass =  0.14
+Simulating Hadron
+Made Track: tt12  :7964585323801870348:    0.63    0.61 -0.23  2.05
+Made SmearedTrack: ts12  :7955578180144726028:    0.63    0.61 -0.23  2.05
+Made Cluster: et17  :3352890808341626897:    0.44 -1.02 -2.00 sub(et17, )
+Made SmearedCluster: es16  :3343902028328861712:    0.91 -1.02 -2.00 sub(es16, )
+Made Cluster: ht12  :5658713249674166284:    0.20 -1.31 -1.48 sub(ht12, )
+Made SmearedCluster: hs10  :5649691170211627018:    0.11 -1.31 -1.48 sub(hs10, )
+Rejected SmearedCluster: hs10  :5649691170211627018:    0.11 -1.31 -1.48 sub(hs10, )
+Simulating Particle :ps24  :10261421113212928024: pdgid =   211, status =   1, q =  1, e =   0.6, theta =  0.75, phi =  0.10, mass =  0.14
+Simulating Hadron
+Made Track: tt13  :7964584751757525005:    0.61    0.45  0.75  0.10
+Made SmearedTrack: ts13  :7955577619676659725:    0.62    0.45  0.75  0.10
+Made Cluster: et18  :3352879629412073490:    0.29  1.07 -1.77 sub(et18, )
+Made SmearedCluster: es17  :3343881866861084689:    0.42  1.07 -1.77 sub(es17, )
+Rejected SmearedCluster: es17  :3343881866861084689:    0.42  1.07 -1.77 sub(es17, )
+Made Cluster: ht13  :5658726765080608781:    0.34  1.13 -1.95 sub(ht13, )
+Made SmearedCluster: hs10  :5647513932722601994:   -0.12  1.13 -1.95 sub(hs10, )
+Rejected SmearedCluster: hs10  :5647513932722601994:   -0.12  1.13 -1.95 sub(hs10, )
+Simulating Particle :ps25  :10261418422527066137: pdgid =   211, status =   1, q =  1, e =   0.6, theta = -0.25, phi =  0.54, mass =  0.14
+Simulating Hadron
+Made Track: tt14  :7964581982380228622:    0.53    0.52 -0.25  0.54
+Made SmearedTrack: ts14  :7955574745571786766:    0.53    0.52 -0.25  0.54
+Made Cluster: et19  :3352878658875293715:    0.27 -1.36 -2.27 sub(et19, )
+Made SmearedCluster: es17  :3341670923508908049:   -0.22 -1.36 -2.27 sub(es17, )
+Rejected SmearedCluster: es17  :3341670923508908049:   -0.22 -1.36 -2.27 sub(es17, )
+Made Cluster: ht14  :5658722354247761934:    0.28 -1.43  0.30 sub(ht14, )
+Made SmearedCluster: hs10  :5647513932722601994:   -0.02 -1.43  0.30 sub(hs10, )
+Rejected SmearedCluster: hs10  :5647513932722601994:   -0.02 -1.43  0.30 sub(hs10, )
+Simulating Particle :ps26  :10261410238550769690: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.82, phi = -1.25, mass =  0.00
+Simulating Photon
+Made Cluster: et20  :3352888410164428820:    0.41  0.82 -1.25 sub(et20, )
+Made SmearedCluster: es17  :3343886878217601041:    0.49  0.82 -1.25 sub(es17, )
+Rejected SmearedCluster: es17  :3343886878217601041:    0.49  0.82 -1.25 sub(es17, )
+Simulating Particle :ps27  :10261387785634054171: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.97, phi = -1.41, mass =  0.00
+Simulating Photon
+Made Cluster: et21  :3352865957247713301:    0.17  0.97 -1.41 sub(et21, )
+Made SmearedCluster: es17  :3343870461598498833:    0.26  0.97 -1.41 sub(es17, )
+Rejected SmearedCluster: es17  :3343870461598498833:    0.26  0.97 -1.41 sub(es17, )
+Simulating Particle :ps29  :10261343164795191325: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -1.54, phi = -0.37, mass =  0.00
+Simulating Photon
+Made Cluster: et22  :3352821336408850454:    0.03 -1.54 -0.37 sub(et22, )
+Made SmearedCluster: es17  :3343825527222829073:    0.05 -1.54 -0.37 sub(es17, )
+Rejected SmearedCluster: es17  :3343825527222829073:    0.05 -1.54 -0.37 sub(es17, )
+Made MergedCluster: em0   :3289844551973339136:    0.51  0.90 -0.89 sub(es15, )
+Made MergedCluster: em1   :3289845758357929985:    0.54 -0.55  2.78 sub(es2, )
+Made MergedCluster: em2   :3289845944088002562:    0.55  0.60 -1.28 sub(es14, )
+Made MergedCluster: em3   :3289846970142687235:    0.57  0.43 -0.41 sub(es11, )
+Made MergedCluster: em4   :3289847622040289284:    0.59 -0.48 -1.40 sub(es9, )
+Made MergedCluster: em5   :3289857340609658885:    0.87 -0.50  2.86 sub(es13, )
+Made MergedCluster: em6   :3289858832800415750:    0.91 -1.02 -2.00 sub(es16, )
+Made MergedCluster: em7   :3289860005737529351:    0.95  0.64 -0.13 sub(es12, )
+Made MergedCluster: em8   :3289867481444777992:    1.32  0.39  0.57 sub(es10, )
+Made MergedCluster: em9   :3289883298156773385:    2.43  0.52 -0.14 sub(es4, )
+Made MergedCluster: em10  :3289884264782364682:    2.54  0.50 -0.34 sub(es8, )
+Made MergedCluster: em11  :3289888165613010955:    2.98  0.59 -0.29 sub(es0, )
+Made MergedCluster: em12  :3289890069430665228:    3.20 -0.48  2.92 sub(es7, )
+Made MergedCluster: em13  :3289892904471887885:    3.52 -0.56  2.80 sub(es6, )
+Made MergedCluster: em14  :3289935174365609998:   18.61 -0.47  2.89 sub(es1, es5, )
+Made MergedCluster: em15  :3289909692968468495:    6.86  0.59 -0.16 sub(es3, )
+Made MergedCluster: hm0   :5595712614448496640:    1.44 -1.12 -2.39 sub(hs9, )
+Made MergedCluster: hm1   :5595718027311054849:    1.74 -0.99  1.15 sub(hs8, )
+Made MergedCluster: hm2   :5595721946089127938:    1.97  0.50  0.06 sub(hs7, )
+Made MergedCluster: hm3   :5595723614495178755:    2.12 -0.36  3.03 sub(hs6, )
+Made MergedCluster: hm4   :5595769400100651012:   13.31 -0.53  2.79 sub(hs1, hs2, )
+Made MergedCluster: hm5   :5595758559854854149:    8.38  0.47 -0.12 sub(hs5, hs3, )
+Made MergedCluster: hm6   :5595743545962004486:    4.78  0.36 -0.44 sub(hs4, )
+Made MergedCluster: hm7   :5595754450139480071:    7.26  0.59 -0.30 sub(hs0, )
+Made block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.5 (3289844551973339136)
+
+Made block:E1H1T2   :br1   : ecals = 1 hcals = 1 tracks = 2
+    elements:
+      t0 = ts1       value=  8.3 (7955644628502315009)
+      t1 = ts2       value=  6.5 (7955637503124307970)
+      h2 = hm4       value= 13.3 (5595769400100651012)
+      e3 = em1       value=  0.5 (3289845758357929985)
+    distances:
+              t0      t1      h2      e3
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+      e3  0.0000     ---     ---       .
+
+Made block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.5 (3289845944088002562)
+
+Made block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.6 (3289846970142687235)
+
+Made block:E1T1     :br4   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  1.3 (7955596710374277128)
+      e1 = em4       value=  0.6 (3289847622040289284)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.9 (3289857340609658885)
+
+Made block:E1T1     :br6   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  0.6 (7955578180144726028)
+      e1 = em6       value=  0.9 (3289858832800415750)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.9 (3289860005737529351)
+
+Made block:E1T1     :br8   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  1.2 (7955594309745508361)
+      e1 = em8       value=  1.3 (3289867481444777992)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1H1T2   :br9   : ecals = 1 hcals = 1 tracks = 2
+    elements:
+      t0 = ts3       value=  6.0 (7955635072049086467)
+      t1 = ts5       value=  3.9 (7955625839310143493)
+      h2 = hm5       value=  8.4 (5595758559854854149)
+      e3 = em9       value=  2.4 (3289883298156773385)
+    distances:
+              t0      t1      h2      e3
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+      e3  0.0000     ---     ---       .
+
+Made block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  2.5 (3289884264782364682)
+
+Made block:E1H1T1   :br11  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts0       value= 11.9 (7955652551630651392)
+      h1 = hm7       value=  7.3 (5595754450139480071)
+      e2 = em11      value=  3.0 (3289888165613010955)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  3.2 (3289890069430665228)
+
+Made block:E1       :br13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  3.5 (3289892904471887885)
+
+Made block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  6.9 (3289909692968468495)
+
+Made block:E1       :br15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value= 18.6 (3289935174365609998)
+
+Made block:H1T1     :br16  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts11      value=  0.7 (7955580762183434251)
+      h1 = hm0       value=  1.4 (5595712614448496640)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br17  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts10      value=  0.9 (7955589263261696010)
+      h1 = hm1       value=  1.7 (5595718027311054849)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br18  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  2.0 (7955608990417682439)
+      h1 = hm2       value=  2.0 (5595721946089127938)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br19  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  2.7 (7955614760106459142)
+      h1 = hm3       value=  2.1 (5595723614495178755)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br20  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  5.7 (7955633638882672644)
+      h1 = hm6       value=  4.8 (5595743545962004486)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:T1       :br21  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  0.5 (7955574745571786766)
+
+Made block:T1       :br22  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  0.6 (7955577619676659725)
+
+Splitting block:E1H1T2   :br9   : ecals = 1 hcals = 1 tracks = 2
+    elements:
+      t0 = ts3       value=  6.0 (7955635072049086467)
+      t1 = ts5       value=  3.9 (7955625839310143493)
+      h2 = hm5       value=  8.4 (5595758559854854149)
+      e3 = em9       value=  2.4 (3289883298156773385)
+    distances:
+              t0      t1      h2      e3
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+      e3  0.0000     ---     ---       .
+
+Made block:E1H1T2   :bs0   : ecals = 1 hcals = 1 tracks = 2
+    elements:
+      t0 = ts3       value=  6.0 (7955635072049086467)
+      t1 = ts5       value=  3.9 (7955625839310143493)
+      h2 = hm5       value=  8.4 (5595758559854854149)
+      e3 = em9       value=  2.4 (3289883298156773385)
+    distances:
+              t0      t1      h2      e3
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+      e3  0.0000     ---     ---       .
+
+Splitting block:E1H1T2   :br1   : ecals = 1 hcals = 1 tracks = 2
+    elements:
+      t0 = ts1       value=  8.3 (7955644628502315009)
+      t1 = ts2       value=  6.5 (7955637503124307970)
+      h2 = hm4       value= 13.3 (5595769400100651012)
+      e3 = em1       value=  0.5 (3289845758357929985)
+    distances:
+              t0      t1      h2      e3
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+      e3  0.0000     ---     ---       .
+
+Made block:E1H1T2   :bs1   : ecals = 1 hcals = 1 tracks = 2
+    elements:
+      t0 = ts1       value=  8.3 (7955644628502315009)
+      t1 = ts2       value=  6.5 (7955637503124307970)
+      h2 = hm4       value= 13.3 (5595769400100651012)
+      e3 = em1       value=  0.5 (3289845758357929985)
+    distances:
+              t0      t1      h2      e3
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+      e3  0.0000     ---     ---       .
+
+Splitting block:E1H1T1   :br11  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts0       value= 11.9 (7955652551630651392)
+      h1 = hm7       value=  7.3 (5595754450139480071)
+      e2 = em11      value=  3.0 (3289888165613010955)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts0       value= 11.9 (7955652551630651392)
+      h1 = hm7       value=  7.3 (5595754450139480071)
+      e2 = em11      value=  3.0 (3289888165613010955)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:H1T1     :br20  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  5.7 (7955633638882672644)
+      h1 = hm6       value=  4.8 (5595743545962004486)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs3   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  5.7 (7955633638882672644)
+      h1 = hm6       value=  4.8 (5595743545962004486)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br19  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  2.7 (7955614760106459142)
+      h1 = hm3       value=  2.1 (5595723614495178755)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs4   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  2.7 (7955614760106459142)
+      h1 = hm3       value=  2.1 (5595723614495178755)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br18  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  2.0 (7955608990417682439)
+      h1 = hm2       value=  2.0 (5595721946089127938)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs5   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  2.0 (7955608990417682439)
+      h1 = hm2       value=  2.0 (5595721946089127938)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br17  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts10      value=  0.9 (7955589263261696010)
+      h1 = hm1       value=  1.7 (5595718027311054849)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs6   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts10      value=  0.9 (7955589263261696010)
+      h1 = hm1       value=  1.7 (5595718027311054849)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br16  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts11      value=  0.7 (7955580762183434251)
+      h1 = hm0       value=  1.4 (5595712614448496640)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs7   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts11      value=  0.7 (7955580762183434251)
+      h1 = hm0       value=  1.4 (5595712614448496640)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:E1T1     :br8   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  1.2 (7955594309745508361)
+      e1 = em8       value=  1.3 (3289867481444777992)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs8   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  1.2 (7955594309745508361)
+      e1 = em8       value=  1.3 (3289867481444777992)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br6   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  0.6 (7955578180144726028)
+      e1 = em6       value=  0.9 (3289858832800415750)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs9   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  0.6 (7955578180144726028)
+      e1 = em6       value=  0.9 (3289858832800415750)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br4   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  1.3 (7955596710374277128)
+      e1 = em4       value=  0.6 (3289847622040289284)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs10  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  1.3 (7955596710374277128)
+      e1 = em4       value=  0.6 (3289847622040289284)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:T1       :br22  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  0.6 (7955577619676659725)
+
+Made block:T1       :bs11  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  0.6 (7955577619676659725)
+
+Splitting block:T1       :br21  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  0.5 (7955574745571786766)
+
+Made block:T1       :bs12  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  0.5 (7955574745571786766)
+
+Splitting block:E1       :br15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value= 18.6 (3289935174365609998)
+
+Made block:E1       :bs13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value= 18.6 (3289935174365609998)
+
+Splitting block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  6.9 (3289909692968468495)
+
+Made block:E1       :bs14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  6.9 (3289909692968468495)
+
+Splitting block:E1       :br13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  3.5 (3289892904471887885)
+
+Made block:E1       :bs15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  3.5 (3289892904471887885)
+
+Splitting block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  3.2 (3289890069430665228)
+
+Made block:E1       :bs16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  3.2 (3289890069430665228)
+
+Splitting block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  2.5 (3289884264782364682)
+
+Made block:E1       :bs17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  2.5 (3289884264782364682)
+
+Splitting block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.9 (3289860005737529351)
+
+Made block:E1       :bs18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.9 (3289860005737529351)
+
+Splitting block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.9 (3289857340609658885)
+
+Made block:E1       :bs19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.9 (3289857340609658885)
+
+Splitting block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.6 (3289846970142687235)
+
+Made block:E1       :bs20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.6 (3289846970142687235)
+
+Splitting block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.5 (3289845944088002562)
+
+Made block:E1       :bs21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.5 (3289845944088002562)
+
+Splitting block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.5 (3289844551973339136)
+
+Made block:E1       :bs22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.5 (3289844551973339136)
+
+Processing block:E1H1T2   :bs1   : ecals = 1 hcals = 1 tracks = 2
+    elements:
+      t0 = ts1       value=  8.3 (7955644628502315009)
+      t1 = ts2       value=  6.5 (7955637503124307970)
+      h2 = hm4       value= 13.3 (5595769400100651012)
+      e3 = em1       value=  0.5 (3289845758357929985)
+    distances:
+              t0      t1      h2      e3
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+      e3  0.0000     ---     ---       .
+
+Made Particle :pr0   :10252480441013501952: pdgid =   211, status =   1, q =  1, e =   8.3, theta = -0.54, phi =  2.87, mass =  0.14 from SmearedTrack: ts1   :7955644628502315009:    8.32    7.11 -0.54  2.87
+Made Particle :pr1   :10252473319580237825: pdgid =   211, status =   1, q =  1, e =   6.5, theta = -0.50, phi =  2.97, mass =  0.14 from SmearedTrack: ts2   :7955637503124307970:    6.54    5.73 -0.50  2.97
+Finished block
+Processing block:E1H1T2   :bs0   : ecals = 1 hcals = 1 tracks = 2
+    elements:
+      t0 = ts3       value=  6.0 (7955635072049086467)
+      t1 = ts5       value=  3.9 (7955625839310143493)
+      h2 = hm5       value=  8.4 (5595758559854854149)
+      e3 = em9       value=  2.4 (3289883298156773385)
+    distances:
+              t0      t1      h2      e3
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+      e3  0.0000     ---     ---       .
+
+Made Particle :pr2   :10252470889102704642: pdgid =  -211, status =   1, q = -1, e =   6.0, theta =  0.52, phi = -0.26, mass =  0.14 from SmearedTrack: ts3   :7955635072049086467:    5.99    5.21  0.52 -0.26
+Made Particle :pr3   :10252461670808944643: pdgid =  -211, status =   1, q = -1, e =   3.9, theta =  0.43, phi = -0.32, mass =  0.14 from SmearedTrack: ts5   :7955625839310143493:    3.94    3.59  0.43 -0.32
+Finished block
+Processing block:E1H1T1   :bs2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts0       value= 11.9 (7955652551630651392)
+      h1 = hm7       value=  7.3 (5595754450139480071)
+      e2 = em11      value=  3.0 (3289888165613010955)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr4   :10252488363372183556: pdgid =   211, status =   1, q =  1, e =  11.9, theta =  0.59, phi = -0.23, mass =  0.14 from SmearedTrack: ts0   :7955652551630651392:   11.92    9.91  0.59 -0.23
+Finished block
+Processing block:E1T1     :bs10  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  1.3 (7955596710374277128)
+      e1 = em4       value=  0.6 (3289847622040289284)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr5   :10252432649106751493: pdgid =   211, status =   1, q =  1, e =   1.3, theta = -0.45, phi = -0.83, mass =  0.14 from SmearedTrack: ts8   :7955596710374277128:    1.32    1.18 -0.45 -0.83
+Finished block
+Processing block:E1T1     :bs9   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  0.6 (7955578180144726028)
+      e1 = em6       value=  0.9 (3289858832800415750)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr6   :10252414522071449606: pdgid =  -211, status =   1, q = -1, e =   0.6, theta = -0.23, phi =  2.05, mass =  0.14 from SmearedTrack: ts12  :7955578180144726028:    0.63    0.61 -0.23  2.05
+Finished block
+Processing block:E1T1     :bs8   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  1.2 (7955594309745508361)
+      e1 = em8       value=  1.3 (3289867481444777992)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr7   :10252430263277584391: pdgid =  -211, status =   1, q = -1, e =   1.2, theta =  0.37, phi = -0.05, mass =  0.14 from SmearedTrack: ts9   :7955594309745508361:    1.18    1.10  0.37 -0.05
+Finished block
+Processing block:H1T1     :bs7   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts11      value=  0.7 (7955580762183434251)
+      h1 = hm0       value=  1.4 (5595712614448496640)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr8   :10252417049823281160: pdgid =  -211, status =   1, q = -1, e =   0.7, theta = -0.95, phi =  2.41, mass =  0.14 from SmearedTrack: ts11  :7955580762183434251:    0.70    0.41 -0.95  2.41
+Finished block
+Processing block:H1T1     :bs6   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts10      value=  0.9 (7955589263261696010)
+      h1 = hm1       value=  1.7 (5595718027311054849)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr9   :10252425430457909257: pdgid =   211, status =   1, q =  1, e =   1.0, theta = -0.87, phi =  2.34, mass =  0.14 from SmearedTrack: ts10  :7955589263261696010:    0.95    0.61 -0.87  2.34
+Finished block
+Processing block:H1T1     :bs5   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  2.0 (7955608990417682439)
+      h1 = hm2       value=  2.0 (5595721946089127938)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr10  :10252444842221109258: pdgid =  -211, status =   1, q = -1, e =   2.0, theta =  0.49, phi = -0.35, mass =  0.14 from SmearedTrack: ts7   :7955608990417682439:    2.03    1.79  0.49 -0.35
+Finished block
+Processing block:H1T1     :bs4   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  2.7 (7955614760106459142)
+      h1 = hm3       value=  2.1 (5595723614495178755)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr11  :10252450601700950027: pdgid =  -211, status =   1, q = -1, e =   2.7, theta = -0.35, phi =  2.74, mass =  0.14 from SmearedTrack: ts6   :7955614760106459142:    2.68    2.52 -0.35  2.74
+Finished block
+Processing block:H1T1     :bs3   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  5.7 (7955633638882672644)
+      h1 = hm6       value=  4.8 (5595743545962004486)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr12  :10252469456345235468: pdgid =   211, status =   1, q =  1, e =   5.7, theta =  0.36, phi = -0.30, mass =  0.14 from SmearedTrack: ts4   :7955633638882672644:    5.66    5.30  0.36 -0.30
+Finished block
+Processing block:E1       :bs22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.5 (3289844551973339136)
+
+Made Particle :pr13  :10252409575888125965: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.90, phi = -0.89, mass =  0.00 from MergedCluster: em0   :3289844551973339136:    0.51  0.90 -0.89 sub(es15, )
+Finished block
+Processing block:E1       :bs21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.5 (3289845944088002562)
+
+Made Particle :pr14  :10252410968002789390: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.60, phi = -1.28, mass =  0.00 from MergedCluster: em2   :3289845944088002562:    0.55  0.60 -1.28 sub(es14, )
+Finished block
+Processing block:E1       :bs20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.6 (3289846970142687235)
+
+Made Particle :pr15  :10252411994057474063: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.43, phi = -0.41, mass =  0.00 from MergedCluster: em3   :3289846970142687235:    0.57  0.43 -0.41 sub(es11, )
+Finished block
+Processing block:E1       :bs19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.9 (3289857340609658885)
+
+Made Particle :pr16  :10252422364524445712: pdgid =    22, status =   1, q =  0, e =   0.9, theta = -0.50, phi =  2.86, mass =  0.00 from MergedCluster: em5   :3289857340609658885:    0.87 -0.50  2.86 sub(es13, )
+Finished block
+Processing block:E1       :bs18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.9 (3289860005737529351)
+
+Made Particle :pr17  :10252425029652316177: pdgid =    22, status =   1, q =  0, e =   0.9, theta =  0.64, phi = -0.13, mass =  0.00 from MergedCluster: em7   :3289860005737529351:    0.95  0.64 -0.13 sub(es12, )
+Finished block
+Processing block:E1       :bs17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  2.5 (3289884264782364682)
+
+Made Particle :pr18  :10252449288697151506: pdgid =    22, status =   1, q =  0, e =   2.5, theta =  0.50, phi = -0.34, mass =  0.00 from MergedCluster: em10  :3289884264782364682:    2.54  0.50 -0.34 sub(es8, )
+Finished block
+Processing block:E1       :bs16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  3.2 (3289890069430665228)
+
+Made Particle :pr19  :10252455093345452051: pdgid =    22, status =   1, q =  0, e =   3.2, theta = -0.48, phi =  2.92, mass =  0.00 from MergedCluster: em12  :3289890069430665228:    3.20 -0.48  2.92 sub(es7, )
+Finished block
+Processing block:E1       :bs15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  3.5 (3289892904471887885)
+
+Made Particle :pr20  :10252457928386674708: pdgid =    22, status =   1, q =  0, e =   3.5, theta = -0.56, phi =  2.80, mass =  0.00 from MergedCluster: em13  :3289892904471887885:    3.52 -0.56  2.80 sub(es6, )
+Finished block
+Processing block:E1       :bs14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  6.9 (3289909692968468495)
+
+Made Particle :pr21  :10252474716883255317: pdgid =    22, status =   1, q =  0, e =   6.9, theta =  0.59, phi = -0.16, mass =  0.00 from MergedCluster: em15  :3289909692968468495:    6.86  0.59 -0.16 sub(es3, )
+Finished block
+Processing block:E1       :bs13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value= 18.6 (3289935174365609998)
+
+Made Particle :pr22  :10252500198280396822: pdgid =    22, status =   1, q =  0, e =  18.6, theta = -0.47, phi =  2.89, mass =  0.00 from MergedCluster: em14  :3289935174365609998:   18.61 -0.47  2.89 sub(es1, es5, )
+Finished block
+Processing block:T1       :bs12  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  0.5 (7955574745571786766)
+
+Made Particle :pr23  :10252411181874544663: pdgid =   211, status =   1, q =  1, e =   0.6, theta = -0.25, phi =  0.54, mass =  0.14 from SmearedTrack: ts14  :7955574745571786766:    0.53    0.52 -0.25  0.54
+Finished block
+Processing block:T1       :bs11  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  0.6 (7955577619676659725)
+
+Made Particle :pr24  :10252413975037739032: pdgid =   211, status =   1, q =  1, e =   0.6, theta =  0.75, phi =  0.10, mass =  0.14 from SmearedTrack: ts13  :7955577619676659725:    0.62    0.45  0.75  0.10
+Finished block
+Finished reconstruction
+Event: 6
+Made Particle :ps0   :10261511688526233600: pdgid =    22, status =   1, q =  0, e =  22.5, theta =  0.80, phi =  1.61, mass =  0.00
+Made Particle :ps1   :10261493727608438785: pdgid =   211, status =   1, q =  1, e =  11.1, theta = -0.79, phi = -1.53, mass =  0.14
+Made Particle :ps2   :10261490272116408322: pdgid =    22, status =   1, q =  0, e =   9.5, theta = -0.79, phi = -1.57, mass =  0.00
+Made Particle :ps3   :10261484698270171139: pdgid =    22, status =   1, q =  0, e =   7.5, theta = -0.79, phi = -1.55, mass =  0.00
+Made Particle :ps4   :10261484385706442756: pdgid =    22, status =   1, q =  0, e =   7.4, theta =  0.81, phi =  1.61, mass =  0.00
+Made Particle :ps5   :10261478953921282053: pdgid = -2212, status =   1, q = -1, e =   6.2, theta = -0.80, phi = -1.52, mass =  0.94
+Made Particle :ps6   :10261462292264648710: pdgid =    22, status =   1, q =  0, e =   3.2, theta =  0.85, phi =  1.63, mass =  0.00
+Made Particle :ps7   :10261461461635170311: pdgid =  -211, status =   1, q = -1, e =   3.1, theta = -0.75, phi = -1.46, mass =  0.14
+Made Particle :ps8   :10261457191032586248: pdgid =  -211, status =   1, q = -1, e =   2.6, theta =  0.77, phi =  1.62, mass =  0.14
+Made Particle :ps9   :10261456775582580745: pdgid =  2212, status =   1, q =  1, e =   2.6, theta = -0.90, phi = -1.61, mass =  0.94
+Made Particle :ps10  :10261451781724700682: pdgid =  -211, status =   1, q = -1, e =   2.0, theta =  1.08, phi =  1.33, mass =  0.14
+Made Particle :ps11  :10261448065927872523: pdgid =  -211, status =   1, q = -1, e =   1.8, theta = -0.87, phi = -1.92, mass =  0.14
+Made Particle :ps12  :10261445486915354636: pdgid =   211, status =   1, q =  1, e =   1.6, theta =  0.75, phi =  1.91, mass =  0.14
+Made Particle :ps13  :10261444172919603213: pdgid =   211, status =   1, q =  1, e =   1.6, theta =  0.85, phi =  1.63, mass =  0.14
+Made Particle :ps14  :10261436483739058190: pdgid =  -211, status =   1, q = -1, e =   1.1, theta = -0.41, phi = -0.48, mass =  0.14
+Made Particle :ps15  :10261431245156122639: pdgid =   211, status =   1, q =  1, e =   0.9, theta = -0.77, phi = -1.35, mass =  0.14
+Made Particle :ps16  :10261430415262744592: pdgid =    22, status =   1, q =  0, e =   0.9, theta =  0.84, phi =  1.75, mass =  0.00
+Made Particle :ps17  :10261429413988007953: pdgid =   211, status =   1, q =  1, e =   0.9, theta =  0.45, phi =  1.90, mass =  0.14
+Made Particle :ps18  :10261424783426060306: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.51, phi =  1.57, mass =  0.00
+Made Particle :ps19  :10261423134701781011: pdgid =  -211, status =   1, q = -1, e =   0.7, theta =  0.28, phi = -0.84, mass =  0.14
+Made Particle :ps20  :10261418528112377876: pdgid =  -211, status =   1, q = -1, e =   0.6, theta = -0.93, phi =  1.47, mass =  0.14
+Made Particle :ps21  :10261412063861538837: pdgid =   211, status =   1, q =  1, e =   0.4, theta = -0.94, phi =  3.07, mass =  0.14
+Made Particle :ps22  :10261405632739409942: pdgid =   211, status =   1, q =  1, e =   0.3, theta =  0.98, phi =  1.94, mass =  0.14
+Made Particle :ps23  :10261401256574582807: pdgid =   211, status =   1, q =  1, e =   0.3, theta =  1.29, phi =  3.13, mass =  0.14
+Made Particle :ps24  :10261400861647306776: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -1.55, phi = -1.50, mass =  0.00
+Made Particle :ps25  :10261397959889387545: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.67, phi = -2.08, mass =  0.00
+Made Particle :ps26  :10261397066825596954: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.91, phi =  0.68, mass =  0.00
+Made Particle :ps27  :10261395923951157275: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -1.05, phi =  2.24, mass =  0.00
+Made Particle :ps28  :10261391885281001500: pdgid =  -211, status =   1, q = -1, e =   0.2, theta =  0.05, phi =  1.59, mass =  0.14
+Made Particle :ps29  :10261382099441287197: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.95, phi =  1.61, mass =  0.00
+Made Particle :ps30  :10261374650906837022: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -1.31, phi =  2.07, mass =  0.00
+Made Particle :ps31  :10261336280870682655: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.23, phi = -2.00, mass =  0.00
+Simulating Particle :ps0   :10261511688526233600: pdgid =    22, status =   1, q =  0, e =  22.5, theta =  0.80, phi =  1.61, mass =  0.00
+Simulating Photon
+Made Cluster: et0   :3352989860139892736:   22.51  0.80  1.61 sub(et0, )
+Made SmearedCluster: es0   :3343983028773847040:   22.85  0.80  1.61 sub(es0, )
+Simulating Particle :ps1   :10261493727608438785: pdgid =   211, status =   1, q =  1, e =  11.1, theta = -0.79, phi = -1.53, mass =  0.14
+Simulating Hadron
+Made Track: tt0   :7964657915718008832:   11.09    7.82 -0.79 -1.53
+Made SmearedTrack: ts0   :7955650513706418176:   11.00    7.75 -0.79 -1.53
+Rejected SmearedTrack: ts0   :7955650513706418176:   11.00    7.75 -0.79 -1.53
+Made Cluster: et1   :3352951264641024001:    4.85 -0.79 -1.58 sub(et1, )
+Made SmearedCluster: es1   :3343937561063063553:    3.69 -0.79 -1.58 sub(es1, )
+Made Cluster: ht0   :5658800358646874112:    6.24 -0.79 -1.59 sub(ht0, )
+Made SmearedCluster: hs0   :5649796928251101184:    7.09 -0.79 -1.59 sub(hs0, )
+Simulating Particle :ps2   :10261490272116408322: pdgid =    22, status =   1, q =  0, e =   9.5, theta = -0.79, phi = -1.57, mass =  0.00
+Simulating Photon
+Made Cluster: et2   :3352968443730067458:    9.52 -0.79 -1.57 sub(et2, )
+Made SmearedCluster: es2   :3343962144147243010:    9.93 -0.79 -1.57 sub(es2, )
+Simulating Particle :ps3   :10261484698270171139: pdgid =    22, status =   1, q =  0, e =   7.5, theta = -0.79, phi = -1.55, mass =  0.00
+Simulating Photon
+Made Cluster: et3   :3352962869883830275:    7.49 -0.79 -1.55 sub(et3, )
+Made SmearedCluster: es3   :3343957419093917699:    7.89 -0.79 -1.55 sub(es3, )
+Simulating Particle :ps4   :10261484385706442756: pdgid =    22, status =   1, q =  0, e =   7.4, theta =  0.81, phi =  1.61, mass =  0.00
+Simulating Photon
+Made Cluster: et4   :3352962557320101892:    7.42  0.81  1.61 sub(et4, )
+Made SmearedCluster: es4   :3343953317635031044:    6.96  0.81  1.61 sub(es4, )
+Simulating Particle :ps5   :10261478953921282053: pdgid = -2212, status =   1, q = -1, e =   6.2, theta = -0.80, phi = -1.52, mass =  0.94
+Simulating Hadron
+Made Track: tt1   :7964642829152550913:    6.11    4.28 -0.80 -1.52
+Made SmearedTrack: ts0   :7955635356001370112:    6.05    4.24 -0.80 -1.52
+Made Cluster: et5   :3352930664902033413:    2.08 -0.80 -1.44 sub(et5, )
+Made SmearedCluster: es5   :3343915053941260293:    1.56 -0.80 -1.44 sub(es5, )
+Made Cluster: ht1   :5658790967493263361:    4.10 -0.80 -1.42 sub(ht1, )
+Made SmearedCluster: hs1   :5649773510694797313:    2.88 -0.80 -1.42 sub(hs1, )
+Simulating Particle :ps6   :10261462292264648710: pdgid =    22, status =   1, q =  0, e =   3.2, theta =  0.85, phi =  1.63, mass =  0.00
+Simulating Photon
+Made Cluster: et6   :3352940463878307846:    3.20  0.85  1.63 sub(et6, )
+Made SmearedCluster: es6   :3343937013800763398:    3.62  0.85  1.63 sub(es6, )
+Simulating Particle :ps7   :10261461461635170311: pdgid =  -211, status =   1, q = -1, e =   3.1, theta = -0.75, phi = -1.46, mass =  0.14
+Simulating Hadron
+Made Track: tt2   :7964625624060919810:    3.10    2.26 -0.75 -1.46
+Made SmearedTrack: ts1   :7955618303284609025:    3.09    2.25 -0.75 -1.46
+Made Cluster: et7   :3352915007508578311:    1.15 -0.76 -1.26 sub(et7, )
+Made SmearedCluster: es7   :3343873168719740935:    0.30 -0.76 -1.26 sub(es7, )
+Rejected SmearedCluster: es7   :3343873168719740935:    0.30 -0.76 -1.26 sub(es7, )
+Made Cluster: ht2   :5658772083832782850:    1.95 -0.77 -1.23 sub(ht2, )
+Made SmearedCluster: hs2   :5649769737821880322:    2.46 -0.77 -1.23 sub(hs2, )
+Simulating Particle :ps8   :10261457191032586248: pdgid =  -211, status =   1, q = -1, e =   2.6, theta =  0.77, phi =  1.62, mass =  0.14
+Simulating Hadron
+Made Track: tt3   :7964621348330799107:    2.61    1.88  0.77  1.62
+Made SmearedTrack: ts2   :7955613647758163970:    2.56    1.84  0.77  1.62
+Made Cluster: et8   :3352905073375051784:    0.79  0.78  1.97 sub(et8, )
+Made SmearedCluster: es7   :3343908048925097991:    1.17  0.78  1.97 sub(es7, )
+Made Cluster: ht3   :5658769848249876483:    1.82  0.78  2.01 sub(ht3, )
+Made SmearedCluster: hs3   :5649768291047047171:    2.29  0.78  2.01 sub(hs3, )
+Simulating Particle :ps9   :10261456775582580745: pdgid =  2212, status =   1, q =  1, e =   2.6, theta = -0.90, phi = -1.61, mass =  0.94
+Simulating Hadron
+Made Track: tt4   :7964619406026211332:    2.39    1.48 -0.90 -1.61
+Made SmearedTrack: ts3   :7955612182220111875:    2.39    1.48 -0.90 -1.61
+Made Cluster: et9   :3352827093168685065:    0.04 -0.92 -2.03 sub(et9, )
+Made SmearedCluster: es8   :3343855200422068232:    0.15 -0.92 -2.03 sub(es8, )
+Rejected SmearedCluster: es8   :3343855200422068232:    0.15 -0.92 -2.03 sub(es8, )
+Made Cluster: ht4   :5658777638974521348:    2.54 -0.92 -2.07 sub(ht4, )
+Made SmearedCluster: hs4   :5649764274782863364:    1.92 -0.92 -2.07 sub(hs4, )
+Simulating Particle :ps10  :10261451781724700682: pdgid =  -211, status =   1, q = -1, e =   2.0, theta =  1.08, phi =  1.33, mass =  0.14
+Simulating Hadron
+Made Track: tt5   :7964615916900057093:    2.00    0.94  1.08  1.33
+Made SmearedTrack: ts4   :7955609015568826372:    2.03    0.96  1.08  1.33
+Made Cluster: et10  :3352918696375877642:    1.36  1.09  1.77 sub(et10, )
+Made SmearedCluster: es8   :3343907051936940040:    1.11  1.09  1.77 sub(es8, )
+Made Cluster: ht5   :5658742730682007557:    0.64  1.10  1.81 sub(ht5, )
+Made SmearedCluster: hs5   :5649760742891585541:    1.72  1.10  1.81 sub(hs5, )
+Simulating Particle :ps11  :10261448065927872523: pdgid =  -211, status =   1, q = -1, e =   1.8, theta = -0.87, phi = -1.92, mass =  0.14
+Simulating Hadron
+Made Track: tt6   :7964612160126976006:    1.79    1.16 -0.87 -1.92
+Made SmearedTrack: ts5   :7955604846986395653:    1.78    1.15 -0.87 -1.92
+Made Cluster: ht6   :5658769246755225606:    1.79 -0.90 -1.29 sub(ht6, )
+Made SmearedCluster: hs6   :5649768121041420294:    2.27 -0.90 -1.29 sub(hs6, )
+Simulating Particle :ps12  :10261445486915354636: pdgid =   211, status =   1, q =  1, e =   1.6, theta =  0.75, phi =  1.91, mass =  0.14
+Simulating Hadron
+Made Track: tt7   :7964609572537106439:    1.64    1.20  0.75  1.91
+Made SmearedTrack: ts6   :7955602737163403270:    1.66    1.21  0.75  1.91
+Made Cluster: et11  :3352906172978954251:    0.82  0.78  1.34 sub(et11, )
+Made SmearedCluster: es9   :3343896078419230729:    0.74  0.78  1.34 sub(es9, )
+Made Cluster: ht7   :5658748968920678407:    0.82  0.78  1.26 sub(ht7, )
+Made SmearedCluster: hs7   :5649724877393887239:    0.42  0.78  1.26 sub(hs7, )
+Rejected SmearedCluster: hs7   :5649724877393887239:    0.42  0.78  1.26 sub(hs7, )
+Simulating Particle :ps13  :10261444172919603213: pdgid =   211, status =   1, q =  1, e =   1.6, theta =  0.85, phi =  1.63, mass =  0.14
+Simulating Hadron
+Made Track: tt8   :7964608253552230408:    1.56    1.04  0.85  1.63
+Made SmearedTrack: ts7   :7955601290367598599:    1.58    1.05  0.85  1.63
+Made Cluster: et12  :3352881877693235212:    0.32  0.88  0.97 sub(et12, )
+Made SmearedCluster: es10  :3343901421987692554:    0.89  0.88  0.97 sub(es10, )
+Made Cluster: ht8   :5658759772780888072:    1.25  0.89  0.90 sub(ht8, )
+Made SmearedCluster: hs7   :5649762474656792583:    1.81  0.89  0.90 sub(hs7, )
+Simulating Particle :ps14  :10261436483739058190: pdgid =  -211, status =   1, q = -1, e =   1.1, theta = -0.41, phi = -0.48, mass =  0.14
+Simulating Hadron
+Made Track: tt9   :7964600521856122889:    1.12    1.03 -0.41 -0.48
+Made SmearedTrack: ts8   :7955593286582796296:    1.12    1.03 -0.41 -0.48
+Made Cluster: et13  :3352901710956724237:    0.70 -0.44  0.20 sub(et13, )
+Made SmearedCluster: es11  :3343871221692366859:    0.27 -0.44  0.20 sub(es11, )
+Rejected SmearedCluster: es11  :3343871221692366859:    0.27 -0.44  0.20 sub(es11, )
+Made Cluster: ht9   :5658733101759594505:    0.43 -0.45  0.30 sub(ht9, )
+Made SmearedCluster: hs8   :5649730829077708808:    0.51 -0.45  0.30 sub(hs8, )
+Rejected SmearedCluster: hs8   :5649730829077708808:    0.51 -0.45  0.30 sub(hs8, )
+Simulating Particle :ps15  :10261431245156122639: pdgid =   211, status =   1, q =  1, e =   0.9, theta = -0.77, phi = -1.35, mass =  0.14
+Simulating Hadron
+Made Track: tt10  :7964595059377045514:    0.91    0.65 -0.77 -1.35
+Made SmearedTrack: ts9   :7955587511546281993:    0.90    0.65 -0.77 -1.35
+Made Cluster: et14  :3352891083324391438:    0.45 -0.84 -2.00 sub(et14, )
+Made SmearedCluster: es11  :3343893785615532043:    0.68 -0.84 -2.00 sub(es11, )
+Made Cluster: ht10  :5658735575056777226:    0.47 -0.88 -2.18 sub(ht10, )
+Made SmearedCluster: hs8   :5649727429564956680:    0.46 -0.88 -2.18 sub(hs8, )
+Rejected SmearedCluster: hs8   :5649727429564956680:    0.46 -0.88 -2.18 sub(hs8, )
+Simulating Particle :ps16  :10261430415262744592: pdgid =    22, status =   1, q =  0, e =   0.9, theta =  0.84, phi =  1.75, mass =  0.00
+Simulating Photon
+Made Cluster: et15  :3352908586876403727:    0.89  0.84  1.75 sub(et15, )
+Made SmearedCluster: es12  :3343887207524990988:    0.50  0.84  1.75 sub(es12, )
+Rejected SmearedCluster: es12  :3343887207524990988:    0.50  0.84  1.75 sub(es12, )
+Simulating Particle :ps17  :10261429413988007953: pdgid =   211, status =   1, q =  1, e =   0.9, theta =  0.45, phi =  1.90, mass =  0.14
+Simulating Hadron
+Made Track: tt11  :7964593205308030987:    0.85    0.77  0.45  1.90
+Made SmearedTrack: ts10  :7955586030971650058:    0.85    0.77  0.45  1.90
+Made Cluster: et16  :3352887315266535440:    0.39  0.52  0.91 sub(et16, )
+Made SmearedCluster: es12  :3343884069432721420:    0.45  0.52  0.91 sub(es12, )
+Rejected SmearedCluster: es12  :3343884069432721420:    0.45  0.52  0.91 sub(es12, )
+Made Cluster: ht11  :5658735680778403851:    0.47  0.56  0.69 sub(ht11, )
+Made SmearedCluster: hs8   :5649725510847037448:    0.43  0.56  0.69 sub(hs8, )
+Rejected SmearedCluster: hs8   :5649725510847037448:    0.43  0.56  0.69 sub(hs8, )
+Simulating Particle :ps18  :10261424783426060306: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.51, phi =  1.57, mass =  0.00
+Simulating Photon
+Made Cluster: et17  :3352902955039719441:    0.73  0.51  1.57 sub(et17, )
+Made SmearedCluster: es12  :3343898341734875148:    0.81  0.51  1.57 sub(es12, )
+Simulating Particle :ps19  :10261423134701781011: pdgid =  -211, status =   1, q = -1, e =   0.7, theta =  0.28, phi = -0.84, mass =  0.14
+Simulating Hadron
+Made Track: tt12  :7964586820419715084:    0.67    0.65  0.28 -0.84
+Made SmearedTrack: ts11  :7955579687390937099:    0.67    0.65  0.28 -0.84
+Made Cluster: et18  :3352816359183482898:    0.02  0.40  0.65 sub(et18, )
+Made SmearedCluster: es13  :3343838842147831821:    0.08  0.40  0.65 sub(es13, )
+Rejected SmearedCluster: es13  :3343838842147831821:    0.08  0.40  0.65 sub(es13, )
+Made Cluster: ht12  :5658743466337763340:    0.66  0.92  0.68 sub(ht12, )
+Made SmearedCluster: hs8   :5649734255557738504:    0.61  0.92  0.68 sub(hs8, )
+Rejected SmearedCluster: hs8   :5649734255557738504:    0.61  0.92  0.68 sub(hs8, )
+Simulating Particle :ps20  :10261418528112377876: pdgid =  -211, status =   1, q = -1, e =   0.6, theta = -0.93, phi =  1.47, mass =  0.14
+Simulating Hadron
+Made Track: tt13  :7964582091480367117:    0.54    0.32 -0.93  1.47
+Made SmearedTrack: ts12  :7955575085675315212:    0.54    0.33 -0.93  1.47
+Rejected SmearedTrack: ts12  :7955575085675315212:    0.54    0.33 -0.93  1.47
+Made Cluster: ht13  :5658739708939730957:    0.56 -1.24 -2.83 sub(ht13, )
+Made SmearedCluster: hs8   :5649702772774273032:    0.18 -1.24 -2.83 sub(hs8, )
+Rejected SmearedCluster: hs8   :5649702772774273032:    0.18 -1.24 -2.83 sub(hs8, )
+Simulating Particle :ps21  :10261412063861538837: pdgid =   211, status =   1, q =  1, e =   0.4, theta = -0.94, phi =  3.07, mass =  0.14
+Simulating Hadron
+Made Track: tt14  :7964574639491907598:    0.41    0.24 -0.94  3.07
+Made SmearedTrack: ts12  :7955567344793681932:    0.41    0.24 -0.94  3.07
+Rejected SmearedTrack: ts12  :7955567344793681932:    0.41    0.24 -0.94  3.07
+Made Cluster: ht14  :5658733244688891918:    0.44 -1.42  0.51 sub(ht14, )
+Made SmearedCluster: hs8   :5647513932722601992:   -0.01 -1.42  0.51 sub(hs8, )
+Rejected SmearedCluster: hs8   :5647513932722601992:   -0.01 -1.42  0.51 sub(hs8, )
+Simulating Particle :ps24  :10261400861647306776: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -1.55, phi = -1.50, mass =  0.00
+Simulating Photon
+Made Cluster: et19  :3352879033260965907:    0.28 -1.55 -1.50 sub(et19, )
+Made SmearedCluster: es13  :3343878591417942029:    0.37 -1.55 -1.50 sub(es13, )
+Rejected SmearedCluster: es13  :3343878591417942029:    0.37 -1.55 -1.50 sub(es13, )
+Simulating Particle :ps25  :10261397959889387545: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.67, phi = -2.08, mass =  0.00
+Simulating Photon
+Made Cluster: et20  :3352876131503046676:    0.24 -0.67 -2.08 sub(et20, )
+Made SmearedCluster: es13  :3343852441079644173:    0.13 -0.67 -2.08 sub(es13, )
+Rejected SmearedCluster: es13  :3343852441079644173:    0.13 -0.67 -2.08 sub(es13, )
+Simulating Particle :ps26  :10261397066825596954: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.91, phi =  0.68, mass =  0.00
+Simulating Photon
+Made Cluster: et21  :3352875238439256085:    0.24  0.91  0.68 sub(et21, )
+Made SmearedCluster: es13  :3343878077617799181:    0.37  0.91  0.68 sub(es13, )
+Rejected SmearedCluster: es13  :3343878077617799181:    0.37  0.91  0.68 sub(es13, )
+Simulating Particle :ps27  :10261395923951157275: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -1.05, phi =  2.24, mass =  0.00
+Simulating Photon
+Made Cluster: et22  :3352874095564816406:    0.23 -1.05  2.24 sub(et22, )
+Made SmearedCluster: es13  :3343871433615867917:    0.27 -1.05  2.24 sub(es13, )
+Rejected SmearedCluster: es13  :3343871433615867917:    0.27 -1.05  2.24 sub(es13, )
+Simulating Particle :ps29  :10261382099441287197: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.95, phi =  1.61, mass =  0.00
+Simulating Photon
+Made Cluster: et23  :3352860271054946327:    0.13  0.95  1.61 sub(et23, )
+Made SmearedCluster: es13  :3343838018633990157:    0.07  0.95  1.61 sub(es13, )
+Rejected SmearedCluster: es13  :3343838018633990157:    0.07  0.95  1.61 sub(es13, )
+Simulating Particle :ps30  :10261374650906837022: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -1.31, phi =  2.07, mass =  0.00
+Simulating Photon
+Made Cluster: et24  :3352852822520496152:    0.10 -1.31  2.07 sub(et24, )
+Made SmearedCluster: es13  :3343854159024619533:    0.14 -1.31  2.07 sub(es13, )
+Rejected SmearedCluster: es13  :3343854159024619533:    0.14 -1.31  2.07 sub(es13, )
+Simulating Particle :ps31  :10261336280870682655: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.23, phi = -2.00, mass =  0.00
+Simulating Photon
+Made Cluster: et25  :3352814452484341785:    0.02 -0.23 -2.00 sub(et25, )
+Made SmearedCluster: es13  :3341670923508908045:   -0.00 -0.23 -2.00 sub(es13, )
+Rejected SmearedCluster: es13  :3341670923508908045:   -0.00 -0.23 -2.00 sub(es13, )
+Made MergedCluster: em0   :3289850590087086080:    0.68 -0.84 -2.00 sub(es11, )
+Made MergedCluster: em1   :3289852882890784769:    0.74  0.78  1.34 sub(es9, )
+Made MergedCluster: em2   :3289855146206429186:    0.81  0.51  1.57 sub(es12, )
+Made MergedCluster: em3   :3289858226459246595:    0.89  0.88  0.97 sub(es10, )
+Made MergedCluster: em4   :3289863856408494084:    1.11  1.09  1.77 sub(es8, )
+Made MergedCluster: em5   :3289864853396652037:    1.17  0.78  1.97 sub(es7, )
+Made MergedCluster: em6   :3289871858412814342:    1.56 -0.80 -1.44 sub(es5, )
+Made MergedCluster: em7   :3289893818272317447:    3.62  0.85  1.63 sub(es6, )
+Made MergedCluster: em8   :3289927056099377160:   13.61 -0.79 -1.57 sub(es2, es1, )
+Made MergedCluster: em9   :3289910122106585097:    6.96  0.81  1.61 sub(es4, )
+Made MergedCluster: em10  :3289914223565471754:    7.89 -0.79 -1.55 sub(es3, )
+Made MergedCluster: em11  :3289939833245401099:   22.85  0.80  1.61 sub(es0, )
+Made MergedCluster: hm0   :5595717547363139584:    1.72  1.10  1.81 sub(hs5, )
+Made MergedCluster: hm1   :5595719279128346625:    1.81  0.89  0.90 sub(hs7, )
+Made MergedCluster: hm2   :5595721079254417410:    1.92 -0.92 -2.07 sub(hs4, )
+Made MergedCluster: hm3   :5595724925512974339:    2.27 -0.90 -1.29 sub(hs6, )
+Made MergedCluster: hm4   :5595725095518601220:    2.29  0.78  2.01 sub(hs3, )
+Made MergedCluster: hm5   :5595726542293434373:    2.46 -0.77 -1.23 sub(hs2, )
+Made MergedCluster: hm6   :5595730315166351366:    2.88 -0.80 -1.42 sub(hs1, )
+Made MergedCluster: hm7   :5595753732722655239:    7.09 -0.79 -1.59 sub(hs0, )
+Made block:E1T1     :br0   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  0.9 (7955587511546281993)
+      e1 = em0       value=  0.7 (3289850590087086080)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :br1   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts6       value=  1.7 (7955602737163403270)
+      e1 = em1       value=  0.7 (3289852882890784769)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.8 (3289855146206429186)
+
+Made block:E1H1T1   :br3   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  1.6 (7955601290367598599)
+      h1 = hm1       value=  1.8 (5595719279128346625)
+      e2 = em3       value=  0.9 (3289858226459246595)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :br4   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  2.0 (7955609015568826372)
+      h1 = hm0       value=  1.7 (5595717547363139584)
+      e2 = em4       value=  1.1 (3289863856408494084)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :br5   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts2       value=  2.6 (7955613647758163970)
+      h1 = hm4       value=  2.3 (5595725095518601220)
+      e2 = em5       value=  1.2 (3289864853396652037)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :br6   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts0       value=  6.1 (7955635356001370112)
+      h1 = hm6       value=  2.9 (5595730315166351366)
+      e2 = em6       value=  1.6 (3289871858412814342)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  3.6 (3289893818272317447)
+
+Made block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  7.0 (3289910122106585097)
+
+Made block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  7.9 (3289914223565471754)
+
+Made block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value= 13.6 (3289927056099377160)
+
+Made block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value= 22.8 (3289939833245401099)
+
+Made block:H1T1     :br12  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  2.4 (7955612182220111875)
+      h1 = hm2       value=  1.9 (5595721079254417410)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br13  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  1.8 (7955604846986395653)
+      h1 = hm3       value=  2.3 (5595724925512974339)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br14  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts1       value=  3.1 (7955618303284609025)
+      h1 = hm5       value=  2.5 (5595726542293434373)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1       :br15  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm7       value=  7.1 (5595753732722655239)
+
+Made block:T1       :br16  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  0.7 (7955579687390937099)
+
+Made block:T1       :br17  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  0.9 (7955586030971650058)
+
+Made block:T1       :br18  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  1.1 (7955593286582796296)
+
+Splitting block:E1H1T1   :br6   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts0       value=  6.1 (7955635356001370112)
+      h1 = hm6       value=  2.9 (5595730315166351366)
+      e2 = em6       value=  1.6 (3289871858412814342)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs0   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts0       value=  6.1 (7955635356001370112)
+      h1 = hm6       value=  2.9 (5595730315166351366)
+      e2 = em6       value=  1.6 (3289871858412814342)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:E1H1T1   :br5   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts2       value=  2.6 (7955613647758163970)
+      h1 = hm4       value=  2.3 (5595725095518601220)
+      e2 = em5       value=  1.2 (3289864853396652037)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs1   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts2       value=  2.6 (7955613647758163970)
+      h1 = hm4       value=  2.3 (5595725095518601220)
+      e2 = em5       value=  1.2 (3289864853396652037)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:E1H1T1   :br4   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  2.0 (7955609015568826372)
+      h1 = hm0       value=  1.7 (5595717547363139584)
+      e2 = em4       value=  1.1 (3289863856408494084)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  2.0 (7955609015568826372)
+      h1 = hm0       value=  1.7 (5595717547363139584)
+      e2 = em4       value=  1.1 (3289863856408494084)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:E1H1T1   :br3   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  1.6 (7955601290367598599)
+      h1 = hm1       value=  1.8 (5595719279128346625)
+      e2 = em3       value=  0.9 (3289858226459246595)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs3   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  1.6 (7955601290367598599)
+      h1 = hm1       value=  1.8 (5595719279128346625)
+      e2 = em3       value=  0.9 (3289858226459246595)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:H1T1     :br14  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts1       value=  3.1 (7955618303284609025)
+      h1 = hm5       value=  2.5 (5595726542293434373)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs4   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts1       value=  3.1 (7955618303284609025)
+      h1 = hm5       value=  2.5 (5595726542293434373)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br13  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  1.8 (7955604846986395653)
+      h1 = hm3       value=  2.3 (5595724925512974339)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs5   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  1.8 (7955604846986395653)
+      h1 = hm3       value=  2.3 (5595724925512974339)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br12  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  2.4 (7955612182220111875)
+      h1 = hm2       value=  1.9 (5595721079254417410)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs6   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  2.4 (7955612182220111875)
+      h1 = hm2       value=  1.9 (5595721079254417410)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:E1T1     :br1   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts6       value=  1.7 (7955602737163403270)
+      e1 = em1       value=  0.7 (3289852882890784769)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs7   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts6       value=  1.7 (7955602737163403270)
+      e1 = em1       value=  0.7 (3289852882890784769)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br0   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  0.9 (7955587511546281993)
+      e1 = em0       value=  0.7 (3289850590087086080)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs8   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  0.9 (7955587511546281993)
+      e1 = em0       value=  0.7 (3289850590087086080)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:T1       :br18  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  1.1 (7955593286582796296)
+
+Made block:T1       :bs9   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  1.1 (7955593286582796296)
+
+Splitting block:T1       :br17  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  0.9 (7955586030971650058)
+
+Made block:T1       :bs10  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  0.9 (7955586030971650058)
+
+Splitting block:T1       :br16  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  0.7 (7955579687390937099)
+
+Made block:T1       :bs11  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  0.7 (7955579687390937099)
+
+Splitting block:H1       :br15  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm7       value=  7.1 (5595753732722655239)
+
+Made block:H1       :bs12  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm7       value=  7.1 (5595753732722655239)
+
+Splitting block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value= 22.8 (3289939833245401099)
+
+Made block:E1       :bs13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value= 22.8 (3289939833245401099)
+
+Splitting block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value= 13.6 (3289927056099377160)
+
+Made block:E1       :bs14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value= 13.6 (3289927056099377160)
+
+Splitting block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  7.9 (3289914223565471754)
+
+Made block:E1       :bs15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  7.9 (3289914223565471754)
+
+Splitting block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  7.0 (3289910122106585097)
+
+Made block:E1       :bs16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  7.0 (3289910122106585097)
+
+Splitting block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  3.6 (3289893818272317447)
+
+Made block:E1       :bs17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  3.6 (3289893818272317447)
+
+Splitting block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.8 (3289855146206429186)
+
+Made block:E1       :bs18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.8 (3289855146206429186)
+
+Processing block:E1H1T1   :bs3   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  1.6 (7955601290367598599)
+      h1 = hm1       value=  1.8 (5595719279128346625)
+      e2 = em3       value=  0.9 (3289858226459246595)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr0   :10252437207923032064: pdgid =   211, status =   1, q =  1, e =   1.6, theta =  0.85, phi =  1.63, mass =  0.14 from SmearedTrack: ts7   :7955601290367598599:    1.58    1.05  0.85  1.63
+Finished block
+Processing block:E1H1T1   :bs2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  2.0 (7955609015568826372)
+      h1 = hm0       value=  1.7 (5595717547363139584)
+      e2 = em4       value=  1.1 (3289863856408494084)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr1   :10252444867313532929: pdgid =  -211, status =   1, q = -1, e =   2.0, theta =  1.08, phi =  1.33, mass =  0.14 from SmearedTrack: ts4   :7955609015568826372:    2.03    0.96  1.08  1.33
+Finished block
+Processing block:E1H1T1   :bs1   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts2       value=  2.6 (7955613647758163970)
+      h1 = hm4       value=  2.3 (5595725095518601220)
+      e2 = em5       value=  1.2 (3289864853396652037)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr2   :10252449490915033090: pdgid =  -211, status =   1, q = -1, e =   2.6, theta =  0.77, phi =  1.62, mass =  0.14 from SmearedTrack: ts2   :7955613647758163970:    2.56    1.84  0.77  1.62
+Finished block
+Processing block:E1H1T1   :bs0   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts0       value=  6.1 (7955635356001370112)
+      h1 = hm6       value=  2.9 (5595730315166351366)
+      e2 = em6       value=  1.6 (3289871858412814342)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr3   :10252471172981587971: pdgid =  -211, status =   1, q = -1, e =   6.1, theta = -0.80, phi = -1.52, mass =  0.14 from SmearedTrack: ts0   :7955635356001370112:    6.05    4.24 -0.80 -1.52
+Finished block
+Processing block:E1T1     :bs8   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  0.9 (7955587511546281993)
+      e1 = em0       value=  0.7 (3289850590087086080)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr4   :10252423698350866436: pdgid =   211, status =   1, q =  1, e =   0.9, theta = -0.77, phi = -1.35, mass =  0.14 from SmearedTrack: ts9   :7955587511546281993:    0.90    0.65 -0.77 -1.35
+Finished block
+Processing block:E1T1     :bs7   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts6       value=  1.7 (7955602737163403270)
+      e1 = em1       value=  0.7 (3289852882890784769)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr5   :10252438649404653573: pdgid =   211, status =   1, q =  1, e =   1.7, theta =  0.75, phi =  1.91, mass =  0.14 from SmearedTrack: ts6   :7955602737163403270:    1.66    1.21  0.75  1.91
+Finished block
+Processing block:H1T1     :bs6   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  2.4 (7955612182220111875)
+      h1 = hm2       value=  1.9 (5595721079254417410)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr6   :10252448027685945350: pdgid =   211, status =   1, q =  1, e =   2.4, theta = -0.90, phi = -1.61, mass =  0.14 from SmearedTrack: ts3   :7955612182220111875:    2.39    1.48 -0.90 -1.61
+Finished block
+Processing block:H1T1     :bs5   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  1.8 (7955604846986395653)
+      h1 = hm3       value=  2.3 (5595724925512974339)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr7   :10252440752353181703: pdgid =  -211, status =   1, q = -1, e =   1.8, theta = -0.87, phi = -1.92, mass =  0.14 from SmearedTrack: ts5   :7955604846986395653:    1.78    1.15 -0.87 -1.92
+Finished block
+Processing block:H1T1     :bs4   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts1       value=  3.1 (7955618303284609025)
+      h1 = hm5       value=  2.5 (5595726542293434373)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr8   :10252454140756099080: pdgid =  -211, status =   1, q = -1, e =   3.1, theta = -0.75, phi = -1.46, mass =  0.14 from SmearedTrack: ts1   :7955618303284609025:    3.09    2.25 -0.75 -1.46
+Finished block
+Processing block:E1       :bs18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.8 (3289855146206429186)
+
+Made Particle :pr9   :10252420170121216009: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.51, phi =  1.57, mass =  0.00 from MergedCluster: em2   :3289855146206429186:    0.81  0.51  1.57 sub(es12, )
+Finished block
+Processing block:E1       :bs17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  3.6 (3289893818272317447)
+
+Made Particle :pr10  :10252458842187104266: pdgid =    22, status =   1, q =  0, e =   3.6, theta =  0.85, phi =  1.63, mass =  0.00 from MergedCluster: em7   :3289893818272317447:    3.62  0.85  1.63 sub(es6, )
+Finished block
+Processing block:E1       :bs16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  7.0 (3289910122106585097)
+
+Made Particle :pr11  :10252475146021371915: pdgid =    22, status =   1, q =  0, e =   7.0, theta =  0.81, phi =  1.61, mass =  0.00 from MergedCluster: em9   :3289910122106585097:    6.96  0.81  1.61 sub(es4, )
+Finished block
+Processing block:E1       :bs15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  7.9 (3289914223565471754)
+
+Made Particle :pr12  :10252479247480258572: pdgid =    22, status =   1, q =  0, e =   7.9, theta = -0.79, phi = -1.55, mass =  0.00 from MergedCluster: em10  :3289914223565471754:    7.89 -0.79 -1.55 sub(es3, )
+Finished block
+Processing block:E1       :bs14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value= 13.6 (3289927056099377160)
+
+Made Particle :pr13  :10252492080014163981: pdgid =    22, status =   1, q =  0, e =  13.6, theta = -0.79, phi = -1.57, mass =  0.00 from MergedCluster: em8   :3289927056099377160:   13.61 -0.79 -1.57 sub(es2, es1, )
+Finished block
+Processing block:E1       :bs13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value= 22.8 (3289939833245401099)
+
+Made Particle :pr14  :10252504857160187918: pdgid =    22, status =   1, q =  0, e =  22.8, theta =  0.80, phi =  1.61, mass =  0.00 from MergedCluster: em11  :3289939833245401099:   22.85  0.80  1.61 sub(es0, )
+Finished block
+Processing block:H1       :bs12  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm7       value=  7.1 (5595753732722655239)
+
+Made Particle :pr15  :10252475747423748111: pdgid =   130, status =   1, q =  0, e =   7.1, theta = -0.79, phi = -1.59, mass =  0.50 from MergedCluster: hm7   :5595753732722655239:    7.09 -0.79 -1.59 sub(hs0, )
+Finished block
+Processing block:T1       :bs11  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  0.7 (7955579687390937099)
+
+Made Particle :pr16  :10252415996235087888: pdgid =  -211, status =   1, q = -1, e =   0.7, theta =  0.28, phi = -0.84, mass =  0.14 from SmearedTrack: ts11  :7955579687390937099:    0.67    0.65  0.28 -0.84
+Finished block
+Processing block:T1       :bs10  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  0.9 (7955586030971650058)
+
+Made Particle :pr17  :10252422236099051537: pdgid =   211, status =   1, q =  1, e =   0.9, theta =  0.45, phi =  1.90, mass =  0.14 from SmearedTrack: ts10  :7955586030971650058:    0.85    0.77  0.45  1.90
+Finished block
+Processing block:T1       :bs9   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  1.1 (7955593286582796296)
+
+Made Particle :pr18  :10252429247505235986: pdgid =  -211, status =   1, q = -1, e =   1.1, theta = -0.41, phi = -0.48, mass =  0.14 from SmearedTrack: ts8   :7955593286582796296:    1.12    1.03 -0.41 -0.48
+Finished block
+Finished reconstruction
+Event: 7
+Made Particle :ps0   :10261493589055897600: pdgid = -2212, status =   1, q = -1, e =  11.0, theta =  0.07, phi =  0.89, mass =  0.94
+Made Particle :ps1   :10261492105295691777: pdgid =  -211, status =   1, q = -1, e =  10.4, theta =  0.01, phi =  0.85, mass =  0.14
+Made Particle :ps2   :10261492075268669442: pdgid =   211, status =   1, q =  1, e =  10.3, theta =  0.06, phi =  0.83, mass =  0.14
+Made Particle :ps3   :10261478657811808259: pdgid =   211, status =   1, q =  1, e =   6.1, theta =  0.15, phi =  0.86, mass =  0.14
+Made Particle :ps4   :10261473536774242308: pdgid =    22, status =   1, q =  0, e =   5.0, theta =  0.32, phi = -2.02, mass =  0.00
+Made Particle :ps5   :10261469033274540037: pdgid =   211, status =   1, q =  1, e =   4.0, theta = -0.52, phi = -2.56, mass =  0.14
+Made Particle :ps6   :10261468857468190726: pdgid =  -211, status =   1, q = -1, e =   3.9, theta =  0.38, phi = -2.03, mass =  0.14
+Made Particle :ps7   :10261468005160452103: pdgid =    22, status =   1, q =  0, e =   3.8, theta =  0.37, phi = -2.14, mass =  0.00
+Made Particle :ps8   :10261461628912402440: pdgid =   211, status =   1, q =  1, e =   3.1, theta = -0.62, phi = -2.39, mass =  0.14
+Made Particle :ps9   :10261455418689585161: pdgid =   211, status =   1, q =  1, e =   2.4, theta = -0.87, phi = -2.54, mass =  0.14
+Made Particle :ps10  :10261452815830351882: pdgid =  -211, status =   1, q = -1, e =   2.1, theta = -0.74, phi = -2.54, mass =  0.14
+Made Particle :ps11  :10261447325039722507: pdgid =   211, status =   1, q =  1, e =   1.7, theta =  0.13, phi = -2.17, mass =  0.14
+Made Particle :ps12  :10261445478644187148: pdgid =  -321, status =   1, q = -1, e =   1.6, theta = -0.70, phi = -2.12, mass =  0.49
+Made Particle :ps13  :10261444377173819405: pdgid =    22, status =   1, q =  0, e =   1.6, theta = -0.45, phi = -2.51, mass =  0.00
+Made Particle :ps14  :10261442682312196110: pdgid =   211, status =   1, q =  1, e =   1.5, theta =  0.41, phi = -2.08, mass =  0.14
+Made Particle :ps15  :10261441043251593231: pdgid =  2212, status =   1, q =  1, e =   1.4, theta = -0.13, phi =  0.98, mass =  0.94
+Made Particle :ps16  :10261440918909354000: pdgid =    22, status =   1, q =  0, e =   1.4, theta = -0.48, phi = -2.60, mass =  0.00
+Made Particle :ps17  :10261440608212090897: pdgid =    22, status =   1, q =  0, e =   1.4, theta =  0.40, phi = -2.64, mass =  0.00
+Made Particle :ps18  :10261438948999954450: pdgid =  -211, status =   1, q = -1, e =   1.3, theta = -0.73, phi = -2.74, mass =  0.14
+Made Particle :ps19  :10261438786418245651: pdgid =   130, status =   1, q =  0, e =   1.3, theta = -0.67, phi = -2.54, mass =  0.50
+Made Particle :ps20  :10261437701515378708: pdgid =    22, status =   1, q =  0, e =   1.2, theta =  0.31, phi = -2.15, mass =  0.00
+Made Particle :ps21  :10261437102929477653: pdgid =    22, status =   1, q =  0, e =   1.2, theta =  0.30, phi = -2.40, mass =  0.00
+Made Particle :ps22  :10261436637747609622: pdgid =    22, status =   1, q =  0, e =   1.1, theta =  0.11, phi = -2.39, mass =  0.00
+Made Particle :ps23  :10261433285827624983: pdgid =  -211, status =   1, q = -1, e =   1.0, theta =  0.27, phi = -2.20, mass =  0.14
+Made Particle :ps24  :10261432786281824280: pdgid =  -211, status =   1, q = -1, e =   1.0, theta = -0.82, phi =  1.82, mass =  0.14
+Made Particle :ps25  :10261430530062942233: pdgid =   211, status =   1, q =  1, e =   0.9, theta =  0.73, phi = -2.27, mass =  0.14
+Made Particle :ps26  :10261424688313925658: pdgid =  -211, status =   1, q = -1, e =   0.7, theta =  0.05, phi = -1.77, mass =  0.14
+Made Particle :ps27  :10261424066929885211: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.42, phi = -2.31, mass =  0.00
+Made Particle :ps28  :10261422827745837084: pdgid =   211, status =   1, q =  1, e =   0.7, theta =  0.41, phi = -1.95, mass =  0.14
+Made Particle :ps29  :10261422593827405853: pdgid =   321, status =   1, q =  1, e =   0.7, theta =  0.14, phi =  0.29, mass =  0.49
+Made Particle :ps30  :10261421758699536414: pdgid =  -211, status =   1, q = -1, e =   0.6, theta =  0.51, phi =  2.53, mass =  0.14
+Made Particle :ps31  :10261421488406003743: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.72, phi = -0.62, mass =  0.00
+Made Particle :ps32  :10261418539306975264: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.51, phi = -2.38, mass =  0.00
+Made Particle :ps33  :10261418522122911777: pdgid =   211, status =   1, q =  1, e =   0.6, theta =  1.12, phi =  0.98, mass =  0.14
+Made Particle :ps34  :10261416671923142690: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.72, phi = -2.56, mass =  0.00
+Made Particle :ps35  :10261415477347614755: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.43, phi = -2.47, mass =  0.00
+Made Particle :ps36  :10261413463842619428: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.25, phi = -2.20, mass =  0.00
+Made Particle :ps37  :10261408117600288805: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  1.00, phi = -1.59, mass =  0.00
+Made Particle :ps38  :10261404036458610726: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.08, phi = -2.34, mass =  0.00
+Made Particle :ps39  :10261403776581632039: pdgid =   211, status =   1, q =  1, e =   0.3, theta = -0.15, phi = -0.68, mass =  0.14
+Made Particle :ps40  :10261402207800786984: pdgid =  -211, status =   1, q = -1, e =   0.3, theta = -0.20, phi =  3.09, mass =  0.14
+Made Particle :ps41  :10261400287853936681: pdgid =  -211, status =   1, q = -1, e =   0.3, theta = -0.21, phi =  0.42, mass =  0.14
+Made Particle :ps42  :10261392834282127402: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.43, phi = -1.94, mass =  0.00
+Made Particle :ps43  :10261390761775857707: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.35, phi = -0.75, mass =  0.00
+Made Particle :ps44  :10261390641516773420: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.18, phi = -2.29, mass =  0.00
+Made Particle :ps45  :10261388884663337005: pdgid =  -211, status =   1, q = -1, e =   0.2, theta =  0.29, phi = -1.19, mass =  0.14
+Made Particle :ps46  :10261379124666826798: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.07, phi = -0.96, mass =  0.00
+Made Particle :ps47  :10261376506263502895: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.81, phi = -2.69, mass =  0.00
+Made Particle :ps48  :10261354110253006896: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.82, phi =  2.35, mass =  0.00
+Made Particle :ps49  :10261342138346242097: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  0.68, phi = -2.06, mass =  0.00
+Made Particle :ps50  :10261333059123019826: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  0.63, phi =  3.04, mass =  0.00
+Made Particle :ps51  :10261323654044319795: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  1.07, phi =  0.28, mass =  0.00
+Simulating Particle :ps0   :10261493589055897600: pdgid = -2212, status =   1, q = -1, e =  11.0, theta =  0.07, phi =  0.89, mass =  0.94
+Simulating Hadron
+Made Track: tt0   :7964657691146584064:   10.99   10.96  0.07  0.89
+Made SmearedTrack: ts0   :7955650512458612736:   11.00   10.97  0.07  0.89
+Made Cluster: et0   :3352939233837842432:    3.06  0.07  0.95 sub(et0, )
+Made SmearedCluster: es0   :3343934570574643200:    3.35  0.07  0.95 sub(es0, )
+Made Cluster: ht0   :5658807971879059456:    7.97  0.07  0.96 sub(ht0, )
+Made SmearedCluster: hs0   :5649795219885916160:    6.70  0.07  0.96 sub(hs0, )
+Simulating Particle :ps1   :10261492105295691777: pdgid =  -211, status =   1, q = -1, e =  10.4, theta =  0.01, phi =  0.85, mass =  0.14
+Simulating Hadron
+Made Track: tt1   :7964656293268946945:   10.35   10.35  0.01  0.85
+Made SmearedTrack: ts1   :7955649108717338625:   10.36   10.36  0.01  0.85
+Made Cluster: ht1   :5658813286123044865:   10.35  0.01  0.92 sub(ht1, )
+Made SmearedCluster: hs1   :5649812491255939073:   13.26  0.01  0.92 sub(hs1, )
+Simulating Particle :ps2   :10261492075268669442: pdgid =   211, status =   1, q =  1, e =  10.3, theta =  0.06, phi =  0.83, mass =  0.14
+Simulating Hadron
+Made Track: tt2   :7964656263235633154:   10.34   10.32  0.06  0.83
+Made SmearedTrack: ts2   :7955649065845260290:   10.34   10.32  0.06  0.83
+Made Cluster: et1   :3352941636089806849:    3.33  0.06  0.77 sub(et1, )
+Made SmearedCluster: es1   :3343923824520331265:    2.13  0.06  0.77 sub(es1, )
+Made Cluster: ht2   :5658803743177572354:    7.01  0.06  0.76 sub(ht2, )
+Made SmearedCluster: hs2   :5649784692470185986:    4.31  0.06  0.76 sub(hs2, )
+Simulating Particle :ps3   :10261478657811808259: pdgid =   211, status =   1, q =  1, e =   6.1, theta =  0.15, phi =  0.86, mass =  0.14
+Simulating Hadron
+Made Track: tt3   :7964642840850464771:    6.12    6.05  0.15  0.86
+Made SmearedTrack: ts3   :7955635618459942915:    6.11    6.05  0.15  0.86
+Made Cluster: et2   :3352944089604554754:    3.61  0.15  0.75 sub(et2, )
+Made SmearedCluster: es2   :3343944896368082946:    5.04  0.15  0.75 sub(es2, )
+Made Cluster: ht3   :5658777394090082307:    2.51  0.15  0.74 sub(ht3, )
+Made SmearedCluster: hs3   :5649763647119949827:    1.88  0.15  0.74 sub(hs3, )
+Simulating Particle :ps4   :10261473536774242308: pdgid =    22, status =   1, q =  0, e =   5.0, theta =  0.32, phi = -2.02, mass =  0.00
+Simulating Photon
+Made Cluster: et3   :3352951708387901443:    4.95  0.32 -2.02 sub(et3, )
+Made SmearedCluster: es3   :3343944267373477891:    4.90  0.32 -2.02 sub(es3, )
+Simulating Particle :ps5   :10261469033274540037: pdgid =   211, status =   1, q =  1, e =   4.0, theta = -0.52, phi = -2.56, mass =  0.14
+Simulating Hadron
+Made Track: tt4   :7964633201700241412:    3.96    3.44 -0.52 -2.56
+Made SmearedTrack: ts4   :7955625878499622916:    3.95    3.43 -0.52 -2.56
+Rejected SmearedTrack: ts4   :7955625878499622916:    3.95    3.43 -0.52 -2.56
+Made Cluster: ht4   :5658790214101893124:    3.96 -0.52 -2.78 sub(ht4, )
+Made SmearedCluster: hs4   :5649787887720333316:    5.04 -0.52 -2.78 sub(hs4, )
+Simulating Particle :ps6   :10261468857468190726: pdgid =  -211, status =   1, q = -1, e =   3.9, theta =  0.38, phi = -2.03, mass =  0.14
+Simulating Hadron
+Made Track: tt5   :7964633025784840197:    3.94    3.66  0.38 -2.03
+Made SmearedTrack: ts4   :7955625893796249604:    3.95    3.67  0.38 -2.03
+Made Cluster: et4   :3352931694572208132:    2.20  0.38 -1.85 sub(et4, )
+Made SmearedCluster: es4   :3343924818113200132:    2.24  0.38 -1.85 sub(es4, )
+Made Cluster: ht5   :5658768416438222853:    1.74  0.38 -1.83 sub(ht5, )
+Made SmearedCluster: hs5   :5649749944156815365:    1.10  0.38 -1.83 sub(hs5, )
+Simulating Particle :ps7   :10261468005160452103: pdgid =    22, status =   1, q =  0, e =   3.8, theta =  0.37, phi = -2.14, mass =  0.00
+Simulating Photon
+Made Cluster: et5   :3352946176774111237:    3.85  0.37 -2.14 sub(et5, )
+Made SmearedCluster: es5   :3343942110029021189:    4.41  0.37 -2.14 sub(es5, )
+Simulating Particle :ps8   :10261461628912402440: pdgid =   211, status =   1, q =  1, e =   3.1, theta = -0.62, phi = -2.39, mass =  0.14
+Simulating Hadron
+Made Track: tt6   :7964625791505924102:    3.12    2.53 -0.62 -2.39
+Made SmearedTrack: ts5   :7955618553382567941:    3.12    2.53 -0.62 -2.39
+Made Cluster: ht6   :5658782809739755526:    3.12 -0.63 -2.68 sub(ht6, )
+Made SmearedCluster: hs6   :5649773973720793094:    2.94 -0.63 -2.68 sub(hs6, )
+Simulating Particle :ps9   :10261455418689585161: pdgid =   211, status =   1, q =  1, e =   2.4, theta = -0.87, phi = -2.54, mass =  0.14
+Simulating Hadron
+Made Track: tt7   :7964619573255208967:    2.41    1.56 -0.87 -2.54
+Made SmearedTrack: ts6   :7955612468630257670:    2.42    1.56 -0.87 -2.54
+Made Cluster: et6   :3352924475218722822:    1.69 -0.88 -2.96 sub(et6, )
+Made SmearedCluster: es6   :3343915570044076038:    1.59 -0.88 -2.96 sub(es6, )
+Made Cluster: ht7   :5658745720853757959:    0.73 -0.89 -3.01 sub(ht7, )
+Made SmearedCluster: hs7   :5649752926321639431:    1.27 -0.89 -3.01 sub(hs7, )
+Simulating Particle :ps10  :10261452815830351882: pdgid =  -211, status =   1, q = -1, e =   2.1, theta = -0.74, phi = -2.54, mass =  0.14
+Simulating Hadron
+Made Track: tt8   :7964616965436211208:    2.12    1.57 -0.74 -2.54
+Made SmearedTrack: ts7   :7955609793077444615:    2.12    1.57 -0.74 -2.54
+Made Cluster: et7   :3352894875031830535:    0.50 -0.75 -2.12 sub(et7, )
+Made SmearedCluster: es7   :3343896295237484551:    0.75 -0.75 -2.12 sub(es7, )
+Made Cluster: ht8   :5658766197020164104:    1.62 -0.75 -2.07 sub(ht8, )
+Made SmearedCluster: hs8   :5649773604317954056:    2.89 -0.75 -2.07 sub(hs8, )
+Simulating Particle :ps11  :10261447325039722507: pdgid =   211, status =   1, q =  1, e =   1.7, theta =  0.13, phi = -2.17, mass =  0.14
+Simulating Hadron
+Made Track: tt9   :7964611416923570185:    1.74    1.73  0.13 -2.17
+Made SmearedTrack: ts8   :7955604201703211016:    1.74    1.73  0.13 -2.17
+Made Cluster: et8   :3352911823740338184:    0.99  0.13 -2.55 sub(et8, )
+Made SmearedCluster: es8   :3343889025936130056:    0.54  0.13 -2.55 sub(es8, )
+Made Cluster: ht9   :5658746994410127369:    0.76  0.14 -2.60 sub(ht9, )
+Made SmearedCluster: hs9   :5649753280379617289:    1.29  0.14 -2.60 sub(hs9, )
+Simulating Particle :ps12  :10261445478644187148: pdgid =  -321, status =   1, q = -1, e =   1.6, theta = -0.70, phi = -2.12, mass =  0.49
+Simulating Hadron
+Made Track: tt10  :7964608333418070026:    1.57    1.20 -0.70 -2.12
+Made SmearedTrack: ts9   :7955601142266724361:    1.57    1.20 -0.70 -2.12
+Made Cluster: et9   :3352897472832733193:    0.58 -0.73 -1.55 sub(et9, )
+Made SmearedCluster: es9   :3341670923508908041:   -0.11 -0.73 -1.55 sub(es9, )
+Rejected SmearedCluster: es9   :3341670923508908041:   -0.11 -0.73 -1.55 sub(es9, )
+Made Cluster: ht10  :5658756496064774154:    1.07 -0.73 -1.48 sub(ht10, )
+Made SmearedCluster: hs10  :5649767737998704650:    2.23 -0.73 -1.48 sub(hs10, )
+Simulating Particle :ps13  :10261444377173819405: pdgid =    22, status =   1, q =  0, e =   1.6, theta = -0.45, phi = -2.51, mass =  0.00
+Simulating Photon
+Made Cluster: et10  :3352922548787478538:    1.58 -0.45 -2.51 sub(et10, )
+Made SmearedCluster: es9   :3343911663158951945:    1.37 -0.45 -2.51 sub(es9, )
+Simulating Particle :ps14  :10261442682312196110: pdgid =   211, status =   1, q =  1, e =   1.5, theta =  0.41, phi = -2.08, mass =  0.14
+Simulating Hadron
+Made Track: tt11  :7964606756674338827:    1.48    1.36  0.41 -2.08
+Made SmearedTrack: ts10  :7955599381174943754:    1.47    1.35  0.41 -2.08
+Made Cluster: ht11  :5658763863139549195:    1.48  0.43 -2.64 sub(ht11, )
+Made SmearedCluster: hs11  :5649760362275274763:    1.69  0.43 -2.64 sub(hs11, )
+Simulating Particle :ps15  :10261441043251593231: pdgid =  2212, status =   1, q =  1, e =   1.4, theta = -0.13, phi =  0.98, mass =  0.94
+Simulating Hadron
+Made Track: tt12  :7964598830138130444:    1.03    1.02 -0.13  0.98
+Made SmearedTrack: ts11  :7955591631172796427:    1.03    1.02 -0.13  0.98
+Made Cluster: et11  :3352897360876273675:    0.57 -0.15  0.31 sub(et11, )
+Made SmearedCluster: es10  :3343894367705235466:    0.69 -0.15  0.31 sub(es10, )
+Made Cluster: ht12  :5658748893695836172:    0.82 -0.15  0.21 sub(ht12, )
+Made SmearedCluster: hs12  :5649751799991631884:    1.21 -0.15  0.21 sub(hs12, )
+Simulating Particle :ps16  :10261440918909354000: pdgid =    22, status =   1, q =  0, e =   1.4, theta = -0.48, phi = -2.60, mass =  0.00
+Simulating Photon
+Made Cluster: et12  :3352919090523013132:    1.38 -0.48 -2.60 sub(et12, )
+Made SmearedCluster: es11  :3343909829889490955:    1.27 -0.48 -2.60 sub(es11, )
+Simulating Particle :ps17  :10261440608212090897: pdgid =    22, status =   1, q =  0, e =   1.4, theta =  0.40, phi = -2.64, mass =  0.00
+Simulating Photon
+Made Cluster: et13  :3352918779825750029:    1.37  0.40 -2.64 sub(et13, )
+Made SmearedCluster: es12  :3343906887377616908:    1.10  0.40 -2.64 sub(es12, )
+Simulating Particle :ps18  :10261438948999954450: pdgid =  -211, status =   1, q = -1, e =   1.3, theta = -0.73, phi = -2.74, mass =  0.14
+Simulating Hadron
+Made Track: tt13  :7964603003959246861:    1.26    0.94 -0.73 -2.74
+Made SmearedTrack: ts12  :7955595830470115340:    1.27    0.94 -0.73 -2.74
+Rejected SmearedTrack: ts12  :7955595830470115340:    1.27    0.94 -0.73 -2.74
+Made Cluster: et14  :3352901776396255246:    0.70 -0.78 -1.99 sub(et14, )
+Made SmearedCluster: es13  :3343882194901794829:    0.42 -0.78 -1.99 sub(es13, )
+Rejected SmearedCluster: es13  :3343882194901794829:    0.42 -0.78 -1.99 sub(es13, )
+Made Cluster: ht13  :5658740289672577037:    0.57 -0.79 -1.87 sub(ht13, )
+Made SmearedCluster: hs13  :5649724113613225997:    0.41 -0.79 -1.87 sub(hs13, )
+Rejected SmearedCluster: hs13  :5649724113613225997:    0.41 -0.79 -1.87 sub(hs13, )
+Simulating Particle :ps19  :10261438786418245651: pdgid =   130, status =   1, q =  0, e =   1.3, theta = -0.67, phi = -2.54, mass =  0.50
+Simulating Hadron
+Made Cluster: et15  :3352883313908908047:    0.34 -0.67 -2.54 sub(et15, )
+Made SmearedCluster: es13  :3341670923508908045:   -0.41 -0.67 -2.54 sub(es13, )
+Rejected SmearedCluster: es13  :3341670923508908045:   -0.41 -0.67 -2.54 sub(es13, )
+Made Cluster: ht14  :5658752714847289358:    0.93 -0.67 -2.54 sub(ht14, )
+Made SmearedCluster: hs13  :5649725372187541517:    0.43 -0.67 -2.54 sub(hs13, )
+Rejected SmearedCluster: hs13  :5649725372187541517:    0.43 -0.67 -2.54 sub(hs13, )
+Simulating Particle :ps20  :10261437701515378708: pdgid =    22, status =   1, q =  0, e =   1.2, theta =  0.31, phi = -2.15, mass =  0.00
+Simulating Photon
+Made Cluster: et16  :3352915873129037840:    1.20  0.31 -2.15 sub(et16, )
+Made SmearedCluster: es13  :3343908516422221837:    1.19  0.31 -2.15 sub(es13, )
+Simulating Particle :ps21  :10261437102929477653: pdgid =    22, status =   1, q =  0, e =   1.2, theta =  0.30, phi = -2.40, mass =  0.00
+Simulating Photon
+Made Cluster: et17  :3352915274543136785:    1.17  0.30 -2.40 sub(et17, )
+Made SmearedCluster: es14  :3343906865552556046:    1.10  0.30 -2.40 sub(es14, )
+Simulating Particle :ps22  :10261436637747609622: pdgid =    22, status =   1, q =  0, e =   1.1, theta =  0.11, phi = -2.39, mass =  0.00
+Simulating Photon
+Made Cluster: et18  :3352914809361268754:    1.14  0.11 -2.39 sub(et18, )
+Made SmearedCluster: es15  :3343907255308255247:    1.12  0.11 -2.39 sub(es15, )
+Simulating Particle :ps23  :10261433285827624983: pdgid =  -211, status =   1, q = -1, e =   1.0, theta =  0.27, phi = -2.20, mass =  0.14
+Simulating Hadron
+Made Track: tt14  :7964597122639069198:    0.97    0.93  0.27 -2.20
+Made SmearedTrack: ts12  :7955589886801608716:    0.96    0.93  0.27 -2.20
+Made Cluster: et19  :3352879351497490451:    0.28  0.30 -1.44 sub(et19, )
+Made SmearedCluster: es16  :3343887905534771216:    0.51  0.30 -1.44 sub(es16, )
+Made Cluster: ht15  :5658744567822811151:    0.69  0.31 -1.32 sub(ht15, )
+Made SmearedCluster: hs13  :5649726967277158413:    0.45  0.31 -1.32 sub(hs13, )
+Rejected SmearedCluster: hs13  :5649726967277158413:    0.45  0.31 -1.32 sub(hs13, )
+Simulating Particle :ps24  :10261432786281824280: pdgid =  -211, status =   1, q = -1, e =   1.0, theta = -0.82, phi =  1.82, mass =  0.14
+Simulating Hadron
+Made Track: tt15  :7964596617821028367:    0.95    0.65 -0.82  1.82
+Made SmearedTrack: ts13  :7955589805815889933:    0.96    0.66 -0.82  1.82
+Made Cluster: et20  :3352893273459916820:    0.48 -0.93  2.95 sub(et20, )
+Made SmearedCluster: es17  :3343885886822547473:    0.48 -0.93  2.95 sub(es17, )
+Rejected SmearedCluster: es17  :3343885886822547473:    0.48 -0.93  2.95 sub(es17, )
+Made Cluster: ht16  :5658736467174752272:    0.48 -0.95  3.05 sub(ht16, )
+Made SmearedCluster: hs13  :5649725065904783373:    0.42 -0.95  3.05 sub(hs13, )
+Rejected SmearedCluster: hs13  :5649725065904783373:    0.42 -0.95  3.05 sub(hs13, )
+Simulating Particle :ps25  :10261430530062942233: pdgid =   211, status =   1, q =  1, e =   0.9, theta =  0.73, phi = -2.27, mass =  0.14
+Simulating Hadron
+Made Track: tt16  :7964594335662473232:    0.89    0.66  0.73 -2.27
+Made SmearedTrack: ts14  :7955586869230567438:    0.88    0.66  0.73 -2.27
+Made Cluster: et21  :3352898737757224981:    0.61  0.88  2.68 sub(et21, )
+Made SmearedCluster: es17  :3343890845328736273:    0.59  0.88  2.68 sub(es17, )
+Made Cluster: ht17  :5658722490883506193:    0.28  0.91  2.56 sub(ht17, )
+Made SmearedCluster: hs13  :5649725195919818765:    0.42  0.91  2.56 sub(hs13, )
+Rejected SmearedCluster: hs13  :5649725195919818765:    0.42  0.91  2.56 sub(hs13, )
+Simulating Particle :ps26  :10261424688313925658: pdgid =  -211, status =   1, q = -1, e =   0.7, theta =  0.05, phi = -1.77, mass =  0.14
+Simulating Hadron
+Made Track: tt17  :7964588405094875153:    0.72    0.72  0.05 -1.77
+Made SmearedTrack: ts15  :7955581231257616399:    0.72    0.72  0.05 -1.77
+Made Cluster: et22  :3352871034094092310:    0.21  0.07 -0.65 sub(et22, )
+Made SmearedCluster: es18  :3343888499217530898:    0.53  0.07 -0.65 sub(es18, )
+Made Cluster: ht18  :5658738601029009426:    0.52  1.23 -1.33 sub(ht18, )
+Made SmearedCluster: hs13  :5649738188103614477:    0.72  1.23 -1.33 sub(hs13, )
+Rejected SmearedCluster: hs13  :5649738188103614477:    0.72  1.23 -1.33 sub(hs13, )
+Simulating Particle :ps27  :10261424066929885211: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.42, phi = -2.31, mass =  0.00
+Simulating Photon
+Made Cluster: et23  :3352902238543544343:    0.71  0.42 -2.31 sub(et23, )
+Made SmearedCluster: es19  :3343888282453803027:    0.52  0.42 -2.31 sub(es19, )
+Simulating Particle :ps28  :10261422827745837084: pdgid =   211, status =   1, q =  1, e =   0.7, theta =  0.41, phi = -1.95, mass =  0.14
+Simulating Hadron
+Made Track: tt18  :7964586506832576530:    0.66    0.61  0.41 -1.95
+Made SmearedTrack: ts16  :7955579323056914448:    0.66    0.61  0.41 -1.95
+Made Cluster: ht19  :5658744008573190163:    0.68  1.50 -2.04 sub(ht19, )
+Made SmearedCluster: hs13  :5649752953980977165:    1.27  1.50 -2.04 sub(hs13, )
+Rejected SmearedCluster: hs13  :5649752953980977165:    1.27  1.50 -2.04 sub(hs13, )
+Simulating Particle :ps29  :10261422593827405853: pdgid =   321, status =   1, q =  1, e =   0.7, theta =  0.14, phi =  0.29, mass =  0.49
+Simulating Hadron
+Made Track: tt19  :7964577582658093075:    0.45    0.45  0.14  0.29
+Made SmearedTrack: ts17  :7955570433277820945:    0.46    0.45  0.14  0.29
+Made Cluster: et24  :3352890328569872408:    0.44  1.23 -2.18 sub(et24, )
+Made SmearedCluster: es20  :3343843076612292628:    0.09  1.23 -2.18 sub(es20, )
+Rejected SmearedCluster: es20  :3343843076612292628:    0.09  1.23 -2.18 sub(es20, )
+Made Cluster: ht20  :5658717899072733204:    0.23  1.34 -0.18 sub(ht20, )
+Made SmearedCluster: hs13  :5649643814871105549:    0.02  1.34 -0.18 sub(hs13, )
+Rejected SmearedCluster: hs13  :5649643814871105549:    0.02  1.34 -0.18 sub(hs13, )
+Simulating Particle :ps30  :10261421758699536414: pdgid =  -211, status =   1, q = -1, e =   0.6, theta =  0.51, phi =  2.53, mass =  0.14
+Simulating Hadron
+Made Track: tt20  :7964585413249597460:    0.63    0.55  0.51  2.53
+Made SmearedTrack: ts18  :7955578210375172114:    0.63    0.55  0.51  2.53
+Made Cluster: et25  :3352869461970386969:    0.20  1.19 -1.21 sub(et25, )
+Made SmearedCluster: es20  :3343884734659821588:    0.46  1.19 -1.21 sub(es20, )
+Rejected SmearedCluster: es20  :3343884734659821588:    0.46  1.19 -1.21 sub(es20, )
+Made Cluster: ht21  :5658734381473202197:    0.45  1.35 -0.96 sub(ht21, )
+Made SmearedCluster: hs13  :5649738130373214221:    0.72  1.35 -0.96 sub(hs13, )
+Rejected SmearedCluster: hs13  :5649738130373214221:    0.72  1.35 -0.96 sub(hs13, )
+Simulating Particle :ps31  :10261421488406003743: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.72, phi = -0.62, mass =  0.00
+Simulating Photon
+Made Cluster: et26  :3352899660019662874:    0.64 -0.72 -0.62 sub(et26, )
+Made SmearedCluster: es20  :3343893368299061268:    0.67 -0.72 -0.62 sub(es20, )
+Simulating Particle :ps32  :10261418539306975264: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.51, phi = -2.38, mass =  0.00
+Simulating Photon
+Made Cluster: et27  :3352896710920634395:    0.56  0.51 -2.38 sub(et27, )
+Made SmearedCluster: es21  :3343882279259734037:    0.43  0.51 -2.38 sub(es21, )
+Rejected SmearedCluster: es21  :3343882279259734037:    0.43  0.51 -2.38 sub(es21, )
+Simulating Particle :ps33  :10261418522122911777: pdgid =   211, status =   1, q =  1, e =   0.6, theta =  1.12, phi =  0.98, mass =  0.14
+Simulating Hadron
+Made Track: tt21  :7964582085293768725:    0.54    0.24  1.12  0.98
+Made SmearedTrack: ts19  :7955574647324409875:    0.53    0.23  1.12  0.98
+Rejected SmearedTrack: ts19  :7955574647324409875:    0.53    0.23  1.12  0.98
+Made Cluster: ht22  :5658739702950264854:    0.56  1.31 -0.78 sub(ht22, )
+Made SmearedCluster: hs13  :5649718589387702285:    0.33  1.31 -0.78 sub(hs13, )
+Rejected SmearedCluster: hs13  :5649718589387702285:    0.33  1.31 -0.78 sub(hs13, )
+Simulating Particle :ps34  :10261416671923142690: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.72, phi = -2.56, mass =  0.00
+Simulating Photon
+Made Cluster: et28  :3352894843536801820:    0.50  0.72 -2.56 sub(et28, )
+Made SmearedCluster: es21  :3343891947249991701:    0.63  0.72 -2.56 sub(es21, )
+Simulating Particle :ps35  :10261415477347614755: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.43, phi = -2.47, mass =  0.00
+Simulating Photon
+Made Cluster: et29  :3352893648961273885:    0.48  0.43 -2.47 sub(et29, )
+Made SmearedCluster: es22  :3343884238228291606:    0.45  0.43 -2.47 sub(es22, )
+Rejected SmearedCluster: es22  :3343884238228291606:    0.45  0.43 -2.47 sub(es22, )
+Simulating Particle :ps36  :10261413463842619428: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.25, phi = -2.20, mass =  0.00
+Simulating Photon
+Made Cluster: et30  :3352891635456278558:    0.46 -0.25 -2.20 sub(et30, )
+Made SmearedCluster: es22  :3343888239040659478:    0.52 -0.25 -2.20 sub(es22, )
+Simulating Particle :ps37  :10261408117600288805: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  1.00, phi = -1.59, mass =  0.00
+Simulating Photon
+Made Cluster: et31  :3352886289213947935:    0.38  1.00 -1.59 sub(et31, )
+Made SmearedCluster: es23  :3343878807093248023:    0.38  1.00 -1.59 sub(es23, )
+Rejected SmearedCluster: es23  :3343878807093248023:    0.38  1.00 -1.59 sub(es23, )
+Simulating Particle :ps38  :10261404036458610726: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.08, phi = -2.34, mass =  0.00
+Simulating Photon
+Made Cluster: et32  :3352882208072269856:    0.32  0.08 -2.34 sub(et32, )
+Made SmearedCluster: es23  :3343866634260447255:    0.23  0.08 -2.34 sub(es23, )
+Rejected SmearedCluster: es23  :3343866634260447255:    0.23  0.08 -2.34 sub(es23, )
+Simulating Particle :ps39  :10261403776581632039: pdgid =   211, status =   1, q =  1, e =   0.3, theta = -0.15, phi = -0.68, mass =  0.14
+Simulating Hadron
+Made Track: tt22  :7964565698070446102:    0.29    0.28 -0.15 -0.68
+Made SmearedTrack: ts19  :7955558474136420371:    0.29    0.28 -0.15 -0.68
+Rejected SmearedTrack: ts19  :7955558474136420371:    0.29    0.28 -0.15 -0.68
+Made Cluster: et33  :3352854967852466209:    0.11 -1.56  2.50 sub(et33, )
+Made SmearedCluster: es23  :3341670923508908055:   -0.10 -1.56  2.50 sub(es23, )
+Rejected SmearedCluster: es23  :3341670923508908055:   -0.10 -1.56  2.50 sub(es23, )
+Made Cluster: ht23  :5658714460389376023:    0.21 -1.26 -2.45 sub(ht23, )
+Made SmearedCluster: hs13  :5649718441072918541:    0.33 -1.26 -2.45 sub(hs13, )
+Rejected SmearedCluster: hs13  :5649718441072918541:    0.33 -1.26 -2.45 sub(hs13, )
+Simulating Particle :ps40  :10261402207800786984: pdgid =  -211, status =   1, q = -1, e =   0.3, theta = -0.20, phi =  3.09, mass =  0.14
+Simulating Hadron
+Made Track: tt23  :7964563936508903447:    0.26    0.26 -0.20  3.09
+Made SmearedTrack: ts19  :7955556740915789843:    0.26    0.26 -0.20  3.09
+Rejected SmearedTrack: ts19  :7955556740915789843:    0.26    0.26 -0.20  3.09
+Made Cluster: et34  :3352868708014882850:    0.19 -1.34 -0.83 sub(et34, )
+Made SmearedCluster: es23  :3343888889153585175:    0.54 -1.34 -0.83 sub(es23, )
+Made Cluster: ht24  :5658697188266475544:    0.11 -1.39 -2.54 sub(ht24, )
+Made SmearedCluster: hs13  :5649650158636367885:    0.02 -1.39 -2.54 sub(hs13, )
+Rejected SmearedCluster: hs13  :5649650158636367885:    0.02 -1.39 -2.54 sub(hs13, )
+Simulating Particle :ps41  :10261400287853936681: pdgid =  -211, status =   1, q = -1, e =   0.3, theta = -0.21, phi =  0.42, mass =  0.14
+Simulating Hadron
+Made Track: tt24  :7964560288821280792:    0.23    0.22 -0.21  0.42
+Made SmearedTrack: ts19  :7955553132547670035:    0.23    0.22 -0.21  0.42
+Rejected SmearedTrack: ts19  :7955553132547670035:    0.23    0.22 -0.21  0.42
+Made Cluster: et35  :3352846609376346147:    0.08 -1.38  1.07 sub(et35, )
+Made SmearedCluster: es24  :3341670923508908056:   -0.17 -1.38  1.07 sub(es24, )
+Rejected SmearedCluster: es24  :3341670923508908056:   -0.17 -1.38  1.07 sub(es24, )
+Made Cluster: ht25  :5658711662172045337:    0.19 -1.37  2.60 sub(ht25, )
+Made SmearedCluster: hs13  :5649736649981034509:    0.67 -1.37  2.60 sub(hs13, )
+Rejected SmearedCluster: hs13  :5649736649981034509:    0.67 -1.37  2.60 sub(hs13, )
+Simulating Particle :ps42  :10261392834282127402: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.43, phi = -1.94, mass =  0.00
+Simulating Photon
+Made Cluster: et36  :3352871005895786532:    0.21  0.43 -1.94 sub(et36, )
+Made SmearedCluster: es24  :3343863271865188376:    0.20  0.43 -1.94 sub(es24, )
+Rejected SmearedCluster: es24  :3343863271865188376:    0.20  0.43 -1.94 sub(es24, )
+Simulating Particle :ps43  :10261390761775857707: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.35, phi = -0.75, mass =  0.00
+Simulating Photon
+Made Cluster: et37  :3352868933389516837:    0.19 -0.35 -0.75 sub(et37, )
+Made SmearedCluster: es24  :3343830688339066904:    0.06 -0.35 -0.75 sub(es24, )
+Rejected SmearedCluster: es24  :3343830688339066904:    0.06 -0.35 -0.75 sub(es24, )
+Simulating Particle :ps44  :10261390641516773420: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.18, phi = -2.29, mass =  0.00
+Simulating Photon
+Made Cluster: et38  :3352868813130432550:    0.19 -0.18 -2.29 sub(et38, )
+Made SmearedCluster: es24  :3343861384189313048:    0.19 -0.18 -2.29 sub(es24, )
+Rejected SmearedCluster: es24  :3343861384189313048:    0.19 -0.18 -2.29 sub(es24, )
+Simulating Particle :ps46  :10261379124666826798: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.07, phi = -0.96, mass =  0.00
+Simulating Photon
+Made Cluster: et39  :3352857296280485927:    0.12  0.07 -0.96 sub(et39, )
+Made SmearedCluster: es24  :3343843672815829016:    0.09  0.07 -0.96 sub(es24, )
+Rejected SmearedCluster: es24  :3343843672815829016:    0.09  0.07 -0.96 sub(es24, )
+Simulating Particle :ps47  :10261376506263502895: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.81, phi = -2.69, mass =  0.00
+Simulating Photon
+Made Cluster: et40  :3352854677877162024:    0.11  0.81 -2.69 sub(et40, )
+Made SmearedCluster: es24  :3343852770554806296:    0.13  0.81 -2.69 sub(es24, )
+Rejected SmearedCluster: es24  :3343852770554806296:    0.13  0.81 -2.69 sub(es24, )
+Simulating Particle :ps48  :10261354110253006896: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.82, phi =  2.35, mass =  0.00
+Simulating Photon
+Made Cluster: et41  :3352832281866666025:    0.05 -0.82  2.35 sub(et41, )
+Made SmearedCluster: es24  :3343825592358273048:    0.05 -0.82  2.35 sub(es24, )
+Rejected SmearedCluster: es24  :3343825592358273048:    0.05 -0.82  2.35 sub(es24, )
+Simulating Particle :ps49  :10261342138346242097: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  0.68, phi = -2.06, mass =  0.00
+Simulating Photon
+Made Cluster: et42  :3352820309959901226:    0.03  0.68 -2.06 sub(et42, )
+Made SmearedCluster: es24  :3343838157863911448:    0.07  0.68 -2.06 sub(es24, )
+Rejected SmearedCluster: es24  :3343838157863911448:    0.07  0.68 -2.06 sub(es24, )
+Simulating Particle :ps50  :10261333059123019826: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  0.63, phi =  3.04, mass =  0.00
+Simulating Photon
+Made Cluster: et43  :3352811230736678955:    0.02  0.63  3.04 sub(et43, )
+Made SmearedCluster: es24  :3341670923508908056:   -0.00  0.63  3.04 sub(es24, )
+Rejected SmearedCluster: es24  :3341670923508908056:   -0.00  0.63  3.04 sub(es24, )
+Simulating Particle :ps51  :10261323654044319795: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  1.07, phi =  0.28, mass =  0.00
+Simulating Photon
+Made Cluster: et44  :3352801825657978924:    0.01  1.07  0.28 sub(et44, )
+Made SmearedCluster: es24  :3343800982617194520:    0.02  1.07  0.28 sub(es24, )
+Rejected SmearedCluster: es24  :3343800982617194520:    0.02  1.07  0.28 sub(es24, )
+Made MergedCluster: em0   :3289844710006325248:    0.51  0.30 -1.44 sub(es16, )
+Made MergedCluster: em1   :3289845043512213505:    0.52 -0.25 -2.20 sub(es22, )
+Made MergedCluster: em2   :3289845086925357058:    0.52  0.42 -2.31 sub(es19, )
+Made MergedCluster: em3   :3289845303689084931:    0.53  0.07 -0.65 sub(es18, )
+Made MergedCluster: em4   :3289845693625139204:    0.54 -1.34 -0.83 sub(es23, )
+Made MergedCluster: em5   :3289845830407684101:    0.54  0.13 -2.55 sub(es8, )
+Made MergedCluster: em6   :3289847649800290310:    0.59  0.88  2.68 sub(es17, )
+Made MergedCluster: em7   :3289848751721545735:    0.63  0.72 -2.56 sub(es21, )
+Made MergedCluster: em8   :3289850172770615304:    0.67 -0.72 -0.62 sub(es20, )
+Made MergedCluster: em9   :3289851172176789513:    0.69 -0.15  0.31 sub(es10, )
+Made MergedCluster: em10  :3289853099709038602:    0.75 -0.75 -2.12 sub(es7, )
+Made MergedCluster: em11  :3289863670024110091:    1.10  0.30 -2.40 sub(es14, )
+Made MergedCluster: em12  :3289863691849170956:    1.10  0.40 -2.64 sub(es12, )
+Made MergedCluster: em13  :3289864059779809293:    1.12  0.11 -2.39 sub(es15, )
+Made MergedCluster: em14  :3289865320893775886:    1.19  0.31 -2.15 sub(es13, )
+Made MergedCluster: em15  :3289866634361045007:    1.27 -0.48 -2.60 sub(es11, )
+Made MergedCluster: em16  :3289868467630506000:    1.37 -0.45 -2.51 sub(es9, )
+Made MergedCluster: em17  :3289872374515630097:    1.59 -0.88 -2.96 sub(es6, )
+Made MergedCluster: em18  :3289880628991885330:    2.13  0.06  0.77 sub(es1, )
+Made MergedCluster: em19  :3289881622584754195:    2.24  0.38 -1.85 sub(es4, )
+Made MergedCluster: em20  :3289891375046197268:    3.35  0.07  0.95 sub(es0, )
+Made MergedCluster: em21  :3289898914500575253:    4.41  0.37 -2.14 sub(es5, )
+Made MergedCluster: em22  :3289901071845031958:    4.90  0.32 -2.02 sub(es3, )
+Made MergedCluster: em23  :3289901700839637015:    5.04  0.15  0.75 sub(es2, )
+Made MergedCluster: hm0   :5595706748628369408:    1.10  0.38 -1.83 sub(hs5, )
+Made MergedCluster: hm1   :5595708604463185921:    1.21 -0.15  0.21 sub(hs12, )
+Made MergedCluster: hm2   :5595709730793193474:    1.27 -0.89 -3.01 sub(hs7, )
+Made MergedCluster: hm3   :5595710084851171331:    1.29  0.14 -2.60 sub(hs9, )
+Made MergedCluster: hm4   :5595717166746828804:    1.69  0.43 -2.64 sub(hs11, )
+Made MergedCluster: hm5   :5595786485153398789:   26.16  0.04  0.89 sub(hs1, hs0, hs2, hs3, )
+Made MergedCluster: hm6   :5595724542470258694:    2.23 -0.73 -1.48 sub(hs10, )
+Made MergedCluster: hm7   :5595730408789508103:    2.89 -0.75 -2.07 sub(hs8, )
+Made MergedCluster: hm8   :5595757608878211080:    7.97 -0.57 -2.74 sub(hs4, hs6, )
+Made block:E1T1     :br0   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.0 (7955589886801608716)
+      e1 = em0       value=  0.5 (3289844710006325248)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.5 (3289845043512213505)
+
+Made block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.5 (3289845086925357058)
+
+Made block:E1T1     :br3   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  0.7 (7955581231257616399)
+      e1 = em3       value=  0.5 (3289845303689084931)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.5 (3289845693625139204)
+
+Made block:E1H1T1   :br5   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts8       value=  1.7 (7955604201703211016)
+      h1 = hm3       value=  1.3 (5595710084851171331)
+      e2 = em5       value=  0.5 (3289845830407684101)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1T1     :br6   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  0.9 (7955586869230567438)
+      e1 = em6       value=  0.6 (3289847649800290310)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.6 (3289848751721545735)
+
+Made block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.7 (3289850172770615304)
+
+Made block:E1H1T1   :br9   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts11      value=  1.0 (7955591631172796427)
+      h1 = hm1       value=  1.2 (5595708604463185921)
+      e2 = em9       value=  0.7 (3289851172176789513)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :br10  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  2.1 (7955609793077444615)
+      h1 = hm7       value=  2.9 (5595730408789508103)
+      e2 = em10      value=  0.7 (3289853099709038602)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.1 (3289863670024110091)
+
+Made block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  1.1 (3289863691849170956)
+
+Made block:E1       :br13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  1.1 (3289864059779809293)
+
+Made block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  1.2 (3289865320893775886)
+
+Made block:E1       :br15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  1.3 (3289866634361045007)
+
+Made block:E1       :br16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  1.4 (3289868467630506000)
+
+Made block:E1H1T1   :br17  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  2.4 (7955612468630257670)
+      h1 = hm2       value=  1.3 (5595709730793193474)
+      e2 = em17      value=  1.6 (3289872374515630097)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E3H1T4   :br18  : ecals = 3 hcals = 1 tracks = 4
+    elements:
+      t0 = ts0       value= 11.0 (7955650512458612736)
+      t1 = ts1       value= 10.4 (7955649108717338625)
+      t2 = ts2       value= 10.3 (7955649065845260290)
+      t3 = ts3       value=  6.1 (7955635618459942915)
+      h4 = hm5       value= 26.2 (5595786485153398789)
+      e5 = em23      value=  5.0 (3289901700839637015)
+      e6 = em20      value=  3.3 (3289891375046197268)
+      e7 = em18      value=  2.1 (3289880628991885330)
+    distances:
+              t0      t1      t2      t3      h4      e5      e6      e7
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      t3     ---     ---     ---       .
+      h4  0.0000  0.0000  0.0000  0.0000       .
+      e5     ---     ---     ---  0.0000     ---       .
+      e6  0.0000     ---     ---     ---     ---     ---       .
+      e7     ---     ---  0.0000     ---     ---     ---     ---       .
+
+Made block:E1H1T1   :br19  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  3.9 (7955625893796249604)
+      h1 = hm0       value=  1.1 (5595706748628369408)
+      e2 = em19      value=  2.2 (3289881622584754195)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1       :br20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  4.4 (3289898914500575253)
+
+Made block:E1       :br21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  4.9 (3289901071845031958)
+
+Made block:H1T1     :br22  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts10      value=  1.5 (7955599381174943754)
+      h1 = hm4       value=  1.7 (5595717166746828804)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br23  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  1.6 (7955601142266724361)
+      h1 = hm6       value=  2.2 (5595724542470258694)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br24  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  3.1 (7955618553382567941)
+      h1 = hm8       value=  8.0 (5595757608878211080)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:T1       :br25  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts17      value=  0.5 (7955570433277820945)
+
+Made block:T1       :br26  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts18      value=  0.6 (7955578210375172114)
+
+Made block:T1       :br27  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  0.7 (7955579323056914448)
+
+Made block:T1       :br28  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.0 (7955589805815889933)
+
+Splitting block:E3H1T4   :br18  : ecals = 3 hcals = 1 tracks = 4
+    elements:
+      t0 = ts0       value= 11.0 (7955650512458612736)
+      t1 = ts1       value= 10.4 (7955649108717338625)
+      t2 = ts2       value= 10.3 (7955649065845260290)
+      t3 = ts3       value=  6.1 (7955635618459942915)
+      h4 = hm5       value= 26.2 (5595786485153398789)
+      e5 = em23      value=  5.0 (3289901700839637015)
+      e6 = em20      value=  3.3 (3289891375046197268)
+      e7 = em18      value=  2.1 (3289880628991885330)
+    distances:
+              t0      t1      t2      t3      h4      e5      e6      e7
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      t3     ---     ---     ---       .
+      h4  0.0000  0.0000  0.0000  0.0000       .
+      e5     ---     ---     ---  0.0000     ---       .
+      e6  0.0000     ---     ---     ---     ---     ---       .
+      e7     ---     ---  0.0000     ---     ---     ---     ---       .
+
+Made block:E3H1T4   :bs0   : ecals = 3 hcals = 1 tracks = 4
+    elements:
+      t0 = ts0       value= 11.0 (7955650512458612736)
+      t1 = ts1       value= 10.4 (7955649108717338625)
+      t2 = ts2       value= 10.3 (7955649065845260290)
+      t3 = ts3       value=  6.1 (7955635618459942915)
+      h4 = hm5       value= 26.2 (5595786485153398789)
+      e5 = em23      value=  5.0 (3289901700839637015)
+      e6 = em20      value=  3.3 (3289891375046197268)
+      e7 = em18      value=  2.1 (3289880628991885330)
+    distances:
+              t0      t1      t2      t3      h4      e5      e6      e7
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      t3     ---     ---     ---       .
+      h4  0.0000  0.0000  0.0000  0.0000       .
+      e5     ---     ---     ---  0.0000     ---       .
+      e6  0.0000     ---     ---     ---     ---     ---       .
+      e7     ---     ---  0.0000     ---     ---     ---     ---       .
+
+Splitting block:E1H1T1   :br19  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  3.9 (7955625893796249604)
+      h1 = hm0       value=  1.1 (5595706748628369408)
+      e2 = em19      value=  2.2 (3289881622584754195)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs1   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  3.9 (7955625893796249604)
+      h1 = hm0       value=  1.1 (5595706748628369408)
+      e2 = em19      value=  2.2 (3289881622584754195)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:E1H1T1   :br17  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  2.4 (7955612468630257670)
+      h1 = hm2       value=  1.3 (5595709730793193474)
+      e2 = em17      value=  1.6 (3289872374515630097)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  2.4 (7955612468630257670)
+      h1 = hm2       value=  1.3 (5595709730793193474)
+      e2 = em17      value=  1.6 (3289872374515630097)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:E1H1T1   :br10  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  2.1 (7955609793077444615)
+      h1 = hm7       value=  2.9 (5595730408789508103)
+      e2 = em10      value=  0.7 (3289853099709038602)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs3   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  2.1 (7955609793077444615)
+      h1 = hm7       value=  2.9 (5595730408789508103)
+      e2 = em10      value=  0.7 (3289853099709038602)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:E1H1T1   :br9   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts11      value=  1.0 (7955591631172796427)
+      h1 = hm1       value=  1.2 (5595708604463185921)
+      e2 = em9       value=  0.7 (3289851172176789513)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs4   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts11      value=  1.0 (7955591631172796427)
+      h1 = hm1       value=  1.2 (5595708604463185921)
+      e2 = em9       value=  0.7 (3289851172176789513)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:E1H1T1   :br5   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts8       value=  1.7 (7955604201703211016)
+      h1 = hm3       value=  1.3 (5595710084851171331)
+      e2 = em5       value=  0.5 (3289845830407684101)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs5   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts8       value=  1.7 (7955604201703211016)
+      h1 = hm3       value=  1.3 (5595710084851171331)
+      e2 = em5       value=  0.5 (3289845830407684101)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:H1T1     :br24  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  3.1 (7955618553382567941)
+      h1 = hm8       value=  8.0 (5595757608878211080)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs6   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  3.1 (7955618553382567941)
+      h1 = hm8       value=  8.0 (5595757608878211080)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br23  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  1.6 (7955601142266724361)
+      h1 = hm6       value=  2.2 (5595724542470258694)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs7   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  1.6 (7955601142266724361)
+      h1 = hm6       value=  2.2 (5595724542470258694)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br22  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts10      value=  1.5 (7955599381174943754)
+      h1 = hm4       value=  1.7 (5595717166746828804)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs8   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts10      value=  1.5 (7955599381174943754)
+      h1 = hm4       value=  1.7 (5595717166746828804)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:E1T1     :br6   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  0.9 (7955586869230567438)
+      e1 = em6       value=  0.6 (3289847649800290310)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs9   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  0.9 (7955586869230567438)
+      e1 = em6       value=  0.6 (3289847649800290310)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br3   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  0.7 (7955581231257616399)
+      e1 = em3       value=  0.5 (3289845303689084931)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs10  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  0.7 (7955581231257616399)
+      e1 = em3       value=  0.5 (3289845303689084931)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br0   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.0 (7955589886801608716)
+      e1 = em0       value=  0.5 (3289844710006325248)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs11  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.0 (7955589886801608716)
+      e1 = em0       value=  0.5 (3289844710006325248)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:T1       :br28  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.0 (7955589805815889933)
+
+Made block:T1       :bs12  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.0 (7955589805815889933)
+
+Splitting block:T1       :br27  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  0.7 (7955579323056914448)
+
+Made block:T1       :bs13  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  0.7 (7955579323056914448)
+
+Splitting block:T1       :br26  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts18      value=  0.6 (7955578210375172114)
+
+Made block:T1       :bs14  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts18      value=  0.6 (7955578210375172114)
+
+Splitting block:T1       :br25  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts17      value=  0.5 (7955570433277820945)
+
+Made block:T1       :bs15  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts17      value=  0.5 (7955570433277820945)
+
+Splitting block:E1       :br21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  4.9 (3289901071845031958)
+
+Made block:E1       :bs16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  4.9 (3289901071845031958)
+
+Splitting block:E1       :br20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  4.4 (3289898914500575253)
+
+Made block:E1       :bs17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  4.4 (3289898914500575253)
+
+Splitting block:E1       :br16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  1.4 (3289868467630506000)
+
+Made block:E1       :bs18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  1.4 (3289868467630506000)
+
+Splitting block:E1       :br15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  1.3 (3289866634361045007)
+
+Made block:E1       :bs19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  1.3 (3289866634361045007)
+
+Splitting block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  1.2 (3289865320893775886)
+
+Made block:E1       :bs20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  1.2 (3289865320893775886)
+
+Splitting block:E1       :br13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  1.1 (3289864059779809293)
+
+Made block:E1       :bs21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  1.1 (3289864059779809293)
+
+Splitting block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  1.1 (3289863691849170956)
+
+Made block:E1       :bs22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  1.1 (3289863691849170956)
+
+Splitting block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.1 (3289863670024110091)
+
+Made block:E1       :bs23  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.1 (3289863670024110091)
+
+Splitting block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.7 (3289850172770615304)
+
+Made block:E1       :bs24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.7 (3289850172770615304)
+
+Splitting block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.6 (3289848751721545735)
+
+Made block:E1       :bs25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.6 (3289848751721545735)
+
+Splitting block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.5 (3289845693625139204)
+
+Made block:E1       :bs26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.5 (3289845693625139204)
+
+Splitting block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.5 (3289845086925357058)
+
+Made block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.5 (3289845086925357058)
+
+Splitting block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.5 (3289845043512213505)
+
+Made block:E1       :bs28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.5 (3289845043512213505)
+
+Processing block:E3H1T4   :bs0   : ecals = 3 hcals = 1 tracks = 4
+    elements:
+      t0 = ts0       value= 11.0 (7955650512458612736)
+      t1 = ts1       value= 10.4 (7955649108717338625)
+      t2 = ts2       value= 10.3 (7955649065845260290)
+      t3 = ts3       value=  6.1 (7955635618459942915)
+      h4 = hm5       value= 26.2 (5595786485153398789)
+      e5 = em23      value=  5.0 (3289901700839637015)
+      e6 = em20      value=  3.3 (3289891375046197268)
+      e7 = em18      value=  2.1 (3289880628991885330)
+    distances:
+              t0      t1      t2      t3      h4      e5      e6      e7
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      t3     ---     ---     ---       .
+      h4  0.0000  0.0000  0.0000  0.0000       .
+      e5     ---     ---     ---  0.0000     ---       .
+      e6  0.0000     ---     ---     ---     ---     ---       .
+      e7     ---     ---  0.0000     ---     ---     ---     ---       .
+
+Made Particle :pr0   :10252486324351139840: pdgid =  -211, status =   1, q = -1, e =  11.0, theta =  0.07, phi =  0.89, mass =  0.14 from SmearedTrack: ts0   :7955650512458612736:   11.00   10.97  0.07  0.89
+Made Particle :pr1   :10252484920727306241: pdgid =  -211, status =   1, q = -1, e =  10.4, theta =  0.01, phi =  0.85, mass =  0.14 from SmearedTrack: ts1   :7955649108717338625:   10.36   10.36  0.01  0.85
+Made Particle :pr2   :10252484877857325058: pdgid =   211, status =   1, q =  1, e =  10.3, theta =  0.06, phi =  0.83, mass =  0.14 from SmearedTrack: ts2   :7955649065845260290:   10.34   10.32  0.06  0.83
+Made Particle :pr3   :10252471435370954755: pdgid =   211, status =   1, q =  1, e =   6.1, theta =  0.15, phi =  0.86, mass =  0.14 from SmearedTrack: ts3   :7955635618459942915:    6.11    6.05  0.15  0.86
+Finished block
+Processing block:E1H1T1   :bs5   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts8       value=  1.7 (7955604201703211016)
+      h1 = hm3       value=  1.3 (5595710084851171331)
+      e2 = em5       value=  0.5 (3289845830407684101)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr4   :10252440109070680068: pdgid =   211, status =   1, q =  1, e =   1.7, theta =  0.13, phi = -2.17, mass =  0.14 from SmearedTrack: ts8   :7955604201703211016:    1.74    1.73  0.13 -2.17
+Finished block
+Processing block:E1H1T1   :bs4   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts11      value=  1.0 (7955591631172796427)
+      h1 = hm1       value=  1.2 (5595708604463185921)
+      e2 = em9       value=  0.7 (3289851172176789513)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr5   :10252427605802221573: pdgid =   211, status =   1, q =  1, e =   1.0, theta = -0.13, phi =  0.98, mass =  0.14 from SmearedTrack: ts11  :7955591631172796427:    1.03    1.02 -0.13  0.98
+Finished block
+Processing block:E1H1T1   :bs3   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  2.1 (7955609793077444615)
+      h1 = hm7       value=  2.9 (5595730408789508103)
+      e2 = em10      value=  0.7 (3289853099709038602)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr6   :10252445643083612166: pdgid =  -211, status =   1, q = -1, e =   2.1, theta = -0.74, phi = -2.54, mass =  0.14 from SmearedTrack: ts7   :7955609793077444615:    2.12    1.57 -0.74 -2.54
+Finished block
+Processing block:E1H1T1   :bs2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  2.4 (7955612468630257670)
+      h1 = hm2       value=  1.3 (5595709730793193474)
+      e2 = em17      value=  1.6 (3289872374515630097)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr7   :10252448313620037639: pdgid =   211, status =   1, q =  1, e =   2.4, theta = -0.87, phi = -2.54, mass =  0.14 from SmearedTrack: ts6   :7955612468630257670:    2.42    1.56 -0.87 -2.54
+Finished block
+Processing block:E1H1T1   :bs1   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  3.9 (7955625893796249604)
+      h1 = hm0       value=  1.1 (5595706748628369408)
+      e2 = em19      value=  2.2 (3289881622584754195)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr8   :10252461725261496328: pdgid =  -211, status =   1, q = -1, e =   4.0, theta =  0.38, phi = -2.03, mass =  0.14 from SmearedTrack: ts4   :7955625893796249604:    3.95    3.67  0.38 -2.03
+Finished block
+Processing block:E1T1     :bs11  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.0 (7955589886801608716)
+      e1 = em0       value=  0.5 (3289844710006325248)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr9   :10252426047498747913: pdgid =  -211, status =   1, q = -1, e =   1.0, theta =  0.27, phi = -2.20, mass =  0.14 from SmearedTrack: ts12  :7955589886801608716:    0.96    0.93  0.27 -2.20
+Finished block
+Processing block:E1T1     :bs10  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  0.7 (7955581231257616399)
+      e1 = em3       value=  0.5 (3289845303689084931)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr10  :10252417510192185354: pdgid =  -211, status =   1, q = -1, e =   0.7, theta =  0.05, phi = -1.77, mass =  0.14 from SmearedTrack: ts15  :7955581231257616399:    0.72    0.72  0.05 -1.77
+Finished block
+Processing block:E1T1     :bs9   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  0.9 (7955586869230567438)
+      e1 = em6       value=  0.6 (3289847649800290310)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr11  :10252423063773642763: pdgid =   211, status =   1, q =  1, e =   0.9, theta =  0.73, phi = -2.27, mass =  0.14 from SmearedTrack: ts14  :7955586869230567438:    0.88    0.66  0.73 -2.27
+Finished block
+Processing block:H1T1     :bs8   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts10      value=  1.5 (7955599381174943754)
+      h1 = hm4       value=  1.7 (5595717166746828804)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr12  :10252435306653417484: pdgid =   211, status =   1, q =  1, e =   1.5, theta =  0.41, phi = -2.08, mass =  0.14 from SmearedTrack: ts10  :7955599381174943754:    1.47    1.35  0.41 -2.08
+Finished block
+Processing block:H1T1     :bs7   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  1.6 (7955601142266724361)
+      h1 = hm6       value=  2.2 (5595724542470258694)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr13  :10252437060396777485: pdgid =  -211, status =   1, q = -1, e =   1.6, theta = -0.70, phi = -2.12, mass =  0.14 from SmearedTrack: ts9   :7955601142266724361:    1.57    1.20 -0.70 -2.12
+Finished block
+Processing block:H1T1     :bs6   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  3.1 (7955618553382567941)
+      h1 = hm8       value=  8.0 (5595757608878211080)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr14  :10252454390604496910: pdgid =   211, status =   1, q =  1, e =   3.1, theta = -0.62, phi = -2.39, mass =  0.14 from SmearedTrack: ts5   :7955618553382567941:    3.12    2.53 -0.62 -2.39
+Made Particle :pr15  :10252465921668939791: pdgid =   130, status =   1, q =  0, e =   4.9, theta = -0.57, phi = -2.74, mass =  0.50 from MergedCluster: hm8   :5595757608878211080:    7.97 -0.57 -2.74 sub(hs4, hs6, )
+Finished block
+Processing block:E1       :bs28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.5 (3289845043512213505)
+
+Made Particle :pr16  :10252410067427000336: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.25, phi = -2.20, mass =  0.00 from MergedCluster: em1   :3289845043512213505:    0.52 -0.25 -2.20 sub(es22, )
+Finished block
+Processing block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.5 (3289845086925357058)
+
+Made Particle :pr17  :10252410110840143889: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.42, phi = -2.31, mass =  0.00 from MergedCluster: em2   :3289845086925357058:    0.52  0.42 -2.31 sub(es19, )
+Finished block
+Processing block:E1       :bs26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.5 (3289845693625139204)
+
+Made Particle :pr18  :10252410717539926034: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -1.34, phi = -0.83, mass =  0.00 from MergedCluster: em4   :3289845693625139204:    0.54 -1.34 -0.83 sub(es23, )
+Finished block
+Processing block:E1       :bs25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.6 (3289848751721545735)
+
+Made Particle :pr19  :10252413775636332563: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.72, phi = -2.56, mass =  0.00 from MergedCluster: em7   :3289848751721545735:    0.63  0.72 -2.56 sub(es21, )
+Finished block
+Processing block:E1       :bs24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.7 (3289850172770615304)
+
+Made Particle :pr20  :10252415196685402132: pdgid =    22, status =   1, q =  0, e =   0.7, theta = -0.72, phi = -0.62, mass =  0.00 from MergedCluster: em8   :3289850172770615304:    0.67 -0.72 -0.62 sub(es20, )
+Finished block
+Processing block:E1       :bs23  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.1 (3289863670024110091)
+
+Made Particle :pr21  :10252428693938896917: pdgid =    22, status =   1, q =  0, e =   1.1, theta =  0.30, phi = -2.40, mass =  0.00 from MergedCluster: em11  :3289863670024110091:    1.10  0.30 -2.40 sub(es14, )
+Finished block
+Processing block:E1       :bs22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  1.1 (3289863691849170956)
+
+Made Particle :pr22  :10252428715763957782: pdgid =    22, status =   1, q =  0, e =   1.1, theta =  0.40, phi = -2.64, mass =  0.00 from MergedCluster: em12  :3289863691849170956:    1.10  0.40 -2.64 sub(es12, )
+Finished block
+Processing block:E1       :bs21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  1.1 (3289864059779809293)
+
+Made Particle :pr23  :10252429083694596119: pdgid =    22, status =   1, q =  0, e =   1.1, theta =  0.11, phi = -2.39, mass =  0.00 from MergedCluster: em13  :3289864059779809293:    1.12  0.11 -2.39 sub(es15, )
+Finished block
+Processing block:E1       :bs20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  1.2 (3289865320893775886)
+
+Made Particle :pr24  :10252430344808562712: pdgid =    22, status =   1, q =  0, e =   1.2, theta =  0.31, phi = -2.15, mass =  0.00 from MergedCluster: em14  :3289865320893775886:    1.19  0.31 -2.15 sub(es13, )
+Finished block
+Processing block:E1       :bs19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  1.3 (3289866634361045007)
+
+Made Particle :pr25  :10252431658275831833: pdgid =    22, status =   1, q =  0, e =   1.3, theta = -0.48, phi = -2.60, mass =  0.00 from MergedCluster: em15  :3289866634361045007:    1.27 -0.48 -2.60 sub(es11, )
+Finished block
+Processing block:E1       :bs18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  1.4 (3289868467630506000)
+
+Made Particle :pr26  :10252433491545292826: pdgid =    22, status =   1, q =  0, e =   1.4, theta = -0.45, phi = -2.51, mass =  0.00 from MergedCluster: em16  :3289868467630506000:    1.37 -0.45 -2.51 sub(es9, )
+Finished block
+Processing block:E1       :bs17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  4.4 (3289898914500575253)
+
+Made Particle :pr27  :10252463938415362075: pdgid =    22, status =   1, q =  0, e =   4.4, theta =  0.37, phi = -2.14, mass =  0.00 from MergedCluster: em21  :3289898914500575253:    4.41  0.37 -2.14 sub(es5, )
+Finished block
+Processing block:E1       :bs16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  4.9 (3289901071845031958)
+
+Made Particle :pr28  :10252466095759818780: pdgid =    22, status =   1, q =  0, e =   4.9, theta =  0.32, phi = -2.02, mass =  0.00 from MergedCluster: em22  :3289901071845031958:    4.90  0.32 -2.02 sub(es3, )
+Finished block
+Processing block:T1       :bs15  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts17      value=  0.5 (7955570433277820945)
+
+Made Particle :pr29  :10252407702122659869: pdgid =   211, status =   1, q =  1, e =   0.5, theta =  0.14, phi =  0.29, mass =  0.14 from SmearedTrack: ts17  :7955570433277820945:    0.46    0.45  0.14  0.29
+Finished block
+Processing block:T1       :bs14  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts18      value=  0.6 (7955578210375172114)
+
+Made Particle :pr30  :10252414551597252638: pdgid =  -211, status =   1, q = -1, e =   0.6, theta =  0.51, phi =  2.53, mass =  0.14 from SmearedTrack: ts18  :7955578210375172114:    0.63    0.55  0.51  2.53
+Finished block
+Processing block:T1       :bs13  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  0.7 (7955579323056914448)
+
+Made Particle :pr31  :10252415639520018463: pdgid =   211, status =   1, q =  1, e =   0.7, theta =  0.41, phi = -1.95, mass =  0.14 from SmearedTrack: ts16  :7955579323056914448:    0.66    0.61  0.41 -1.95
+Finished block
+Processing block:T1       :bs12  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.0 (7955589805815889933)
+
+Made Particle :pr32  :10252425967343501344: pdgid =  -211, status =   1, q = -1, e =   1.0, theta = -0.82, phi =  1.82, mass =  0.14 from SmearedTrack: ts13  :7955589805815889933:    0.96    0.66 -0.82  1.82
+Finished block
+Finished reconstruction
+Event: 8
+Made Particle :ps0   :10261498275829907456: pdgid =  -321, status =   1, q = -1, e =  13.2, theta = -1.09, phi = -2.69, mass =  0.49
+Made Particle :ps1   :10261497238589014017: pdgid =  -211, status =   1, q = -1, e =  12.7, theta =  0.97, phi =  0.50, mass =  0.14
+Made Particle :ps2   :10261488240378773506: pdgid =   321, status =   1, q =  1, e =   8.6, theta = -1.12, phi = -2.54, mass =  0.49
+Made Particle :ps3   :10261482229028880387: pdgid =    22, status =   1, q =  0, e =   6.9, theta = -1.08, phi = -2.74, mass =  0.00
+Made Particle :ps4   :10261473504002048004: pdgid =  -211, status =   1, q = -1, e =   4.9, theta =  1.11, phi =  0.13, mass =  0.14
+Made Particle :ps5   :10261472087466049541: pdgid =   211, status =   1, q =  1, e =   4.6, theta =  0.98, phi =  0.32, mass =  0.14
+Made Particle :ps6   :10261467349173403654: pdgid =  2212, status =   1, q =  1, e =   3.8, theta = -1.14, phi = -2.85, mass =  0.94
+Made Particle :ps7   :10261463941576130567: pdgid = -2212, status =   1, q = -1, e =   3.4, theta = -0.97, phi = -2.66, mass =  0.94
+Made Particle :ps8   :10261462614133440520: pdgid =  -321, status =   1, q = -1, e =   3.2, theta =  0.90, phi = -0.54, mass =  0.49
+Made Particle :ps9   :10261455491601268745: pdgid = -2212, status =   1, q = -1, e =   2.4, theta =  0.72, phi =  3.10, mass =  0.94
+Made Particle :ps10  :10261455025089806346: pdgid =  -211, status =   1, q = -1, e =   2.4, theta =  0.72, phi =  2.70, mass =  0.14
+Made Particle :ps11  :10261454355737608203: pdgid =   321, status =   1, q =  1, e =   2.3, theta =  1.06, phi =  0.37, mass =  0.49
+Made Particle :ps12  :10261453899672059916: pdgid =    22, status =   1, q =  0, e =   2.2, theta =  0.89, phi =  0.25, mass =  0.00
+Made Particle :ps13  :10261452190189092877: pdgid =   211, status =   1, q =  1, e =   2.0, theta =  1.09, phi =  0.57, mass =  0.14
+Made Particle :ps14  :10261452014898642958: pdgid =    22, status =   1, q =  0, e =   2.0, theta =  0.94, phi =  0.30, mass =  0.00
+Made Particle :ps15  :10261450142664097807: pdgid =    22, status =   1, q =  0, e =   1.9, theta = -1.19, phi = -2.71, mass =  0.00
+Made Particle :ps16  :10261443767508664336: pdgid =  2212, status =   1, q =  1, e =   1.5, theta =  0.89, phi =  1.77, mass =  0.94
+Made Particle :ps17  :10261443574943973393: pdgid =   211, status =   1, q =  1, e =   1.5, theta =  0.62, phi =  0.03, mass =  0.14
+Made Particle :ps18  :10261440524560891922: pdgid =   130, status =   1, q =  0, e =   1.4, theta = -1.01, phi =  3.04, mass =  0.50
+Made Particle :ps19  :10261440165773836307: pdgid =    22, status =   1, q =  0, e =   1.3, theta =  0.40, phi =  0.63, mass =  0.00
+Made Particle :ps20  :10261437034241458196: pdgid =  -211, status =   1, q = -1, e =   1.2, theta =  0.47, phi = -0.10, mass =  0.14
+Made Particle :ps21  :10261430520590106645: pdgid =    22, status =   1, q =  0, e =   0.9, theta = -1.24, phi = -2.97, mass =  0.00
+Made Particle :ps22  :10261427253678178326: pdgid =   211, status =   1, q =  1, e =   0.8, theta = -1.16, phi = -2.43, mass =  0.14
+Made Particle :ps23  :10261423371604459543: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.68, phi = -1.95, mass =  0.00
+Made Particle :ps24  :10261421572560519192: pdgid =  -211, status =   1, q = -1, e =   0.6, theta =  0.91, phi =  1.21, mass =  0.14
+Made Particle :ps25  :10261420980763099161: pdgid =   211, status =   1, q =  1, e =   0.6, theta = -0.27, phi = -2.89, mass =  0.14
+Made Particle :ps26  :10261419790142799898: pdgid =   130, status =   1, q =  0, e =   0.6, theta = -0.22, phi =  1.06, mass =  0.50
+Made Particle :ps27  :10261417078086959131: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.58, phi =  1.93, mass =  0.00
+Made Particle :ps28  :10261411382243098652: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.88, phi =  0.00, mass =  0.00
+Made Particle :ps29  :10261410852647206941: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.31, phi =  0.49, mass =  0.00
+Made Particle :ps30  :10261409412465819678: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.48, phi =  2.26, mass =  0.00
+Made Particle :ps31  :10261404055509139487: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.46, phi = -2.17, mass =  0.00
+Made Particle :ps32  :10261402710523772960: pdgid =  -211, status =   1, q = -1, e =   0.3, theta = -0.60, phi = -2.59, mass =  0.14
+Made Particle :ps33  :10261393505450459169: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.07, phi =  0.09, mass =  0.00
+Made Particle :ps34  :10261389274572128290: pdgid =   211, status =   1, q =  1, e =   0.2, theta = -0.02, phi = -0.79, mass =  0.14
+Made Particle :ps35  :10261389172883324963: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.96, phi = -2.75, mass =  0.00
+Made Particle :ps36  :10261377132403884068: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  1.33, phi =  1.18, mass =  0.00
+Made Particle :ps37  :10261367706812940325: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.80, phi =  0.82, mass =  0.00
+Simulating Particle :ps0   :10261498275829907456: pdgid =  -321, status =   1, q = -1, e =  13.2, theta = -1.09, phi = -2.69, mass =  0.49
+Simulating Hadron
+Made Track: tt0   :7964662445497122816:   13.15    6.07 -1.09 -2.69
+Made SmearedTrack: ts0   :7955655581553917952:   13.30    6.14 -1.09 -2.69
+Made Cluster: et0   :3352964272436019200:    7.81 -1.09 -2.62 sub(et0, )
+Made SmearedCluster: es0   :3343958618463535104:    8.32 -1.09 -2.62 sub(es0, )
+Made Cluster: ht0   :5658796447292719104:    5.35 -1.09 -2.62 sub(ht0, )
+Made SmearedCluster: hs0   :5649789724039053312:    5.46 -1.09 -2.62 sub(hs0, )
+Simulating Particle :ps1   :10261497238589014017: pdgid =  -211, status =   1, q = -1, e =  12.7, theta =  0.97, phi =  0.50, mass =  0.14
+Simulating Hadron
+Made Track: tt1   :7964661426939756545:   12.68    7.18  0.97  0.50
+Made SmearedTrack: ts1   :7955654106620624897:   12.63    7.15  0.97  0.50
+Made Cluster: et1   :3352957886975180801:    6.36  0.97  0.57 sub(et1, )
+Made SmearedCluster: es1   :3343949695671074817:    6.13  0.97  0.57 sub(es1, )
+Made Cluster: ht1   :5658800758269673473:    6.33  0.97  0.58 sub(ht1, )
+Made SmearedCluster: hs1   :5649793260638437377:    6.26  0.97  0.58 sub(hs1, )
+Simulating Particle :ps2   :10261488240378773506: pdgid =   321, status =   1, q =  1, e =   8.6, theta = -1.12, phi = -2.54, mass =  0.49
+Simulating Hadron
+Made Track: tt2   :7964652399210004482:    8.58    3.74 -1.12 -2.54
+Made SmearedTrack: ts2   :7955645108217446402:    8.54    3.72 -1.12 -2.54
+Made Cluster: ht2   :5658809421206126594:    8.59 -1.12 -2.65 sub(ht2, )
+Made SmearedCluster: hs2   :5649798060851593218:    7.35 -1.12 -2.65 sub(hs2, )
+Simulating Particle :ps3   :10261482229028880387: pdgid =    22, status =   1, q =  0, e =   6.9, theta = -1.08, phi = -2.74, mass =  0.00
+Simulating Photon
+Made Cluster: et2   :3352960400642539522:    6.93 -1.08 -2.74 sub(et2, )
+Made SmearedCluster: es2   :3343955464812494850:    7.44 -1.08 -2.74 sub(es2, )
+Simulating Particle :ps4   :10261473504002048004: pdgid =  -211, status =   1, q = -1, e =   4.9, theta =  1.11, phi =  0.13, mass =  0.14
+Simulating Hadron
+Made Track: tt3   :7964637685381857283:    4.94    2.22  1.11  0.13
+Made SmearedTrack: ts3   :7955630680338071555:    4.99    2.24  1.11  0.13
+Made Cluster: ht3   :5658794684829401091:    4.95  1.11  0.32 sub(ht3, )
+Made SmearedCluster: hs3   :5649792366752563203:    6.06  1.11  0.32 sub(hs3, )
+Simulating Particle :ps5   :10261472087466049541: pdgid =   211, status =   1, q =  1, e =   4.6, theta =  0.98, phi =  0.32, mass =  0.14
+Simulating Hadron
+Made Track: tt4   :7964636268239781892:    4.62    2.58  0.98  0.32
+Made SmearedTrack: ts4   :7955628623872917508:    4.52    2.53  0.98  0.32
+Made Cluster: et3   :3352922342469664771:    1.57  0.98  0.11 sub(et3, )
+Made SmearedCluster: es3   :3343923778041151491:    2.12  0.98  0.11 sub(es3, )
+Made Cluster: ht4   :5658782210476474372:    3.05  0.98  0.09 sub(ht4, )
+Made SmearedCluster: hs4   :5649770683331248132:    2.56  0.98  0.09 sub(hs4, )
+Simulating Particle :ps6   :10261467349173403654: pdgid =  2212, status =   1, q =  1, e =   3.8, theta = -1.14, phi = -2.85, mass =  0.94
+Simulating Hadron
+Made Track: tt5   :7964630496736968709:    3.65    1.52 -1.14 -2.85
+Made SmearedTrack: ts5   :7955623025997512709:    3.62    1.51 -1.14 -2.85
+Made Cluster: et4   :3352903988740620292:    0.76 -1.15 -3.09 sub(et4, )
+Made SmearedCluster: es4   :3343896896753106948:    0.77 -1.15 -3.09 sub(es4, )
+Made Cluster: ht5   :5658781819321974789:    3.01 -1.15 -3.11 sub(ht5, )
+Made SmearedCluster: hs5   :5649774000719527941:    2.94 -1.15 -3.11 sub(hs5, )
+Simulating Particle :ps7   :10261463941576130567: pdgid = -2212, status =   1, q = -1, e =   3.4, theta = -0.97, phi = -2.66, mass =  0.94
+Simulating Hadron
+Made Track: tt6   :7964626965271412742:    3.25    1.83 -0.97 -2.66
+Made SmearedTrack: ts6   :7955619750023790598:    3.25    1.83 -0.97 -2.66
+Made Cluster: ht6   :5658785122403483654:    3.39 -0.98 -2.34 sub(ht6, )
+Made SmearedCluster: hs6   :5649786137191907334:    4.64 -0.98 -2.34 sub(hs6, )
+Simulating Particle :ps8   :10261462614133440520: pdgid =  -321, status =   1, q = -1, e =   3.2, theta =  0.90, phi = -0.54, mass =  0.49
+Simulating Hadron
+Made Track: tt7   :7964626470880411655:    3.20    2.00  0.90 -0.54
+Made SmearedTrack: ts7   :7955619257243402247:    3.20    1.99  0.90 -0.54
+Made Cluster: et5   :3352930260820688901:    2.04  0.90 -0.23 sub(et5, )
+Made SmearedCluster: es5   :3343931071726092293:    2.95  0.90 -0.23 sub(es5, )
+Made Cluster: ht7   :5658758797273858055:    1.20  0.91 -0.20 sub(ht7, )
+Made SmearedCluster: hs7   :5649755117667221511:    1.40  0.91 -0.20 sub(hs7, )
+Simulating Particle :ps9   :10261455491601268745: pdgid = -2212, status =   1, q = -1, e =   2.4, theta =  0.72, phi =  3.10, mass =  0.94
+Simulating Hadron
+Made Track: tt8   :7964618020513382408:    2.24    1.69  0.72  3.10
+Made SmearedTrack: ts8   :7955610936383897608:    2.25    1.70  0.72  3.10
+Made Cluster: ht8   :5658776672428621832:    2.43  0.73 -2.74 sub(ht8, )
+Made SmearedCluster: hs8   :5649772250824441864:    2.74  0.73 -2.74 sub(hs8, )
+Simulating Particle :ps10  :10261455025089806346: pdgid =  -211, status =   1, q = -1, e =   2.4, theta =  0.72, phi =  2.70, mass =  0.14
+Simulating Hadron
+Made Track: tt9   :7964619178986438665:    2.37    1.78  0.72  2.70
+Made SmearedTrack: ts9   :7955611984871817225:    2.37    1.79  0.72  2.70
+Made Cluster: ht9   :5658776205917159433:    2.37  0.73  3.11 sub(ht9, )
+Made SmearedCluster: hs9   :5649759720842461193:    1.66  0.73  3.11 sub(hs9, )
+Simulating Particle :ps11  :10261454355737608203: pdgid =   321, status =   1, q =  1, e =   2.3, theta =  1.06, phi =  0.37, mass =  0.49
+Simulating Hadron
+Made Track: tt10  :7964618073430818826:    2.24    1.09  1.06  0.37
+Made SmearedTrack: ts10  :7955611146713563146:    2.27    1.10  1.06  0.37
+Made Cluster: et6   :3352900774599327750:    0.67  1.07 -0.03 sub(et6, )
+Made SmearedCluster: es6   :3343850013039001606:    0.12  1.07 -0.03 sub(es6, )
+Rejected SmearedCluster: es6   :3343850013039001606:    0.12  1.07 -0.03 sub(es6, )
+Made Cluster: ht10  :5658766327049879562:    1.62  1.08 -0.07 sub(ht10, )
+Made SmearedCluster: hs10  :5649754222315438090:    1.35  1.08 -0.07 sub(hs10, )
+Simulating Particle :ps12  :10261453899672059916: pdgid =    22, status =   1, q =  0, e =   2.2, theta =  0.89, phi =  0.25, mass =  0.00
+Simulating Photon
+Made Cluster: et7   :3352932071285719047:    2.24  0.89  0.25 sub(et7, )
+Made SmearedCluster: es6   :3343922042631094278:    1.96  0.89  0.25 sub(es6, )
+Simulating Particle :ps13  :10261452190189092877: pdgid =   211, status =   1, q =  1, e =   2.0, theta =  1.09, phi =  0.57, mass =  0.14
+Simulating Hadron
+Made Track: tt11  :7964616338387763211:    2.05    0.94  1.09  0.57
+Made SmearedTrack: ts11  :7955608932771168267:    2.02    0.93  1.09  0.57
+Made Cluster: et8   :3352899304095219720:    0.63  1.11  0.14 sub(et8, )
+Made SmearedCluster: es7   :3343888495912419335:    0.53  1.11  0.14 sub(es7, )
+Made Cluster: ht11  :5658762731201757195:    1.42  1.11  0.10 sub(ht11, )
+Made SmearedCluster: hs11  :5649752603980988427:    1.25  1.11  0.10 sub(hs11, )
+Simulating Particle :ps14  :10261452014898642958: pdgid =    22, status =   1, q =  0, e =   2.0, theta =  0.94, phi =  0.30, mass =  0.00
+Simulating Photon
+Made Cluster: et9   :3352930186512302089:    2.03  0.94  0.30 sub(et9, )
+Made SmearedCluster: es8   :3343923849879093256:    2.13  0.94  0.30 sub(es8, )
+Simulating Particle :ps15  :10261450142664097807: pdgid =    22, status =   1, q =  0, e =   1.9, theta = -1.19, phi = -2.71, mass =  0.00
+Simulating Photon
+Made Cluster: et10  :3352928314277756938:    1.91 -1.19 -2.71 sub(et10, )
+Made SmearedCluster: es9   :3343924339840909321:    2.18 -1.19 -2.71 sub(es9, )
+Simulating Particle :ps16  :10261443767508664336: pdgid =  2212, status =   1, q =  1, e =   1.5, theta =  0.89, phi =  1.77, mass =  0.94
+Simulating Hadron
+Made Track: tt12  :7964602376866758668:    1.23    0.77  0.89  1.77
+Made SmearedTrack: ts12  :7955595384626085900:    1.24    0.78  0.89  1.77
+Made Cluster: et11  :3352908215892312075:    0.88  0.95  0.95 sub(et11, )
+Made SmearedCluster: es10  :3343862511215575050:    0.20  0.95  0.95 sub(es10, )
+Rejected SmearedCluster: es10  :3343862511215575050:    0.20  0.95  0.95 sub(es10, )
+Made Cluster: ht12  :5658743487193939980:    0.66  0.96  0.87 sub(ht12, )
+Made SmearedCluster: hs12  :5649735259497955340:    0.63  0.96  0.87 sub(hs12, )
+Rejected SmearedCluster: hs12  :5649735259497955340:    0.63  0.96  0.87 sub(hs12, )
+Simulating Particle :ps17  :10261443574943973393: pdgid =   211, status =   1, q =  1, e =   1.5, theta =  0.62, phi =  0.03, mass =  0.14
+Simulating Hadron
+Made Track: tt13  :7964607653146001421:    1.53    1.24  0.62  0.03
+Made SmearedTrack: ts13  :7955600661263941645:    1.54    1.25  0.62  0.03
+Made Cluster: ht13  :5658764755771326477:    1.54  0.66 -0.59 sub(ht13, )
+Made SmearedCluster: hs12  :5649768808957607948:    2.35  0.66 -0.59 sub(hs12, )
+Simulating Particle :ps18  :10261440524560891922: pdgid =   130, status =   1, q =  0, e =   1.4, theta = -1.01, phi =  3.04, mass =  0.50
+Simulating Hadron
+Made Cluster: et12  :3352845208478810124:    0.07 -1.01  3.04 sub(et12, )
+Made SmearedCluster: es10  :3343872148363018250:    0.28 -1.01  3.04 sub(es10, )
+Rejected SmearedCluster: es10  :3343872148363018250:    0.28 -1.01  3.04 sub(es10, )
+Made Cluster: ht14  :5658760402949898254:    1.29 -1.01  3.04 sub(ht14, )
+Made SmearedCluster: hs13  :5649750455861903373:    1.13 -1.01  3.04 sub(hs13, )
+Simulating Particle :ps19  :10261440165773836307: pdgid =    22, status =   1, q =  0, e =   1.3, theta =  0.40, phi =  0.63, mass =  0.00
+Simulating Photon
+Made Cluster: et13  :3352918337387495437:    1.34  0.40  0.63 sub(et13, )
+Made SmearedCluster: es10  :3343915611211169802:    1.60  0.40  0.63 sub(es10, )
+Simulating Particle :ps20  :10261437034241458196: pdgid =  -211, status =   1, q = -1, e =   1.2, theta =  0.47, phi = -0.10, mass =  0.14
+Simulating Hadron
+Made Track: tt14  :7964601076475232270:    1.16    1.03  0.47 -0.10
+Made SmearedTrack: ts14  :7955593819118895118:    1.15    1.03  0.47 -0.10
+Made Cluster: et14  :3352902927663497230:    0.73  0.51  0.58 sub(et14, )
+Made SmearedCluster: es11  :3343863402085744651:    0.20  0.51  0.58 sub(es11, )
+Rejected SmearedCluster: es11  :3343863402085744651:    0.20  0.51  0.58 sub(es11, )
+Made Cluster: ht15  :5658732870355648527:    0.43  0.52  0.68 sub(ht15, )
+Made SmearedCluster: hs14  :5649722075164704782:    0.38  0.52  0.68 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649722075164704782:    0.38  0.52  0.68 sub(hs14, )
+Simulating Particle :ps21  :10261430520590106645: pdgid =    22, status =   1, q =  0, e =   0.9, theta = -1.24, phi = -2.97, mass =  0.00
+Simulating Photon
+Made Cluster: et15  :3352908692203765775:    0.90 -1.24 -2.97 sub(et15, )
+Made SmearedCluster: es11  :3343906853999345675:    1.10 -1.24 -2.97 sub(es11, )
+Simulating Particle :ps22  :10261427253678178326: pdgid =   211, status =   1, q =  1, e =   0.8, theta = -1.16, phi = -2.43, mass =  0.14
+Simulating Hadron
+Made Track: tt15  :7964591014086180879:    0.79    0.32 -1.16 -2.43
+Made SmearedTrack: ts15  :7955583719606059023:    0.79    0.32 -1.16 -2.43
+Rejected SmearedTrack: ts15  :7955583719606059023:    0.79    0.32 -1.16 -2.43
+Made Cluster: ht16  :5658748434505531408:    0.80 -1.24  2.68 sub(ht16, )
+Made SmearedCluster: hs14  :5649747322460962830:    0.98 -1.24  2.68 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649747322460962830:    0.98 -1.24  2.68 sub(hs14, )
+Simulating Particle :ps23  :10261423371604459543: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.68, phi = -1.95, mass =  0.00
+Simulating Photon
+Made Cluster: et16  :3352901543218118672:    0.69  0.68 -1.95 sub(et16, )
+Made SmearedCluster: es12  :3343898768977166348:    0.82  0.68 -1.95 sub(es12, )
+Simulating Particle :ps24  :10261421572560519192: pdgid =  -211, status =   1, q = -1, e =   0.6, theta =  0.91, phi =  1.21, mass =  0.14
+Simulating Hadron
+Made Track: tt16  :7964585222591217680:    0.63    0.38  0.91  1.21
+Made SmearedTrack: ts15  :7955578383461515279:    0.64    0.39  0.91  1.21
+Rejected SmearedTrack: ts15  :7955578383461515279:    0.64    0.39  0.91  1.21
+Made Cluster: et17  :3352878575834365969:    0.27  1.11  2.78 sub(et17, )
+Made SmearedCluster: es13  :3343878493797613581:    0.37  1.11  2.78 sub(es13, )
+Rejected SmearedCluster: es13  :3343878493797613581:    0.37  1.11  2.78 sub(es13, )
+Made Cluster: ht17  :5658728737355595793:    0.37  1.15  2.93 sub(ht17, )
+Made SmearedCluster: hs14  :5647513932722601998:   -0.13  1.15  2.93 sub(hs14, )
+Rejected SmearedCluster: hs14  :5647513932722601998:   -0.13  1.15  2.93 sub(hs14, )
+Simulating Particle :ps25  :10261420980763099161: pdgid =   211, status =   1, q =  1, e =   0.6, theta = -0.27, phi = -2.89, mass =  0.14
+Simulating Hadron
+Made Track: tt17  :7964584615901921297:    0.61    0.59 -0.27 -2.89
+Made SmearedTrack: ts15  :7955577392062267407:    0.61    0.59 -0.27 -2.89
+Made Cluster: et18  :3352864941013991442:    0.16 -0.93  1.68 sub(et18, )
+Made SmearedCluster: es13  :3343853606699794445:    0.13 -0.93  1.68 sub(es13, )
+Rejected SmearedCluster: es13  :3343853606699794445:    0.13 -0.93  1.68 sub(es13, )
+Made Cluster: ht18  :5658735086078525458:    0.46 -1.06  1.21 sub(ht18, )
+Made SmearedCluster: hs14  :5649739934842486798:    0.77 -1.06  1.21 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649739934842486798:    0.77 -1.06  1.21 sub(hs14, )
+Simulating Particle :ps26  :10261419790142799898: pdgid =   130, status =   1, q =  0, e =   0.6, theta = -0.22, phi =  1.06, mass =  0.50
+Simulating Hadron
+Made Cluster: et19  :3352880697690816531:    0.30 -0.22  1.06 sub(et19, )
+Made SmearedCluster: es13  :3343872470806429709:    0.29 -0.22  1.06 sub(es13, )
+Rejected SmearedCluster: es13  :3343872470806429709:    0.29 -0.22  1.06 sub(es13, )
+Made Cluster: ht19  :5658723050665803795:    0.29 -0.22  1.06 sub(ht19, )
+Made SmearedCluster: hs14  :5649672875425136654:    0.05 -0.22  1.06 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649672875425136654:    0.05 -0.22  1.06 sub(hs14, )
+Simulating Particle :ps27  :10261417078086959131: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.58, phi =  1.93, mass =  0.00
+Simulating Photon
+Made Cluster: et20  :3352895249700618260:    0.51  0.58  1.93 sub(et20, )
+Made SmearedCluster: es13  :3343882041799213069:    0.42  0.58  1.93 sub(es13, )
+Rejected SmearedCluster: es13  :3343882041799213069:    0.42  0.58  1.93 sub(es13, )
+Simulating Particle :ps28  :10261411382243098652: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.88, phi =  0.00, mass =  0.00
+Simulating Photon
+Made Cluster: et21  :3352889553856757781:    0.43  0.88  0.00 sub(et21, )
+Made SmearedCluster: es13  :3343879719345979405:    0.39  0.88  0.00 sub(es13, )
+Rejected SmearedCluster: es13  :3343879719345979405:    0.39  0.88  0.00 sub(es13, )
+Simulating Particle :ps29  :10261410852647206941: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.31, phi =  0.49, mass =  0.00
+Simulating Photon
+Made Cluster: et22  :3352889024260866070:    0.42  0.31  0.49 sub(et22, )
+Made SmearedCluster: es13  :3343885856485146637:    0.48  0.31  0.49 sub(es13, )
+Rejected SmearedCluster: es13  :3343885856485146637:    0.48  0.31  0.49 sub(es13, )
+Simulating Particle :ps30  :10261409412465819678: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.48, phi =  2.26, mass =  0.00
+Simulating Photon
+Made Cluster: et23  :3352887584079478807:    0.40  0.48  2.26 sub(et23, )
+Made SmearedCluster: es13  :3343884992414482445:    0.46  0.48  2.26 sub(es13, )
+Rejected SmearedCluster: es13  :3343884992414482445:    0.46  0.48  2.26 sub(es13, )
+Simulating Particle :ps31  :10261404055509139487: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.46, phi = -2.17, mass =  0.00
+Simulating Photon
+Made Cluster: et24  :3352882227122798616:    0.32  0.46 -2.17 sub(et24, )
+Made SmearedCluster: es13  :3343887734015000589:    0.51  0.46 -2.17 sub(es13, )
+Simulating Particle :ps32  :10261402710523772960: pdgid =  -211, status =   1, q = -1, e =   0.3, theta = -0.60, phi = -2.59, mass =  0.14
+Simulating Hadron
+Made Track: tt18  :7964564504702877714:    0.27    0.22 -0.60 -2.59
+Made SmearedTrack: ts16  :7955557392549150736:    0.27    0.22 -0.60 -2.59
+Rejected SmearedTrack: ts16  :7955557392549150736:    0.27    0.22 -0.60 -2.59
+Made Cluster: et25  :3352844387060023321:    0.07 -1.32 -0.58 sub(et25, )
+Made SmearedCluster: es14  :3343872775447117838:    0.29 -1.32 -0.58 sub(es14, )
+Rejected SmearedCluster: es14  :3343872775447117838:    0.29 -1.32 -0.58 sub(es14, )
+Made Cluster: ht20  :5658717618670927892:    0.23 -1.42 -0.08 sub(ht20, )
+Made SmearedCluster: hs14  :5649701234387451918:    0.17 -1.42 -0.08 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649701234387451918:    0.17 -1.42 -0.08 sub(hs14, )
+Simulating Particle :ps33  :10261393505450459169: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.07, phi =  0.09, mass =  0.00
+Simulating Photon
+Made Cluster: et26  :3352871677064118298:    0.21  0.07  0.09 sub(et26, )
+Made SmearedCluster: es14  :3343862492443967502:    0.20  0.07  0.09 sub(es14, )
+Rejected SmearedCluster: es14  :3343862492443967502:    0.20  0.07  0.09 sub(es14, )
+Simulating Particle :ps35  :10261389172883324963: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.96, phi = -2.75, mass =  0.00
+Simulating Photon
+Made Cluster: et27  :3352867344496984091:    0.18 -0.96 -2.75 sub(et27, )
+Made SmearedCluster: es14  :3343855895820894222:    0.15 -0.96 -2.75 sub(es14, )
+Rejected SmearedCluster: es14  :3343855895820894222:    0.15 -0.96 -2.75 sub(es14, )
+Simulating Particle :ps36  :10261377132403884068: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  1.33, phi =  1.18, mass =  0.00
+Simulating Photon
+Made Cluster: et28  :3352855304017543196:    0.11  1.33  1.18 sub(et28, )
+Made SmearedCluster: es14  :3343855946425171982:    0.15  1.33  1.18 sub(es14, )
+Rejected SmearedCluster: es14  :3343855946425171982:    0.15  1.33  1.18 sub(es14, )
+Simulating Particle :ps37  :10261367706812940325: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.80, phi =  0.82, mass =  0.00
+Simulating Photon
+Made Cluster: et29  :3352845878426599453:    0.08  0.80  0.82 sub(et29, )
+Made SmearedCluster: es14  :3343816009407528974:    0.03  0.80  0.82 sub(es14, )
+Rejected SmearedCluster: es14  :3343816009407528974:    0.03  0.80  0.82 sub(es14, )
+Made MergedCluster: em0   :3289844538486554624:    0.51  0.46 -2.17 sub(es13, )
+Made MergedCluster: em1   :3289845300383973377:    0.53  1.11  0.14 sub(es7, )
+Made MergedCluster: em2   :3289853701224660994:    0.77 -1.15 -3.09 sub(es4, )
+Made MergedCluster: em3   :3289855573448720387:    0.82  0.68 -1.95 sub(es12, )
+Made MergedCluster: em4   :3289863658470899716:    1.10 -1.24 -2.97 sub(es11, )
+Made MergedCluster: em5   :3289872415682723845:    1.60  0.40  0.63 sub(es10, )
+Made MergedCluster: em6   :3289878847102648326:    1.96  0.89  0.25 sub(es6, )
+Made MergedCluster: em7   :3289880582512705543:    2.12  0.98  0.11 sub(es3, )
+Made MergedCluster: em8   :3289880654350647304:    2.13  0.94  0.30 sub(es8, )
+Made MergedCluster: em9   :3289881144312463369:    2.18 -1.19 -2.71 sub(es9, )
+Made MergedCluster: em10  :3289887876197646346:    2.95  0.90 -0.23 sub(es5, )
+Made MergedCluster: em11  :3289906500142628875:    6.13  0.97  0.57 sub(es1, )
+Made MergedCluster: em12  :3289912269284048908:    7.44 -1.08 -2.74 sub(es2, )
+Made MergedCluster: em13  :3289915422935089165:    8.32 -1.09 -2.62 sub(es0, )
+Made MergedCluster: hm0   :5595707260333457408:    1.13 -1.01  3.04 sub(hs13, )
+Made MergedCluster: hm1   :5595738515710148609:    3.82  1.02  0.10 sub(hs4, hs11, )
+Made MergedCluster: hm2   :5595711026786992130:    1.35  1.08 -0.07 sub(hs10, )
+Made MergedCluster: hm3   :5595711922138775555:    1.40  0.91 -0.20 sub(hs7, )
+Made MergedCluster: hm4   :5595716525314015236:    1.66  0.73  3.11 sub(hs9, )
+Made MergedCluster: hm5   :5595725613429161989:    2.35  0.66 -0.59 sub(hs12, )
+Made MergedCluster: hm6   :5595729055295995910:    2.74  0.73 -2.74 sub(hs8, )
+Made MergedCluster: hm7   :5595730805191081991:    2.94 -1.15 -3.11 sub(hs5, )
+Made MergedCluster: hm8   :5595742941663461384:    4.64 -0.98 -2.34 sub(hs6, )
+Made MergedCluster: hm9   :5595768289102921737:   12.81 -1.11 -2.64 sub(hs2, hs0, )
+Made MergedCluster: hm10  :5595749171224117258:    6.06  1.11  0.32 sub(hs3, )
+Made MergedCluster: hm11  :5595750065109991435:    6.26  0.97  0.58 sub(hs1, )
+Made block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.5 (3289844538486554624)
+
+Made block:E2H1T2   :br1   : ecals = 2 hcals = 1 tracks = 2
+    elements:
+      t0 = ts4       value=  4.5 (7955628623872917508)
+      t1 = ts11      value=  2.0 (7955608932771168267)
+      h2 = hm1       value=  3.8 (5595738515710148609)
+      e3 = em7       value=  2.1 (3289880582512705543)
+      e4 = em1       value=  0.5 (3289845300383973377)
+    distances:
+              t0      t1      h2      e3      e4
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+      e3  0.0000     ---     ---       .
+      e4     ---  0.0000     ---     ---       .
+
+Made block:E1H1T1   :br2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  3.6 (7955623025997512709)
+      h1 = hm7       value=  2.9 (5595730805191081991)
+      e2 = em2       value=  0.8 (3289853701224660994)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.8 (3289855573448720387)
+
+Made block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  1.1 (3289863658470899716)
+
+Made block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  1.6 (3289872415682723845)
+
+Made block:E1       :br6   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  2.0 (3289878847102648326)
+
+Made block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  2.1 (3289880654350647304)
+
+Made block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  2.2 (3289881144312463369)
+
+Made block:E1H1T1   :br9   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  3.2 (7955619257243402247)
+      h1 = hm3       value=  1.4 (5595711922138775555)
+      e2 = em10      value=  2.9 (3289887876197646346)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :br10  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts1       value= 12.6 (7955654106620624897)
+      h1 = hm11      value=  6.3 (5595750065109991435)
+      e2 = em11      value=  6.1 (3289906500142628875)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  7.4 (3289912269284048908)
+
+Made block:E1H1T2   :br12  : ecals = 1 hcals = 1 tracks = 2
+    elements:
+      t0 = ts0       value= 13.3 (7955655581553917952)
+      t1 = ts2       value=  8.5 (7955645108217446402)
+      h2 = hm9       value= 12.8 (5595768289102921737)
+      e3 = em13      value=  8.3 (3289915422935089165)
+    distances:
+              t0      t1      h2      e3
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+      e3  0.0000     ---     ---       .
+
+Made block:H1       :br13  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm0       value=  1.1 (5595707260333457408)
+
+Made block:H1T1     :br14  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts10      value=  2.3 (7955611146713563146)
+      h1 = hm2       value=  1.3 (5595711026786992130)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br15  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  2.4 (7955611984871817225)
+      h1 = hm4       value=  1.7 (5595716525314015236)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br16  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  1.5 (7955600661263941645)
+      h1 = hm5       value=  2.3 (5595725613429161989)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br17  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts8       value=  2.2 (7955610936383897608)
+      h1 = hm6       value=  2.7 (5595729055295995910)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br18  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  3.3 (7955619750023790598)
+      h1 = hm8       value=  4.6 (5595742941663461384)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br19  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  5.0 (7955630680338071555)
+      h1 = hm10      value=  6.1 (5595749171224117258)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:T1       :br20  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  0.6 (7955577392062267407)
+
+Made block:T1       :br21  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.2 (7955593819118895118)
+
+Made block:T1       :br22  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.2 (7955595384626085900)
+
+Splitting block:E2H1T2   :br1   : ecals = 2 hcals = 1 tracks = 2
+    elements:
+      t0 = ts4       value=  4.5 (7955628623872917508)
+      t1 = ts11      value=  2.0 (7955608932771168267)
+      h2 = hm1       value=  3.8 (5595738515710148609)
+      e3 = em7       value=  2.1 (3289880582512705543)
+      e4 = em1       value=  0.5 (3289845300383973377)
+    distances:
+              t0      t1      h2      e3      e4
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+      e3  0.0000     ---     ---       .
+      e4     ---  0.0000     ---     ---       .
+
+Made block:E2H1T2   :bs0   : ecals = 2 hcals = 1 tracks = 2
+    elements:
+      t0 = ts4       value=  4.5 (7955628623872917508)
+      t1 = ts11      value=  2.0 (7955608932771168267)
+      h2 = hm1       value=  3.8 (5595738515710148609)
+      e3 = em7       value=  2.1 (3289880582512705543)
+      e4 = em1       value=  0.5 (3289845300383973377)
+    distances:
+              t0      t1      h2      e3      e4
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+      e3  0.0000     ---     ---       .
+      e4     ---  0.0000     ---     ---       .
+
+Splitting block:E1H1T2   :br12  : ecals = 1 hcals = 1 tracks = 2
+    elements:
+      t0 = ts0       value= 13.3 (7955655581553917952)
+      t1 = ts2       value=  8.5 (7955645108217446402)
+      h2 = hm9       value= 12.8 (5595768289102921737)
+      e3 = em13      value=  8.3 (3289915422935089165)
+    distances:
+              t0      t1      h2      e3
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+      e3  0.0000     ---     ---       .
+
+Made block:E1H1T2   :bs1   : ecals = 1 hcals = 1 tracks = 2
+    elements:
+      t0 = ts0       value= 13.3 (7955655581553917952)
+      t1 = ts2       value=  8.5 (7955645108217446402)
+      h2 = hm9       value= 12.8 (5595768289102921737)
+      e3 = em13      value=  8.3 (3289915422935089165)
+    distances:
+              t0      t1      h2      e3
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+      e3  0.0000     ---     ---       .
+
+Splitting block:E1H1T1   :br10  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts1       value= 12.6 (7955654106620624897)
+      h1 = hm11      value=  6.3 (5595750065109991435)
+      e2 = em11      value=  6.1 (3289906500142628875)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts1       value= 12.6 (7955654106620624897)
+      h1 = hm11      value=  6.3 (5595750065109991435)
+      e2 = em11      value=  6.1 (3289906500142628875)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:E1H1T1   :br9   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  3.2 (7955619257243402247)
+      h1 = hm3       value=  1.4 (5595711922138775555)
+      e2 = em10      value=  2.9 (3289887876197646346)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs3   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  3.2 (7955619257243402247)
+      h1 = hm3       value=  1.4 (5595711922138775555)
+      e2 = em10      value=  2.9 (3289887876197646346)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:E1H1T1   :br2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  3.6 (7955623025997512709)
+      h1 = hm7       value=  2.9 (5595730805191081991)
+      e2 = em2       value=  0.8 (3289853701224660994)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs4   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  3.6 (7955623025997512709)
+      h1 = hm7       value=  2.9 (5595730805191081991)
+      e2 = em2       value=  0.8 (3289853701224660994)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:H1T1     :br19  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  5.0 (7955630680338071555)
+      h1 = hm10      value=  6.1 (5595749171224117258)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs5   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  5.0 (7955630680338071555)
+      h1 = hm10      value=  6.1 (5595749171224117258)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br18  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  3.3 (7955619750023790598)
+      h1 = hm8       value=  4.6 (5595742941663461384)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs6   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  3.3 (7955619750023790598)
+      h1 = hm8       value=  4.6 (5595742941663461384)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br17  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts8       value=  2.2 (7955610936383897608)
+      h1 = hm6       value=  2.7 (5595729055295995910)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs7   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts8       value=  2.2 (7955610936383897608)
+      h1 = hm6       value=  2.7 (5595729055295995910)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br16  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  1.5 (7955600661263941645)
+      h1 = hm5       value=  2.3 (5595725613429161989)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs8   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  1.5 (7955600661263941645)
+      h1 = hm5       value=  2.3 (5595725613429161989)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br15  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  2.4 (7955611984871817225)
+      h1 = hm4       value=  1.7 (5595716525314015236)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs9   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  2.4 (7955611984871817225)
+      h1 = hm4       value=  1.7 (5595716525314015236)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br14  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts10      value=  2.3 (7955611146713563146)
+      h1 = hm2       value=  1.3 (5595711026786992130)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs10  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts10      value=  2.3 (7955611146713563146)
+      h1 = hm2       value=  1.3 (5595711026786992130)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:T1       :br22  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.2 (7955595384626085900)
+
+Made block:T1       :bs11  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.2 (7955595384626085900)
+
+Splitting block:T1       :br21  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.2 (7955593819118895118)
+
+Made block:T1       :bs12  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.2 (7955593819118895118)
+
+Splitting block:T1       :br20  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  0.6 (7955577392062267407)
+
+Made block:T1       :bs13  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  0.6 (7955577392062267407)
+
+Splitting block:H1       :br13  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm0       value=  1.1 (5595707260333457408)
+
+Made block:H1       :bs14  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm0       value=  1.1 (5595707260333457408)
+
+Splitting block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  7.4 (3289912269284048908)
+
+Made block:E1       :bs15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  7.4 (3289912269284048908)
+
+Splitting block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  2.2 (3289881144312463369)
+
+Made block:E1       :bs16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  2.2 (3289881144312463369)
+
+Splitting block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  2.1 (3289880654350647304)
+
+Made block:E1       :bs17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  2.1 (3289880654350647304)
+
+Splitting block:E1       :br6   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  2.0 (3289878847102648326)
+
+Made block:E1       :bs18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  2.0 (3289878847102648326)
+
+Splitting block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  1.6 (3289872415682723845)
+
+Made block:E1       :bs19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  1.6 (3289872415682723845)
+
+Splitting block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  1.1 (3289863658470899716)
+
+Made block:E1       :bs20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  1.1 (3289863658470899716)
+
+Splitting block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.8 (3289855573448720387)
+
+Made block:E1       :bs21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.8 (3289855573448720387)
+
+Splitting block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.5 (3289844538486554624)
+
+Made block:E1       :bs22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.5 (3289844538486554624)
+
+Processing block:E2H1T2   :bs0   : ecals = 2 hcals = 1 tracks = 2
+    elements:
+      t0 = ts4       value=  4.5 (7955628623872917508)
+      t1 = ts11      value=  2.0 (7955608932771168267)
+      h2 = hm1       value=  3.8 (5595738515710148609)
+      e3 = em7       value=  2.1 (3289880582512705543)
+      e4 = em1       value=  0.5 (3289845300383973377)
+    distances:
+              t0      t1      h2      e3      e4
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+      e3  0.0000     ---     ---       .
+      e4     ---  0.0000     ---     ---       .
+
+Made Particle :pr0   :10252464443229208576: pdgid =   211, status =   1, q =  1, e =   4.5, theta =  0.98, phi =  0.32, mass =  0.14 from SmearedTrack: ts4   :7955628623872917508:    4.52    2.53  0.98  0.32
+Made Particle :pr1   :10252444784710909953: pdgid =   211, status =   1, q =  1, e =   2.0, theta =  1.09, phi =  0.57, mass =  0.14 from SmearedTrack: ts11  :7955608932771168267:    2.02    0.93  1.09  0.57
+Finished block
+Processing block:E1H1T2   :bs1   : ecals = 1 hcals = 1 tracks = 2
+    elements:
+      t0 = ts0       value= 13.3 (7955655581553917952)
+      t1 = ts2       value=  8.5 (7955645108217446402)
+      h2 = hm9       value= 12.8 (5595768289102921737)
+      e3 = em13      value=  8.3 (3289915422935089165)
+    distances:
+              t0      t1      h2      e3
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+      e3  0.0000     ---     ---       .
+
+Made Particle :pr2   :10252491393110900738: pdgid =  -211, status =   1, q = -1, e =  13.3, theta = -1.09, phi = -2.69, mass =  0.14 from SmearedTrack: ts0   :7955655581553917952:   13.30    6.14 -1.09 -2.69
+Made Particle :pr3   :10252480920663621635: pdgid =   211, status =   1, q =  1, e =   8.5, theta = -1.12, phi = -2.54, mass =  0.14 from SmearedTrack: ts2   :7955645108217446402:    8.54    3.72 -1.12 -2.54
+Finished block
+Processing block:E1H1T1   :bs4   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  3.6 (7955623025997512709)
+      h1 = hm7       value=  2.9 (5595730805191081991)
+      e2 = em2       value=  0.8 (3289853701224660994)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr4   :10252458859394236420: pdgid =   211, status =   1, q =  1, e =   3.6, theta = -1.14, phi = -2.85, mass =  0.14 from SmearedTrack: ts5   :7955623025997512709:    3.62    1.51 -1.14 -2.85
+Finished block
+Processing block:E1H1T1   :bs3   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  3.2 (7955619257243402247)
+      h1 = hm3       value=  1.4 (5595711922138775555)
+      e2 = em10      value=  2.9 (3289887876197646346)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr5   :10252455093781659653: pdgid =  -211, status =   1, q = -1, e =   3.2, theta =  0.90, phi = -0.54, mass =  0.14 from SmearedTrack: ts7   :7955619257243402247:    3.20    1.99  0.90 -0.54
+Finished block
+Processing block:E1H1T1   :bs2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts1       value= 12.6 (7955654106620624897)
+      h1 = hm11      value=  6.3 (5595750065109991435)
+      e2 = em11      value=  6.1 (3289906500142628875)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr6   :10252489918261493766: pdgid =  -211, status =   1, q = -1, e =  12.6, theta =  0.97, phi =  0.50, mass =  0.14 from SmearedTrack: ts1   :7955654106620624897:   12.63    7.15  0.97  0.50
+Finished block
+Processing block:H1T1     :bs10  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts10      value=  2.3 (7955611146713563146)
+      h1 = hm2       value=  1.3 (5595711026786992130)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr7   :10252446994014404615: pdgid =   211, status =   1, q =  1, e =   2.3, theta =  1.06, phi =  0.37, mass =  0.14 from SmearedTrack: ts10  :7955611146713563146:    2.27    1.10  1.06  0.37
+Finished block
+Processing block:H1T1     :bs9   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  2.4 (7955611984871817225)
+      h1 = hm4       value=  1.7 (5595716525314015236)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr8   :10252447830673195016: pdgid =  -211, status =   1, q = -1, e =   2.4, theta =  0.72, phi =  2.70, mass =  0.14 from SmearedTrack: ts9   :7955611984871817225:    2.37    1.79  0.72  2.70
+Finished block
+Processing block:H1T1     :bs8   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  1.5 (7955600661263941645)
+      h1 = hm5       value=  2.3 (5595725613429161989)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr9   :10252436581308694537: pdgid =   211, status =   1, q =  1, e =   1.5, theta =  0.62, phi =  0.03, mass =  0.14 from SmearedTrack: ts13  :7955600661263941645:    1.54    1.25  0.62  0.03
+Finished block
+Processing block:H1T1     :bs7   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts8       value=  2.2 (7955610936383897608)
+      h1 = hm6       value=  2.7 (5595729055295995910)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr10  :10252446784081100810: pdgid =  -211, status =   1, q = -1, e =   2.3, theta =  0.72, phi =  3.10, mass =  0.14 from SmearedTrack: ts8   :7955610936383897608:    2.25    1.70  0.72  3.10
+Finished block
+Processing block:H1T1     :bs6   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  3.3 (7955619750023790598)
+      h1 = hm8       value=  4.6 (5595742941663461384)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr11  :10252455586104868875: pdgid =  -211, status =   1, q = -1, e =   3.3, theta = -0.97, phi = -2.66, mass =  0.14 from SmearedTrack: ts6   :7955619750023790598:    3.25    1.83 -0.97 -2.66
+Finished block
+Processing block:H1T1     :bs5   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  5.0 (7955630680338071555)
+      h1 = hm10      value=  6.1 (5595749171224117258)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr12  :10252466498813558796: pdgid =  -211, status =   1, q = -1, e =   5.0, theta =  1.11, phi =  0.13, mass =  0.14 from SmearedTrack: ts3   :7955630680338071555:    4.99    2.24  1.11  0.13
+Finished block
+Processing block:E1       :bs22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.5 (3289844538486554624)
+
+Made Particle :pr13  :10252409562401341453: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.46, phi = -2.17, mass =  0.00 from MergedCluster: em0   :3289844538486554624:    0.51  0.46 -2.17 sub(es13, )
+Finished block
+Processing block:E1       :bs21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.8 (3289855573448720387)
+
+Made Particle :pr14  :10252420597363507214: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.68, phi = -1.95, mass =  0.00 from MergedCluster: em3   :3289855573448720387:    0.82  0.68 -1.95 sub(es12, )
+Finished block
+Processing block:E1       :bs20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  1.1 (3289863658470899716)
+
+Made Particle :pr15  :10252428682385686543: pdgid =    22, status =   1, q =  0, e =   1.1, theta = -1.24, phi = -2.97, mass =  0.00 from MergedCluster: em4   :3289863658470899716:    1.10 -1.24 -2.97 sub(es11, )
+Finished block
+Processing block:E1       :bs19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  1.6 (3289872415682723845)
+
+Made Particle :pr16  :10252437439597510672: pdgid =    22, status =   1, q =  0, e =   1.6, theta =  0.40, phi =  0.63, mass =  0.00 from MergedCluster: em5   :3289872415682723845:    1.60  0.40  0.63 sub(es10, )
+Finished block
+Processing block:E1       :bs18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  2.0 (3289878847102648326)
+
+Made Particle :pr17  :10252443871017435153: pdgid =    22, status =   1, q =  0, e =   2.0, theta =  0.89, phi =  0.25, mass =  0.00 from MergedCluster: em6   :3289878847102648326:    1.96  0.89  0.25 sub(es6, )
+Finished block
+Processing block:E1       :bs17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  2.1 (3289880654350647304)
+
+Made Particle :pr18  :10252445678265434130: pdgid =    22, status =   1, q =  0, e =   2.1, theta =  0.94, phi =  0.30, mass =  0.00 from MergedCluster: em8   :3289880654350647304:    2.13  0.94  0.30 sub(es8, )
+Finished block
+Processing block:E1       :bs16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  2.2 (3289881144312463369)
+
+Made Particle :pr19  :10252446168227250195: pdgid =    22, status =   1, q =  0, e =   2.2, theta = -1.19, phi = -2.71, mass =  0.00 from MergedCluster: em9   :3289881144312463369:    2.18 -1.19 -2.71 sub(es9, )
+Finished block
+Processing block:E1       :bs15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  7.4 (3289912269284048908)
+
+Made Particle :pr20  :10252477293198835732: pdgid =    22, status =   1, q =  0, e =   7.4, theta = -1.08, phi = -2.74, mass =  0.00 from MergedCluster: em12  :3289912269284048908:    7.44 -1.08 -2.74 sub(es2, )
+Finished block
+Processing block:H1       :bs14  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm0       value=  1.1 (5595707260333457408)
+
+Made Particle :pr21  :10252429275034550293: pdgid =   130, status =   1, q =  0, e =   1.1, theta = -1.01, phi =  3.04, mass =  0.50 from MergedCluster: hm0   :5595707260333457408:    1.13 -1.01  3.04 sub(hs13, )
+Finished block
+Processing block:T1       :bs13  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  0.6 (7955577392062267407)
+
+Made Particle :pr22  :10252413753070977046: pdgid =   211, status =   1, q =  1, e =   0.6, theta = -0.27, phi = -2.89, mass =  0.14 from SmearedTrack: ts15  :7955577392062267407:    0.61    0.59 -0.27 -2.89
+Finished block
+Processing block:T1       :bs12  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.2 (7955593819118895118)
+
+Made Particle :pr23  :10252429776102883351: pdgid =  -211, status =   1, q = -1, e =   1.2, theta =  0.47, phi = -0.10, mass =  0.14 from SmearedTrack: ts14  :7955593819118895118:    1.15    1.03  0.47 -0.10
+Finished block
+Processing block:T1       :bs11  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.2 (7955595384626085900)
+
+Made Particle :pr24  :10252431331132702744: pdgid =   211, status =   1, q =  1, e =   1.2, theta =  0.89, phi =  1.77, mass =  0.14 from SmearedTrack: ts12  :7955595384626085900:    1.24    0.78  0.89  1.77
+Finished block
+Finished reconstruction
+Event: 9
+Made Particle :ps0   :10261488368768516096: pdgid =  -211, status =   1, q = -1, e =   8.7, theta = -0.61, phi = -2.38, mass =  0.14
+Made Particle :ps1   :10261485455558049793: pdgid =   211, status =   1, q =  1, e =   7.7, theta = -0.61, phi = -2.32, mass =  0.14
+Made Particle :ps2   :10261481833390669826: pdgid =    22, status =   1, q =  0, e =   6.8, theta =  1.09, phi =  0.99, mass =  0.00
+Made Particle :ps3   :10261479334896205827: pdgid =  -211, status =   1, q = -1, e =   6.3, theta = -0.59, phi = -2.40, mass =  0.14
+Made Particle :ps4   :10261473508164894724: pdgid = -2212, status =   1, q = -1, e =   4.9, theta =  0.04, phi =  0.65, mass =  0.94
+Made Particle :ps5   :10261472009376497669: pdgid =   211, status =   1, q =  1, e =   4.6, theta = -0.55, phi = -2.38, mass =  0.14
+Made Particle :ps6   :10261469437649485830: pdgid =  2112, status =   1, q =  0, e =   4.0, theta =  0.31, phi =  0.72, mass =  0.94
+Made Particle :ps7   :10261466026950524935: pdgid =    22, status =   1, q =  0, e =   3.6, theta = -0.63, phi = -2.38, mass =  0.00
+Made Particle :ps8   :10261463582893932552: pdgid =    22, status =   1, q =  0, e =   3.3, theta =  0.94, phi =  0.73, mass =  0.00
+Made Particle :ps9   :10261463093716451337: pdgid =  -211, status =   1, q = -1, e =   3.3, theta = -0.70, phi = -2.31, mass =  0.14
+Made Particle :ps10  :10261460861300244490: pdgid =    22, status =   1, q =  0, e =   3.0, theta =  0.40, phi =  0.44, mass =  0.00
+Made Particle :ps11  :10261460522822008843: pdgid =    22, status =   1, q =  0, e =   3.0, theta =  1.05, phi =  1.38, mass =  0.00
+Made Particle :ps12  :10261453151475335180: pdgid =   321, status =   1, q =  1, e =   2.2, theta = -0.00, phi =  0.70, mass =  0.49
+Made Particle :ps13  :10261452415769247757: pdgid =   211, status =   1, q =  1, e =   2.1, theta =  0.30, phi =  0.72, mass =  0.14
+Made Particle :ps14  :10261451868580347918: pdgid =    22, status =   1, q =  0, e =   2.0, theta =  1.11, phi =  1.02, mass =  0.00
+Made Particle :ps15  :10261448690434572303: pdgid =    22, status =   1, q =  0, e =   1.8, theta = -0.58, phi = -2.38, mass =  0.00
+Made Particle :ps16  :10261446492225011728: pdgid =   211, status =   1, q =  1, e =   1.7, theta = -0.89, phi = -3.13, mass =  0.14
+Made Particle :ps17  :10261443671880630289: pdgid =   321, status =   1, q =  1, e =   1.5, theta = -0.61, phi = -2.25, mass =  0.49
+Made Particle :ps18  :10261442604189089810: pdgid =  -211, status =   1, q = -1, e =   1.5, theta =  1.04, phi =  1.49, mass =  0.14
+Made Particle :ps19  :10261440869735333907: pdgid =    22, status =   1, q =  0, e =   1.4, theta =  0.41, phi =  0.51, mass =  0.00
+Made Particle :ps20  :10261439022215725076: pdgid =   211, status =   1, q =  1, e =   1.3, theta = -0.19, phi = -0.04, mass =  0.14
+Made Particle :ps21  :10261437761437302805: pdgid =  -211, status =   1, q = -1, e =   1.2, theta = -0.56, phi = -2.53, mass =  0.14
+Made Particle :ps22  :10261434924565266454: pdgid =   211, status =   1, q =  1, e =   1.0, theta =  1.04, phi =  1.06, mass =  0.14
+Made Particle :ps23  :10261434423419338775: pdgid =  -211, status =   1, q = -1, e =   1.0, theta = -0.41, phi =  1.08, mass =  0.14
+Made Particle :ps24  :10261433309695311896: pdgid =    22, status =   1, q =  0, e =   1.0, theta =  1.01, phi =  1.02, mass =  0.00
+Made Particle :ps25  :10261432211358089241: pdgid =    22, status =   1, q =  0, e =   0.9, theta =  1.11, phi =  0.93, mass =  0.00
+Made Particle :ps26  :10261432125137879066: pdgid =   130, status =   1, q =  0, e =   0.9, theta =  0.03, phi =  0.72, mass =  0.50
+Made Particle :ps27  :10261431500207554587: pdgid =    22, status =   1, q =  0, e =   0.9, theta =  0.78, phi =  1.06, mass =  0.00
+Made Particle :ps28  :10261429022684610588: pdgid =  -211, status =   1, q = -1, e =   0.9, theta =  0.79, phi =  0.36, mass =  0.14
+Made Particle :ps29  :10261425722077741085: pdgid =    22, status =   1, q =  0, e =   0.8, theta = -0.64, phi = -2.84, mass =  0.00
+Made Particle :ps30  :10261425419729240094: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.30, phi =  0.38, mass =  0.00
+Made Particle :ps31  :10261424312953077791: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  1.04, phi =  0.93, mass =  0.00
+Made Particle :ps32  :10261422682266402848: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.34, phi =  0.86, mass =  0.00
+Made Particle :ps33  :10261421333227241505: pdgid =   211, status =   1, q =  1, e =   0.6, theta =  0.66, phi = -0.04, mass =  0.14
+Made Particle :ps34  :10261417304233345058: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.34, phi =  0.62, mass =  0.00
+Made Particle :ps35  :10261417123144269859: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.09, phi = -1.79, mass =  0.00
+Made Particle :ps36  :10261417013270282276: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  1.10, phi =  1.37, mass =  0.00
+Made Particle :ps37  :10261414087818739749: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -1.00, phi =  2.08, mass =  0.00
+Made Particle :ps38  :10261412642448998438: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.99, phi =  0.90, mass =  0.00
+Made Particle :ps39  :10261409818919043111: pdgid =  -211, status =   1, q = -1, e =   0.4, theta =  0.54, phi =  1.23, mass =  0.14
+Made Particle :ps40  :10261409486159740968: pdgid =   211, status =   1, q =  1, e =   0.4, theta = -0.02, phi =  1.26, mass =  0.14
+Made Particle :ps41  :10261406127705030697: pdgid =   -11, status =   1, q =  1, e =   0.4, theta =  0.28, phi =  0.71, mass =  0.00
+Made Particle :ps42  :10261403372154257450: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.83, phi = -2.56, mass =  0.00
+Made Particle :ps43  :10261400529143857195: pdgid =  -211, status =   1, q = -1, e =   0.3, theta =  1.05, phi = -0.55, mass =  0.14
+Made Particle :ps44  :10261393509711872044: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.43, phi =  0.32, mass =  0.00
+Made Particle :ps45  :10261388974975090733: pdgid =    11, status =   1, q = -1, e =   0.2, theta =  0.26, phi =  0.74, mass =  0.00
+Made Particle :ps46  :10261381822514462766: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.08, phi = -1.26, mass =  0.00
+Made Particle :ps47  :10261359821045366831: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.16, phi =  2.36, mass =  0.00
+Made Particle :ps48  :10261348650900783152: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  0.22, phi =  1.26, mass =  0.00
+Simulating Particle :ps0   :10261488368768516096: pdgid =  -211, status =   1, q = -1, e =   8.7, theta = -0.61, phi = -2.38, mass =  0.14
+Simulating Hadron
+Made Track: tt0   :7964652556334923776:    8.65    7.09 -0.61 -2.38
+Made SmearedTrack: ts0   :7955645615881322496:    8.77    7.18 -0.61 -2.38
+Made Cluster: et0   :3352921265307385856:    1.51 -0.60 -2.33 sub(et0, )
+Made SmearedCluster: es0   :3343918233645219840:    1.74 -0.60 -2.33 sub(es0, )
+Made Cluster: ht0   :5658804351253086208:    7.14 -0.61 -2.32 sub(ht0, )
+Made SmearedCluster: hs0   :5649806431099027456:   10.51 -0.61 -2.32 sub(hs0, )
+Simulating Particle :ps1   :10261485455558049793: pdgid =   211, status =   1, q =  1, e =   7.7, theta = -0.61, phi = -2.32, mass =  0.14
+Simulating Hadron
+Made Track: tt1   :7964649640008089601:    7.66    6.27 -0.61 -2.32
+Made SmearedTrack: ts1   :7955642586322960385:    7.70    6.30 -0.61 -2.32
+Made Cluster: et1   :3352893477856739329:    0.48 -0.61 -2.42 sub(et1, )
+Made SmearedCluster: es1   :3341670923508908033:   -0.14 -0.61 -2.42 sub(es1, )
+Rejected SmearedCluster: es1   :3341670923508908033:   -0.14 -0.61 -2.42 sub(es1, )
+Made Cluster: ht1   :5658804516133273601:    7.18 -0.61 -2.43 sub(ht1, )
+Made SmearedCluster: hs1   :5649806213253169153:   10.41 -0.61 -2.43 sub(hs1, )
+Simulating Particle :ps2   :10261481833390669826: pdgid =    22, status =   1, q =  0, e =   6.8, theta =  1.09, phi =  0.99, mass =  0.00
+Simulating Photon
+Made Cluster: et2   :3352960005004328962:    6.84  1.09  0.99 sub(et2, )
+Made SmearedCluster: es1   :3343950890829611009:    6.40  1.09  0.99 sub(es1, )
+Simulating Particle :ps3   :10261479334896205827: pdgid =  -211, status =   1, q = -1, e =   6.3, theta = -0.59, phi = -2.40, mass =  0.14
+Simulating Hadron
+Made Track: tt2   :7964643518106828802:    6.27    5.22 -0.59 -2.40
+Made SmearedTrack: ts2   :7955636330256400386:    6.27    5.22 -0.59 -2.40
+Made Cluster: et3   :3352939476644003843:    3.09 -0.59 -2.28 sub(et3, )
+Made SmearedCluster: es2   :3343926326305226754:    2.41 -0.59 -2.28 sub(es2, )
+Made Cluster: ht2   :5658783361217331202:    3.19 -0.59 -2.27 sub(ht2, )
+Made SmearedCluster: hs2   :5649783044043702274:    3.97 -0.59 -2.27 sub(hs2, )
+Simulating Particle :ps4   :10261473508164894724: pdgid = -2212, status =   1, q = -1, e =   4.9, theta =  0.04, phi =  0.65, mass =  0.94
+Simulating Hadron
+Made Track: tt3   :7964637303291248643:    4.86    4.85  0.04  0.65
+Made SmearedTrack: ts3   :7955630088630829059:    4.85    4.85  0.04  0.65
+Made Cluster: et4   :3352930059783503876:    2.02  0.04  0.78 sub(et4, )
+Made SmearedCluster: es3   :3343926834837323779:    2.47  0.04  0.78 sub(es3, )
+Made Cluster: ht3   :5658781124613111811:    2.93  0.04  0.80 sub(ht3, )
+Made SmearedCluster: hs3   :5647513932722601987:   -0.13  0.04  0.80 sub(hs3, )
+Rejected SmearedCluster: hs3   :5647513932722601987:   -0.13  0.04  0.80 sub(hs3, )
+Simulating Particle :ps5   :10261472009376497669: pdgid =   211, status =   1, q =  1, e =   4.6, theta = -0.55, phi = -2.38, mass =  0.14
+Simulating Hadron
+Made Track: tt4   :7964636190116675588:    4.60    3.93 -0.55 -2.38
+Made SmearedTrack: ts4   :7955628949854224388:    4.59    3.92 -0.55 -2.38
+Made Cluster: et5   :3352936319245352965:    2.73 -0.56 -2.46 sub(et5, )
+Made SmearedCluster: es4   :3343931556935761924:    3.00 -0.56 -2.46 sub(es4, )
+Made Cluster: ht4   :5658770803364200452:    1.88 -0.56 -2.48 sub(ht4, )
+Made SmearedCluster: hs3   :5649752968302428163:    1.27 -0.56 -2.48 sub(hs3, )
+Simulating Particle :ps6   :10261469437649485830: pdgid =  2112, status =   1, q =  0, e =   4.0, theta =  0.31, phi =  0.72, mass =  0.94
+Simulating Hadron
+Made Cluster: et6   :3352931751545536518:    2.21  0.31  0.72 sub(et6, )
+Made SmearedCluster: es5   :3343932243564298245:    3.08  0.31  0.72 sub(es5, )
+Made Cluster: ht5   :5658769651853688837:    1.81  0.31  0.72 sub(ht5, )
+Made SmearedCluster: hs4   :5649752138172071940:    1.23  0.31  0.72 sub(hs4, )
+Simulating Particle :ps7   :10261466026950524935: pdgid =    22, status =   1, q =  0, e =   3.6, theta = -0.63, phi = -2.38, mass =  0.00
+Simulating Photon
+Made Cluster: et7   :3352944198564184071:    3.62 -0.63 -2.38 sub(et7, )
+Made SmearedCluster: es6   :3343934221912637446:    3.31 -0.63 -2.38 sub(es6, )
+Simulating Particle :ps8   :10261463582893932552: pdgid =    22, status =   1, q =  0, e =   3.3, theta =  0.94, phi =  0.73, mass =  0.00
+Simulating Photon
+Made Cluster: et8   :3352941754507591688:    3.35  0.94  0.73 sub(et8, )
+Made SmearedCluster: es7   :3343930166192635911:    2.85  0.94  0.73 sub(es7, )
+Simulating Particle :ps9   :10261463093716451337: pdgid =  -211, status =   1, q = -1, e =   3.3, theta = -0.70, phi = -2.31, mass =  0.14
+Simulating Hadron
+Made Track: tt5   :7964627257702481925:    3.29    2.52 -0.70 -2.31
+Made SmearedTrack: ts5   :7955620055165698053:    3.29    2.52 -0.70 -2.31
+Made Cluster: et9   :3352866542957101065:    0.17 -0.70 -2.05 sub(et9, )
+Made SmearedCluster: es8   :3343883910554583048:    0.45 -0.70 -2.05 sub(es8, )
+Rejected SmearedCluster: es8   :3343883910554583048:    0.45 -0.70 -2.05 sub(es8, )
+Made Cluster: ht6   :5658782738212192262:    3.11 -0.70 -2.02 sub(ht6, )
+Made SmearedCluster: hs5   :5649791559627964421:    5.87 -0.70 -2.02 sub(hs5, )
+Simulating Particle :ps10  :10261460861300244490: pdgid =    22, status =   1, q =  0, e =   3.0, theta =  0.40, phi =  0.44, mass =  0.00
+Simulating Photon
+Made Cluster: et10  :3352939032913903626:    3.04  0.40  0.44 sub(et10, )
+Made SmearedCluster: es8   :3343931075899424776:    2.95  0.40  0.44 sub(es8, )
+Simulating Particle :ps11  :10261460522822008843: pdgid =    22, status =   1, q =  0, e =   3.0, theta =  1.05, phi =  1.38, mass =  0.00
+Simulating Photon
+Made Cluster: et11  :3352938694435667979:    3.00  1.05  1.38 sub(et11, )
+Made SmearedCluster: es9   :3343931003669315593:    2.94  1.05  1.38 sub(es9, )
+Simulating Particle :ps12  :10261453151475335180: pdgid =   321, status =   1, q =  1, e =   2.2, theta = -0.00, phi =  0.70, mass =  0.49
+Simulating Hadron
+Made Track: tt6   :7964616838428491782:    2.10    2.10 -0.00  0.70
+Made SmearedTrack: ts6   :7955609636592156678:    2.10    2.10 -0.00  0.70
+Made Cluster: et12  :3352793001658155020:    0.01 -0.00  0.39 sub(et12, )
+Made SmearedCluster: es10  :3341670923508908042:   -0.01 -0.00  0.39 sub(es10, )
+Rejected SmearedCluster: es10  :3341670923508908042:   -0.01 -0.00  0.39 sub(es10, )
+Made Cluster: ht7   :5658774248674557959:    2.15 -0.00  0.35 sub(ht7, )
+Made SmearedCluster: hs6   :5649767442497404934:    2.19 -0.00  0.35 sub(hs6, )
+Simulating Particle :ps13  :10261452415769247757: pdgid =   211, status =   1, q =  1, e =   2.1, theta =  0.30, phi =  0.72, mass =  0.14
+Simulating Hadron
+Made Track: tt7   :7964616564485914631:    2.07    1.98  0.30  0.72
+Made SmearedTrack: ts7   :7955609380202741767:    2.07    1.98  0.30  0.72
+Made Cluster: ht8   :5658773596596600840:    2.08  0.30  0.35 sub(ht8, )
+Made SmearedCluster: hs7   :5649772900035592199:    2.81  0.30  0.35 sub(hs7, )
+Simulating Particle :ps14  :10261451868580347918: pdgid =    22, status =   1, q =  0, e =   2.0, theta =  1.11, phi =  1.02, mass =  0.00
+Simulating Photon
+Made Cluster: et13  :3352930040194007053:    2.01  1.11  1.02 sub(et13, )
+Made SmearedCluster: es10  :3343922741232271370:    2.00  1.11  1.02 sub(es10, )
+Simulating Particle :ps15  :10261448690434572303: pdgid =    22, status =   1, q =  0, e =   1.8, theta = -0.58, phi = -2.38, mass =  0.00
+Simulating Photon
+Made Cluster: et14  :3352926862048231438:    1.83 -0.58 -2.38 sub(et14, )
+Made SmearedCluster: es11  :3343920534093037579:    1.88 -0.58 -2.38 sub(es11, )
+Simulating Particle :ps16  :10261446492225011728: pdgid =   211, status =   1, q =  1, e =   1.7, theta = -0.89, phi = -3.13, mass =  0.14
+Simulating Hadron
+Made Track: tt8   :7964610581367881736:    1.70    1.07 -0.89 -3.13
+Made SmearedTrack: ts8   :7955603528951529480:    1.70    1.08 -0.89 -3.13
+Rejected SmearedTrack: ts8   :7955603528951529480:    1.70    1.08 -0.89 -3.13
+Made Cluster: et15  :3352905757826744335:    0.81 -0.91  2.56 sub(et15, )
+Made SmearedCluster: es12  :3343913903150071820:    1.50 -0.91  2.56 sub(es12, )
+Made Cluster: ht9   :5658751394690105353:    0.89 -0.92  2.50 sub(ht9, )
+Made SmearedCluster: hs8   :5649753053694263304:    1.28 -0.92  2.50 sub(hs8, )
+Simulating Particle :ps17  :10261443671880630289: pdgid =   321, status =   1, q =  1, e =   1.5, theta = -0.61, phi = -2.25, mass =  0.49
+Simulating Hadron
+Made Track: tt9   :7964606432867778569:    1.46    1.20 -0.61 -2.25
+Made SmearedTrack: ts8   :7955598981661196296:    1.45    1.18 -0.61 -2.25
+Made Cluster: et16  :3352908824410325008:    0.90 -0.64 -2.82 sub(et16, )
+Made SmearedCluster: es13  :3343884344652464141:    0.45 -0.64 -2.82 sub(es13, )
+Rejected SmearedCluster: es13  :3343884344652464141:    0.45 -0.64 -2.82 sub(es13, )
+Made Cluster: ht10  :5658742687419858954:    0.64 -0.64 -2.89 sub(ht10, )
+Made SmearedCluster: hs9   :5649752775072940041:    1.26 -0.64 -2.89 sub(hs9, )
+Simulating Particle :ps18  :10261442604189089810: pdgid =  -211, status =   1, q = -1, e =   1.5, theta =  1.04, phi =  1.49, mass =  0.14
+Simulating Hadron
+Made Track: tt10  :7964606678201008138:    1.47    0.74  1.04  1.49
+Made SmearedTrack: ts9   :7955599895883153417:    1.50    0.75  1.04  1.49
+Made Cluster: et17  :3352859713520795665:    0.13  1.07  2.10 sub(et17, )
+Made SmearedCluster: es13  :3343853091215638541:    0.13  1.07  2.10 sub(es13, )
+Rejected SmearedCluster: es13  :3343853091215638541:    0.13  1.07  2.10 sub(es13, )
+Made Cluster: ht11  :5658761566032494603:    1.35  1.07  2.16 sub(ht11, )
+Made SmearedCluster: hs10  :5649766991481798666:    2.14  1.07  2.16 sub(hs10, )
+Simulating Particle :ps19  :10261440869735333907: pdgid =    22, status =   1, q =  0, e =   1.4, theta =  0.41, phi =  0.51, mass =  0.00
+Simulating Photon
+Made Cluster: et18  :3352919041348993042:    1.38  0.41  0.51 sub(et18, )
+Made SmearedCluster: es13  :3343911157726445581:    1.34  0.41  0.51 sub(es13, )
+Simulating Particle :ps20  :10261439022215725076: pdgid =   211, status =   1, q =  1, e =   1.3, theta = -0.19, phi = -0.04, mass =  0.14
+Simulating Hadron
+Made Track: tt11  :7964603077617516555:    1.27    1.25 -0.19 -0.04
+Made SmearedTrack: ts10  :7955595882957635594:    1.27    1.25 -0.19 -0.04
+Made Cluster: ht12  :5658760203043078156:    1.28 -0.20 -0.65 sub(ht12, )
+Made SmearedCluster: hs11  :5649748598124969995:    1.03 -0.20 -0.65 sub(hs11, )
+Simulating Particle :ps21  :10261437761437302805: pdgid =  -211, status =   1, q = -1, e =   1.2, theta = -0.56, phi = -2.53, mass =  0.14
+Simulating Hadron
+Made Track: tt12  :7964601808777641996:    1.20    1.01 -0.56 -2.53
+Made SmearedTrack: ts11  :7955594314055155723:    1.18    1.00 -0.56 -2.53
+Made Cluster: et19  :3352869305317326867:    0.19 -0.60 -1.84 sub(et19, )
+Made SmearedCluster: es14  :3341670923508908046:   -0.07 -0.60 -1.84 sub(es14, )
+Rejected SmearedCluster: es14  :3341670923508908046:   -0.07 -0.60 -1.84 sub(es14, )
+Made Cluster: ht13  :5658755524305354765:    1.01 -0.61 -1.74 sub(ht13, )
+Made SmearedCluster: hs12  :5649680999609532428:    0.07 -0.61 -1.74 sub(hs12, )
+Rejected SmearedCluster: hs12  :5649680999609532428:    0.07 -0.61 -1.74 sub(hs12, )
+Simulating Particle :ps22  :10261434924565266454: pdgid =   211, status =   1, q =  1, e =   1.0, theta =  1.04, phi =  1.06, mass =  0.14
+Simulating Hadron
+Made Track: tt13  :7964598949667405837:    1.03    0.52  1.04  1.06
+Made SmearedTrack: ts12  :7955592107270340620:    1.05    0.53  1.04  1.06
+Made Cluster: ht14  :5658756105392619534:    1.04  1.11  0.10 sub(ht14, )
+Made SmearedCluster: hs12  :5647513932722601996:   -0.45  1.11  0.10 sub(hs12, )
+Rejected SmearedCluster: hs12  :5647513932722601996:   -0.45  1.11  0.10 sub(hs12, )
+Simulating Particle :ps23  :10261434423419338775: pdgid =  -211, status =   1, q = -1, e =   1.0, theta = -0.41, phi =  1.08, mass =  0.14
+Simulating Hadron
+Made Track: tt14  :7964598443849023502:    1.01    0.92 -0.41  1.08
+Made SmearedTrack: ts13  :7955591235289219085:    1.00    0.92 -0.41  1.08
+Made Cluster: et20  :3352858866491588628:    0.12 -0.45  1.86 sub(et20, )
+Made SmearedCluster: es14  :3341670923508908046:   -0.22 -0.45  1.86 sub(es14, )
+Rejected SmearedCluster: es14  :3341670923508908046:   -0.22 -0.45  1.86 sub(es14, )
+Made Cluster: ht15  :5658751556760109071:    0.89 -0.47  1.98 sub(ht15, )
+Made SmearedCluster: hs12  :5649750005257338892:    1.11 -0.47  1.98 sub(hs12, )
+Simulating Particle :ps24  :10261433309695311896: pdgid =    22, status =   1, q =  0, e =   1.0, theta =  1.01, phi =  1.02, mass =  0.00
+Simulating Photon
+Made Cluster: et21  :3352911481308971029:    0.98  1.01  1.02 sub(et21, )
+Made SmearedCluster: es14  :3343901590800039950:    0.90  1.01  1.02 sub(es14, )
+Simulating Particle :ps25  :10261432211358089241: pdgid =    22, status =   1, q =  0, e =   0.9, theta =  1.11, phi =  0.93, mass =  0.00
+Simulating Photon
+Made Cluster: et22  :3352910382971748374:    0.94  1.11  0.93 sub(et22, )
+Made SmearedCluster: es15  :3343899401153150991:    0.84  1.11  0.93 sub(es15, )
+Simulating Particle :ps26  :10261432125137879066: pdgid =   130, status =   1, q =  0, e =   0.9, theta =  0.03, phi =  0.72, mass =  0.50
+Simulating Hadron
+Made Cluster: et23  :3352872463110242327:    0.22  0.03  0.72 sub(et23, )
+Made SmearedCluster: es16  :3343887882266869776:    0.51  0.03  0.72 sub(es16, )
+Made Cluster: ht16  :5658745680598925328:    0.73  0.03  0.72 sub(ht16, )
+Made SmearedCluster: hs13  :5649759206083919885:    1.63  0.03  0.72 sub(hs13, )
+Simulating Particle :ps27  :10261431500207554587: pdgid =    22, status =   1, q =  0, e =   0.9, theta =  0.78, phi =  1.06, mass =  0.00
+Simulating Photon
+Made Cluster: et24  :3352909671821213720:    0.92  0.78  1.06 sub(et24, )
+Made SmearedCluster: es17  :3343904980739293201:    1.00  0.78  1.06 sub(es17, )
+Simulating Particle :ps28  :10261429022684610588: pdgid =  -211, status =   1, q = -1, e =   0.9, theta =  0.79, phi =  0.36, mass =  0.14
+Simulating Hadron
+Made Track: tt15  :7964592808742879247:    0.84    0.59  0.79  0.36
+Made SmearedTrack: ts14  :7955585728069500942:    0.85    0.60  0.79  0.36
+Made Cluster: et25  :3352889053002334233:    0.42  0.94  1.67 sub(et25, )
+Made SmearedCluster: es18  :3343897649779572754:    0.79  0.94  1.67 sub(es18, )
+Made Cluster: ht17  :5658733160435810321:    0.43  0.97  1.79 sub(ht17, )
+Made SmearedCluster: hs14  :5649718258578751502:    0.33  0.97  1.79 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649718258578751502:    0.33  0.97  1.79 sub(hs14, )
+Simulating Particle :ps29  :10261425722077741085: pdgid =    22, status =   1, q =  0, e =   0.8, theta = -0.64, phi = -2.84, mass =  0.00
+Simulating Photon
+Made Cluster: et26  :3352903893691400218:    0.76 -0.64 -2.84 sub(et26, )
+Made SmearedCluster: es19  :3343899230738579475:    0.83 -0.64 -2.84 sub(es19, )
+Simulating Particle :ps30  :10261425419729240094: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.30, phi =  0.38, mass =  0.00
+Simulating Photon
+Made Cluster: et27  :3352903591342899227:    0.75  0.30  0.38 sub(et27, )
+Made SmearedCluster: es20  :3343889036124094484:    0.54  0.30  0.38 sub(es20, )
+Simulating Particle :ps31  :10261424312953077791: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  1.04, phi =  0.93, mass =  0.00
+Simulating Photon
+Made Cluster: et28  :3352902484566736924:    0.72  1.04  0.93 sub(et28, )
+Made SmearedCluster: es21  :3343889545989980181:    0.56  1.04  0.93 sub(es21, )
+Simulating Particle :ps32  :10261422682266402848: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.34, phi =  0.86, mass =  0.00
+Simulating Photon
+Made Cluster: et29  :3352900853880061981:    0.67  0.34  0.86 sub(et29, )
+Made SmearedCluster: es22  :3343897727017680918:    0.79  0.34  0.86 sub(es22, )
+Simulating Particle :ps33  :10261421333227241505: pdgid =   211, status =   1, q =  1, e =   0.6, theta =  0.66, phi = -0.04, mass =  0.14
+Simulating Hadron
+Made Track: tt16  :7964584977333485584:    0.62    0.49  0.66 -0.04
+Made SmearedTrack: ts15  :7955577729334640655:    0.62    0.49  0.66 -0.04
+Made Cluster: et30  :3352839288707350558:    0.06  1.06 -2.10 sub(et30, )
+Made SmearedCluster: es23  :3343872794711556119:    0.29  1.06 -2.10 sub(es23, )
+Rejected SmearedCluster: es23  :3343872794711556119:    0.29  1.06 -2.10 sub(es23, )
+Made Cluster: ht18  :5658740482090467346:    0.58  1.15 -2.30 sub(ht18, )
+Made SmearedCluster: hs14  :5649708095469781006:    0.22  1.15 -2.30 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649708095469781006:    0.22  1.15 -2.30 sub(hs14, )
+Simulating Particle :ps34  :10261417304233345058: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.34, phi =  0.62, mass =  0.00
+Simulating Photon
+Made Cluster: et31  :3352895475847004191:    0.52  0.34  0.62 sub(et31, )
+Made SmearedCluster: es23  :3343881777591615511:    0.42  0.34  0.62 sub(es23, )
+Rejected SmearedCluster: es23  :3343881777591615511:    0.42  0.34  0.62 sub(es23, )
+Simulating Particle :ps35  :10261417123144269859: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.09, phi = -1.79, mass =  0.00
+Simulating Photon
+Made Cluster: et32  :3352895294757928992:    0.52 -0.09 -1.79 sub(et32, )
+Made SmearedCluster: es23  :3343889616542367767:    0.56 -0.09 -1.79 sub(es23, )
+Simulating Particle :ps36  :10261417013270282276: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  1.10, phi =  1.37, mass =  0.00
+Simulating Photon
+Made Cluster: et33  :3352895184883941409:    0.51  1.10  1.37 sub(et33, )
+Made SmearedCluster: es24  :3343883939119890456:    0.45  1.10  1.37 sub(es24, )
+Rejected SmearedCluster: es24  :3343883939119890456:    0.45  1.10  1.37 sub(es24, )
+Simulating Particle :ps37  :10261414087818739749: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -1.00, phi =  2.08, mass =  0.00
+Simulating Photon
+Made Cluster: et34  :3352892259432398882:    0.46 -1.00  2.08 sub(et34, )
+Made SmearedCluster: es24  :3343878732728238104:    0.37 -1.00  2.08 sub(es24, )
+Rejected SmearedCluster: es24  :3343878732728238104:    0.37 -1.00  2.08 sub(es24, )
+Simulating Particle :ps38  :10261412642448998438: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.99, phi =  0.90, mass =  0.00
+Simulating Photon
+Made Cluster: et35  :3352890814062657571:    0.44  0.99  0.90 sub(et35, )
+Made SmearedCluster: es24  :3343871698276450328:    0.27  0.99  0.90 sub(es24, )
+Rejected SmearedCluster: es24  :3343871698276450328:    0.27  0.99  0.90 sub(es24, )
+Simulating Particle :ps39  :10261409818919043111: pdgid =  -211, status =   1, q = -1, e =   0.4, theta =  0.54, phi =  1.23, mass =  0.14
+Simulating Hadron
+Made Track: tt17  :7964572259085975569:    0.38    0.33  0.54  1.23
+Made SmearedTrack: ts16  :7955565238338715664:    0.38    0.33  0.54  1.23
+Rejected SmearedTrack: ts16  :7955565238338715664:    0.38    0.33  0.54  1.23
+Made Cluster: et36  :3352859182003912740:    0.12  1.27  2.08 sub(et36, )
+Made SmearedCluster: es24  :3341670923508908056:   -0.20  1.27  2.08 sub(es24, )
+Rejected SmearedCluster: es24  :3341670923508908056:   -0.20  1.27  2.08 sub(es24, )
+Made Cluster: ht19  :5658722296609636371:    0.28  1.23  2.47 sub(ht19, )
+Made SmearedCluster: hs14  :5649723395579838478:    0.40  1.23  2.47 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649723395579838478:    0.40  1.23  2.47 sub(hs14, )
+Simulating Particle :ps40  :10261409486159740968: pdgid =   211, status =   1, q =  1, e =   0.4, theta = -0.02, phi =  1.26, mass =  0.14
+Simulating Hadron
+Made Track: tt18  :7964571904222691346:    0.37    0.37 -0.02  1.26
+Made SmearedTrack: ts16  :7955564731205419024:    0.37    0.37 -0.02  1.26
+Rejected SmearedTrack: ts16  :7955564731205419024:    0.37    0.37 -0.02  1.26
+Made Cluster: et37  :3352874909488381989:    0.23 -1.39 -1.49 sub(et37, )
+Made SmearedCluster: es24  :3343821202910085144:    0.04 -1.39 -1.49 sub(es24, )
+Rejected SmearedCluster: es24  :3343821202910085144:    0.04 -1.39 -1.49 sub(es24, )
+Made Cluster: ht20  :5658708230902120468:    0.17 -1.44  0.96 sub(ht20, )
+Made SmearedCluster: hs14  :5649702590607261710:    0.18 -1.44  0.96 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649702590607261710:    0.18 -1.44  0.96 sub(hs14, )
+Simulating Particle :ps41  :10261406127705030697: pdgid =   -11, status =   1, q =  1, e =   0.4, theta =  0.28, phi =  0.71, mass =  0.00
+Simulating Electron
+Made Track: tt19  :7964570317718814739:    0.35    0.34  0.28  0.71
+Made SmearedTrack: ts16  :7955560674032091152:    0.32    0.30  0.28  0.71
+Rejected SmearedTrack: ts16  :7955560674032091152:    0.32    0.30  0.28  0.71
+Simulating Particle :ps42  :10261403372154257450: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.83, phi = -2.56, mass =  0.00
+Simulating Photon
+Made Cluster: et38  :3352881543767916582:    0.31 -0.83 -2.56 sub(et38, )
+Made SmearedCluster: es24  :3343876007779106840:    0.34 -0.83 -2.56 sub(es24, )
+Rejected SmearedCluster: es24  :3343876007779106840:    0.34 -0.83 -2.56 sub(es24, )
+Simulating Particle :ps44  :10261393509711872044: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.43, phi =  0.32, mass =  0.00
+Simulating Photon
+Made Cluster: et39  :3352871681325531175:    0.21  0.43  0.32 sub(et39, )
+Made SmearedCluster: es24  :3343870289179050008:    0.25  0.43  0.32 sub(es24, )
+Rejected SmearedCluster: es24  :3343870289179050008:    0.25  0.43  0.32 sub(es24, )
+Simulating Particle :ps45  :10261388974975090733: pdgid =    11, status =   1, q = -1, e =   0.2, theta =  0.26, phi =  0.74, mass =  0.00
+Simulating Electron
+Made Track: tt20  :7964553164913377300:    0.18    0.17  0.26  0.74
+Made SmearedTrack: ts16  :7955539884366626832:    0.14    0.13  0.26  0.74
+Rejected SmearedTrack: ts16  :7955539884366626832:    0.14    0.13  0.26  0.74
+Simulating Particle :ps46  :10261381822514462766: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.08, phi = -1.26, mass =  0.00
+Simulating Photon
+Made Cluster: et40  :3352859994128121896:    0.13 -0.08 -1.26 sub(et40, )
+Made SmearedCluster: es24  :3343818915361849368:    0.03 -0.08 -1.26 sub(es24, )
+Rejected SmearedCluster: es24  :3343818915361849368:    0.03 -0.08 -1.26 sub(es24, )
+Simulating Particle :ps47  :10261359821045366831: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.16, phi =  2.36, mass =  0.00
+Simulating Photon
+Made Cluster: et41  :3352837992659025961:    0.06 -0.16  2.36 sub(et41, )
+Made SmearedCluster: es24  :3343835250466750488:    0.06 -0.16  2.36 sub(es24, )
+Rejected SmearedCluster: es24  :3343835250466750488:    0.06 -0.16  2.36 sub(es24, )
+Simulating Particle :ps48  :10261348650900783152: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  0.22, phi =  1.26, mass =  0.00
+Simulating Photon
+Made Cluster: et42  :3352826822514442282:    0.04  0.22  1.26 sub(et42, )
+Made SmearedCluster: es24  :3343789785333366808:    0.01  0.22  1.26 sub(es24, )
+Rejected SmearedCluster: es24  :3343789785333366808:    0.01  0.22  1.26 sub(es24, )
+Made MergedCluster: em0   :3289844686738423808:    0.51  0.03  0.72 sub(es16, )
+Made MergedCluster: em1   :3289845840595648513:    0.54  0.30  0.38 sub(es20, )
+Made MergedCluster: em2   :3289846350461534210:    0.56  1.04  0.93 sub(es21, )
+Made MergedCluster: em3   :3289846421013921795:    0.56 -0.09 -1.79 sub(es23, )
+Made MergedCluster: em4   :3289854454251126788:    0.79  0.94  1.67 sub(es18, )
+Made MergedCluster: em5   :3289854531489234949:    0.79  0.34  0.86 sub(es22, )
+Made MergedCluster: em6   :3289856035210133510:    0.83 -0.64 -2.84 sub(es19, )
+Made MergedCluster: em7   :3289856205624705031:    0.84  1.11  0.93 sub(es15, )
+Made MergedCluster: em8   :3289858395271593992:    0.90  1.01  1.02 sub(es14, )
+Made MergedCluster: em9   :3289861785210847241:    1.00  0.78  1.06 sub(es17, )
+Made MergedCluster: em10  :3289867962197999626:    1.34  0.41  0.51 sub(es13, )
+Made MergedCluster: em11  :3289870707621625867:    1.50 -0.91  2.56 sub(es12, )
+Made MergedCluster: em12  :3289875038116773900:    1.74 -0.60 -2.33 sub(es0, )
+Made MergedCluster: em13  :3289877338564591629:    1.88 -0.58 -2.38 sub(es11, )
+Made MergedCluster: em14  :3289879545703825422:    2.00  1.11  1.02 sub(es10, )
+Made MergedCluster: em15  :3289883130776780815:    2.41 -0.59 -2.28 sub(es2, )
+Made MergedCluster: em16  :3289883639308877840:    2.47  0.04  0.78 sub(es3, )
+Made MergedCluster: em17  :3289886970664189969:    2.85  0.94  0.73 sub(es7, )
+Made MergedCluster: em18  :3289887808140869650:    2.94  1.05  1.38 sub(es9, )
+Made MergedCluster: em19  :3289887880370978835:    2.95  0.40  0.44 sub(es8, )
+Made MergedCluster: em20  :3289888361407315988:    3.00 -0.56 -2.46 sub(es4, )
+Made MergedCluster: em21  :3289889048035852309:    3.08  0.31  0.72 sub(es5, )
+Made MergedCluster: em22  :3289891026384191510:    3.31 -0.63 -2.38 sub(es6, )
+Made MergedCluster: em23  :3289907695301165079:    6.40  1.09  0.99 sub(es1, )
+Made MergedCluster: hm0   :5595705402596524032:    1.03 -0.20 -0.65 sub(hs11, )
+Made MergedCluster: hm1   :5595706809728892929:    1.11 -0.47  1.98 sub(hs12, )
+Made MergedCluster: hm2   :5595708942643625986:    1.23  0.31  0.72 sub(hs4, )
+Made MergedCluster: hm3   :5595709579544494083:    1.26 -0.64 -2.89 sub(hs9, )
+Made MergedCluster: hm4   :5595786483054149636:   26.16 -0.60 -2.37 sub(hs0, hs1, hs2, hs3, )
+Made MergedCluster: hm5   :5595709858165817349:    1.28 -0.92  2.50 sub(hs8, )
+Made MergedCluster: hm6   :5595716010555473926:    1.63  0.03  0.72 sub(hs13, )
+Made MergedCluster: hm7   :5595723795953352711:    2.14  1.07  2.16 sub(hs10, )
+Made MergedCluster: hm8   :5595724246968958984:    2.19 -0.00  0.35 sub(hs6, )
+Made MergedCluster: hm9   :5595729704507146249:    2.81  0.30  0.35 sub(hs7, )
+Made MergedCluster: hm10  :5595748364099518474:    5.87 -0.70 -2.02 sub(hs5, )
+Made block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.5 (3289844686738423808)
+
+Made block:E1H1T1   :br1   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  2.1 (7955609380202741767)
+      h1 = hm9       value=  2.8 (5595729704507146249)
+      e2 = em1       value=  0.5 (3289845840595648513)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0082     ---       .
+
+Made block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.6 (3289846350461534210)
+
+Made block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.6 (3289846421013921795)
+
+Made block:E1T1     :br4   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  0.8 (7955585728069500942)
+      e1 = em4       value=  0.8 (3289854454251126788)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.8 (3289854531489234949)
+
+Made block:E1       :br6   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.8 (3289856035210133510)
+
+Made block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.8 (3289856205624705031)
+
+Made block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.9 (3289858395271593992)
+
+Made block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  1.0 (3289861785210847241)
+
+Made block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  1.3 (3289867962197999626)
+
+Made block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.5 (3289870707621625867)
+
+Made block:E3H1T4   :br12  : ecals = 3 hcals = 1 tracks = 4
+    elements:
+      t0 = ts0       value=  8.8 (7955645615881322496)
+      t1 = ts1       value=  7.7 (7955642586322960385)
+      t2 = ts2       value=  6.3 (7955636330256400386)
+      t3 = ts4       value=  4.6 (7955628949854224388)
+      h4 = hm4       value= 26.2 (5595786483054149636)
+      e5 = em20      value=  3.0 (3289888361407315988)
+      e6 = em15      value=  2.4 (3289883130776780815)
+      e7 = em12      value=  1.7 (3289875038116773900)
+    distances:
+              t0      t1      t2      t3      h4      e5      e6      e7
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      t3     ---     ---     ---       .
+      h4  0.0000  0.0000  0.0000  0.0000       .
+      e5     ---     ---     ---  0.0000     ---       .
+      e6     ---     ---  0.0000     ---     ---     ---       .
+      e7  0.0000     ---     ---     ---     ---     ---     ---       .
+
+Made block:E1       :br13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  1.9 (3289877338564591629)
+
+Made block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  2.0 (3289879545703825422)
+
+Made block:E1H1T1   :br15  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  4.9 (7955630088630829059)
+      h1 = hm6       value=  1.6 (5595716010555473926)
+      e2 = em16      value=  2.5 (3289883639308877840)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.1848       .
+      e2  0.0000     ---       .
+
+Made block:E1       :br16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  2.8 (3289886970664189969)
+
+Made block:E1       :br17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em18      value=  2.9 (3289887808140869650)
+
+Made block:E1       :br18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  2.9 (3289887880370978835)
+
+Made block:E1       :br19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  3.1 (3289889048035852309)
+
+Made block:E1       :br20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  3.3 (3289891026384191510)
+
+Made block:E1       :br21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  6.4 (3289907695301165079)
+
+Made block:H1T1     :br22  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts10      value=  1.3 (7955595882957635594)
+      h1 = hm0       value=  1.0 (5595705402596524032)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br23  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  1.0 (7955591235289219085)
+      h1 = hm1       value=  1.1 (5595706809728892929)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1       :br24  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm2       value=  1.2 (5595708942643625986)
+
+Made block:H1T1     :br25  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts8       value=  1.4 (7955598981661196296)
+      h1 = hm3       value=  1.3 (5595709579544494083)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1       :br26  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  1.3 (5595709858165817349)
+
+Made block:H1T1     :br27  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  1.5 (7955599895883153417)
+      h1 = hm7       value=  2.1 (5595723795953352711)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br28  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  2.1 (7955609636592156678)
+      h1 = hm8       value=  2.2 (5595724246968958984)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br29  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  3.3 (7955620055165698053)
+      h1 = hm10      value=  5.9 (5595748364099518474)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:T1       :br30  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  0.6 (7955577729334640655)
+
+Made block:T1       :br31  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.1 (7955592107270340620)
+
+Made block:T1       :br32  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  1.2 (7955594314055155723)
+
+Splitting block:E3H1T4   :br12  : ecals = 3 hcals = 1 tracks = 4
+    elements:
+      t0 = ts0       value=  8.8 (7955645615881322496)
+      t1 = ts1       value=  7.7 (7955642586322960385)
+      t2 = ts2       value=  6.3 (7955636330256400386)
+      t3 = ts4       value=  4.6 (7955628949854224388)
+      h4 = hm4       value= 26.2 (5595786483054149636)
+      e5 = em20      value=  3.0 (3289888361407315988)
+      e6 = em15      value=  2.4 (3289883130776780815)
+      e7 = em12      value=  1.7 (3289875038116773900)
+    distances:
+              t0      t1      t2      t3      h4      e5      e6      e7
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      t3     ---     ---     ---       .
+      h4  0.0000  0.0000  0.0000  0.0000       .
+      e5     ---     ---     ---  0.0000     ---       .
+      e6     ---     ---  0.0000     ---     ---     ---       .
+      e7  0.0000     ---     ---     ---     ---     ---     ---       .
+
+Made block:E3H1T4   :bs0   : ecals = 3 hcals = 1 tracks = 4
+    elements:
+      t0 = ts0       value=  8.8 (7955645615881322496)
+      t1 = ts1       value=  7.7 (7955642586322960385)
+      t2 = ts2       value=  6.3 (7955636330256400386)
+      t3 = ts4       value=  4.6 (7955628949854224388)
+      h4 = hm4       value= 26.2 (5595786483054149636)
+      e5 = em20      value=  3.0 (3289888361407315988)
+      e6 = em15      value=  2.4 (3289883130776780815)
+      e7 = em12      value=  1.7 (3289875038116773900)
+    distances:
+              t0      t1      t2      t3      h4      e5      e6      e7
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      t3     ---     ---     ---       .
+      h4  0.0000  0.0000  0.0000  0.0000       .
+      e5     ---     ---     ---  0.0000     ---       .
+      e6     ---     ---  0.0000     ---     ---     ---       .
+      e7  0.0000     ---     ---     ---     ---     ---     ---       .
+
+Splitting block:E1H1T1   :br15  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  4.9 (7955630088630829059)
+      h1 = hm6       value=  1.6 (5595716010555473926)
+      e2 = em16      value=  2.5 (3289883639308877840)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.1848       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs1   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  4.9 (7955630088630829059)
+      h1 = hm6       value=  1.6 (5595716010555473926)
+      e2 = em16      value=  2.5 (3289883639308877840)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.1848       .
+      e2  0.0000     ---       .
+
+Splitting block:E1H1T1   :br1   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  2.1 (7955609380202741767)
+      h1 = hm9       value=  2.8 (5595729704507146249)
+      e2 = em1       value=  0.5 (3289845840595648513)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0082     ---       .
+
+Made block:E1H1T1   :bs2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  2.1 (7955609380202741767)
+      h1 = hm9       value=  2.8 (5595729704507146249)
+      e2 = em1       value=  0.5 (3289845840595648513)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0082     ---       .
+
+Splitting block:H1T1     :br29  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  3.3 (7955620055165698053)
+      h1 = hm10      value=  5.9 (5595748364099518474)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs3   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  3.3 (7955620055165698053)
+      h1 = hm10      value=  5.9 (5595748364099518474)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br28  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  2.1 (7955609636592156678)
+      h1 = hm8       value=  2.2 (5595724246968958984)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs4   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  2.1 (7955609636592156678)
+      h1 = hm8       value=  2.2 (5595724246968958984)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br27  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  1.5 (7955599895883153417)
+      h1 = hm7       value=  2.1 (5595723795953352711)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs5   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  1.5 (7955599895883153417)
+      h1 = hm7       value=  2.1 (5595723795953352711)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br25  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts8       value=  1.4 (7955598981661196296)
+      h1 = hm3       value=  1.3 (5595709579544494083)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs6   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts8       value=  1.4 (7955598981661196296)
+      h1 = hm3       value=  1.3 (5595709579544494083)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br23  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  1.0 (7955591235289219085)
+      h1 = hm1       value=  1.1 (5595706809728892929)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs7   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  1.0 (7955591235289219085)
+      h1 = hm1       value=  1.1 (5595706809728892929)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br22  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts10      value=  1.3 (7955595882957635594)
+      h1 = hm0       value=  1.0 (5595705402596524032)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs8   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts10      value=  1.3 (7955595882957635594)
+      h1 = hm0       value=  1.0 (5595705402596524032)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:E1T1     :br4   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  0.8 (7955585728069500942)
+      e1 = em4       value=  0.8 (3289854454251126788)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs9   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  0.8 (7955585728069500942)
+      e1 = em4       value=  0.8 (3289854454251126788)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:T1       :br32  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  1.2 (7955594314055155723)
+
+Made block:T1       :bs10  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  1.2 (7955594314055155723)
+
+Splitting block:T1       :br31  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.1 (7955592107270340620)
+
+Made block:T1       :bs11  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.1 (7955592107270340620)
+
+Splitting block:T1       :br30  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  0.6 (7955577729334640655)
+
+Made block:T1       :bs12  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  0.6 (7955577729334640655)
+
+Splitting block:H1       :br26  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  1.3 (5595709858165817349)
+
+Made block:H1       :bs13  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  1.3 (5595709858165817349)
+
+Splitting block:H1       :br24  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm2       value=  1.2 (5595708942643625986)
+
+Made block:H1       :bs14  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm2       value=  1.2 (5595708942643625986)
+
+Splitting block:E1       :br21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  6.4 (3289907695301165079)
+
+Made block:E1       :bs15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  6.4 (3289907695301165079)
+
+Splitting block:E1       :br20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  3.3 (3289891026384191510)
+
+Made block:E1       :bs16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  3.3 (3289891026384191510)
+
+Splitting block:E1       :br19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  3.1 (3289889048035852309)
+
+Made block:E1       :bs17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  3.1 (3289889048035852309)
+
+Splitting block:E1       :br18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  2.9 (3289887880370978835)
+
+Made block:E1       :bs18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  2.9 (3289887880370978835)
+
+Splitting block:E1       :br17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em18      value=  2.9 (3289887808140869650)
+
+Made block:E1       :bs19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em18      value=  2.9 (3289887808140869650)
+
+Splitting block:E1       :br16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  2.8 (3289886970664189969)
+
+Made block:E1       :bs20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  2.8 (3289886970664189969)
+
+Splitting block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  2.0 (3289879545703825422)
+
+Made block:E1       :bs21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  2.0 (3289879545703825422)
+
+Splitting block:E1       :br13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  1.9 (3289877338564591629)
+
+Made block:E1       :bs22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  1.9 (3289877338564591629)
+
+Splitting block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.5 (3289870707621625867)
+
+Made block:E1       :bs23  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.5 (3289870707621625867)
+
+Splitting block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  1.3 (3289867962197999626)
+
+Made block:E1       :bs24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  1.3 (3289867962197999626)
+
+Splitting block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  1.0 (3289861785210847241)
+
+Made block:E1       :bs25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  1.0 (3289861785210847241)
+
+Splitting block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.9 (3289858395271593992)
+
+Made block:E1       :bs26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.9 (3289858395271593992)
+
+Splitting block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.8 (3289856205624705031)
+
+Made block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.8 (3289856205624705031)
+
+Splitting block:E1       :br6   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.8 (3289856035210133510)
+
+Made block:E1       :bs28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.8 (3289856035210133510)
+
+Splitting block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.8 (3289854531489234949)
+
+Made block:E1       :bs29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.8 (3289854531489234949)
+
+Splitting block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.6 (3289846421013921795)
+
+Made block:E1       :bs30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.6 (3289846421013921795)
+
+Splitting block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.6 (3289846350461534210)
+
+Made block:E1       :bs31  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.6 (3289846350461534210)
+
+Splitting block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.5 (3289844686738423808)
+
+Made block:E1       :bs32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.5 (3289844686738423808)
+
+Processing block:E3H1T4   :bs0   : ecals = 3 hcals = 1 tracks = 4
+    elements:
+      t0 = ts0       value=  8.8 (7955645615881322496)
+      t1 = ts1       value=  7.7 (7955642586322960385)
+      t2 = ts2       value=  6.3 (7955636330256400386)
+      t3 = ts4       value=  4.6 (7955628949854224388)
+      h4 = hm4       value= 26.2 (5595786483054149636)
+      e5 = em20      value=  3.0 (3289888361407315988)
+      e6 = em15      value=  2.4 (3289883130776780815)
+      e7 = em12      value=  1.7 (3289875038116773900)
+    distances:
+              t0      t1      t2      t3      h4      e5      e6      e7
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      t3     ---     ---     ---       .
+      h4  0.0000  0.0000  0.0000  0.0000       .
+      e5     ---     ---     ---  0.0000     ---       .
+      e6     ---     ---  0.0000     ---     ---     ---       .
+      e7  0.0000     ---     ---     ---     ---     ---     ---       .
+
+Made Particle :pr0   :10252481428262486016: pdgid =  -211, status =   1, q = -1, e =   8.8, theta = -0.61, phi = -2.38, mass =  0.14 from SmearedTrack: ts0   :7955645615881322496:    8.77    7.18 -0.61 -2.38
+Made Particle :pr1   :10252478401801617409: pdgid =   211, status =   1, q =  1, e =   7.7, theta = -0.61, phi = -2.32, mass =  0.14 from SmearedTrack: ts1   :7955642586322960385:    7.70    6.30 -0.61 -2.32
+Made Particle :pr2   :10252472146987057154: pdgid =  -211, status =   1, q = -1, e =   6.3, theta = -0.59, phi = -2.40, mass =  0.14 from SmearedTrack: ts2   :7955636330256400386:    6.27    5.22 -0.59 -2.40
+Made Particle :pr3   :10252464769057423363: pdgid =   211, status =   1, q =  1, e =   4.6, theta = -0.55, phi = -2.38, mass =  0.14 from SmearedTrack: ts4   :7955628949854224388:    4.59    3.92 -0.55 -2.38
+Finished block
+Processing block:E1H1T1   :bs2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  2.1 (7955609380202741767)
+      h1 = hm9       value=  2.8 (5595729704507146249)
+      e2 = em1       value=  0.5 (3289845840595648513)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0082     ---       .
+
+Made Particle :pr4   :10252445231114878980: pdgid =   211, status =   1, q =  1, e =   2.1, theta =  0.30, phi =  0.72, mass =  0.14 from SmearedTrack: ts7   :7955609380202741767:    2.07    1.98  0.30  0.72
+Finished block
+Processing block:E1H1T1   :bs1   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  4.9 (7955630088630829059)
+      h1 = hm6       value=  1.6 (5595716010555473926)
+      e2 = em16      value=  2.5 (3289883639308877840)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.1848       .
+      e2  0.0000     ---       .
+
+Made Particle :pr5   :10252465907341197317: pdgid =  -211, status =   1, q = -1, e =   4.9, theta =  0.04, phi =  0.65, mass =  0.14 from SmearedTrack: ts3   :7955630088630829059:    4.85    4.85  0.04  0.65
+Finished block
+Processing block:E1T1     :bs9   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  0.8 (7955585728069500942)
+      e1 = em4       value=  0.8 (3289854454251126788)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr6   :10252421937164713990: pdgid =  -211, status =   1, q = -1, e =   0.9, theta =  0.79, phi =  0.36, mass =  0.14 from SmearedTrack: ts14  :7955585728069500942:    0.85    0.60  0.79  0.36
+Finished block
+Processing block:H1T1     :bs8   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts10      value=  1.3 (7955595882957635594)
+      h1 = hm0       value=  1.0 (5595705402596524032)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr7   :10252431826433867783: pdgid =   211, status =   1, q =  1, e =   1.3, theta = -0.19, phi = -0.04, mass =  0.14 from SmearedTrack: ts10  :7955595882957635594:    1.27    1.25 -0.19 -0.04
+Finished block
+Processing block:H1T1     :bs7   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  1.0 (7955591235289219085)
+      h1 = hm1       value=  1.1 (5595706809728892929)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr8   :10252427213571883016: pdgid =  -211, status =   1, q = -1, e =   1.0, theta = -0.41, phi =  1.08, mass =  0.14 from SmearedTrack: ts13  :7955591235289219085:    1.00    0.92 -0.41  1.08
+Finished block
+Processing block:H1T1     :bs6   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts8       value=  1.4 (7955598981661196296)
+      h1 = hm3       value=  1.3 (5595709579544494083)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr9   :10252434908945317897: pdgid =   211, status =   1, q =  1, e =   1.5, theta = -0.61, phi = -2.25, mass =  0.14 from SmearedTrack: ts8   :7955598981661196296:    1.45    1.18 -0.61 -2.25
+Finished block
+Processing block:H1T1     :bs5   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  1.5 (7955599895883153417)
+      h1 = hm7       value=  2.1 (5595723795953352711)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr10  :10252435819113480202: pdgid =  -211, status =   1, q = -1, e =   1.5, theta =  1.04, phi =  1.49, mass =  0.14 from SmearedTrack: ts9   :7955599895883153417:    1.50    0.75  1.04  1.49
+Finished block
+Processing block:H1T1     :bs4   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  2.1 (7955609636592156678)
+      h1 = hm8       value=  2.2 (5595724246968958984)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr11  :10252445486938062859: pdgid =   211, status =   1, q =  1, e =   2.1, theta = -0.00, phi =  0.70, mass =  0.14 from SmearedTrack: ts6   :7955609636592156678:    2.10    2.10 -0.00  0.70
+Finished block
+Processing block:H1T1     :bs3   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  3.3 (7955620055165698053)
+      h1 = hm10      value=  5.9 (5595748364099518474)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr12  :10252455890972049420: pdgid =  -211, status =   1, q = -1, e =   3.3, theta = -0.70, phi = -2.31, mass =  0.14 from SmearedTrack: ts5   :7955620055165698053:    3.29    2.52 -0.70 -2.31
+Made Particle :pr13  :10252449708106579981: pdgid =   130, status =   1, q =  0, e =   2.6, theta = -0.70, phi = -2.02, mass =  0.50 from MergedCluster: hm10  :5595748364099518474:    5.87 -0.70 -2.02 sub(hs5, )
+Finished block
+Processing block:E1       :bs32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.5 (3289844686738423808)
+
+Made Particle :pr14  :10252409710653210638: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.03, phi =  0.72, mass =  0.00 from MergedCluster: em0   :3289844686738423808:    0.51  0.03  0.72 sub(es16, )
+Finished block
+Processing block:E1       :bs31  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.6 (3289846350461534210)
+
+Made Particle :pr15  :10252411374376321039: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  1.04, phi =  0.93, mass =  0.00 from MergedCluster: em2   :3289846350461534210:    0.56  1.04  0.93 sub(es21, )
+Finished block
+Processing block:E1       :bs30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.6 (3289846421013921795)
+
+Made Particle :pr16  :10252411444928708624: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.09, phi = -1.79, mass =  0.00 from MergedCluster: em3   :3289846421013921795:    0.56 -0.09 -1.79 sub(es23, )
+Finished block
+Processing block:E1       :bs29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.8 (3289854531489234949)
+
+Made Particle :pr17  :10252419555404021777: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.34, phi =  0.86, mass =  0.00 from MergedCluster: em5   :3289854531489234949:    0.79  0.34  0.86 sub(es22, )
+Finished block
+Processing block:E1       :bs28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.8 (3289856035210133510)
+
+Made Particle :pr18  :10252421059124920338: pdgid =    22, status =   1, q =  0, e =   0.8, theta = -0.64, phi = -2.84, mass =  0.00 from MergedCluster: em6   :3289856035210133510:    0.83 -0.64 -2.84 sub(es19, )
+Finished block
+Processing block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.8 (3289856205624705031)
+
+Made Particle :pr19  :10252421229539491859: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  1.11, phi =  0.93, mass =  0.00 from MergedCluster: em7   :3289856205624705031:    0.84  1.11  0.93 sub(es15, )
+Finished block
+Processing block:E1       :bs26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.9 (3289858395271593992)
+
+Made Particle :pr20  :10252423419186380820: pdgid =    22, status =   1, q =  0, e =   0.9, theta =  1.01, phi =  1.02, mass =  0.00 from MergedCluster: em8   :3289858395271593992:    0.90  1.01  1.02 sub(es14, )
+Finished block
+Processing block:E1       :bs25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  1.0 (3289861785210847241)
+
+Made Particle :pr21  :10252426809125634069: pdgid =    22, status =   1, q =  0, e =   1.0, theta =  0.78, phi =  1.06, mass =  0.00 from MergedCluster: em9   :3289861785210847241:    1.00  0.78  1.06 sub(es17, )
+Finished block
+Processing block:E1       :bs24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  1.3 (3289867962197999626)
+
+Made Particle :pr22  :10252432986112786454: pdgid =    22, status =   1, q =  0, e =   1.3, theta =  0.41, phi =  0.51, mass =  0.00 from MergedCluster: em10  :3289867962197999626:    1.34  0.41  0.51 sub(es13, )
+Finished block
+Processing block:E1       :bs23  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.5 (3289870707621625867)
+
+Made Particle :pr23  :10252435731536412695: pdgid =    22, status =   1, q =  0, e =   1.5, theta = -0.91, phi =  2.56, mass =  0.00 from MergedCluster: em11  :3289870707621625867:    1.50 -0.91  2.56 sub(es12, )
+Finished block
+Processing block:E1       :bs22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  1.9 (3289877338564591629)
+
+Made Particle :pr24  :10252442362479378456: pdgid =    22, status =   1, q =  0, e =   1.9, theta = -0.58, phi = -2.38, mass =  0.00 from MergedCluster: em13  :3289877338564591629:    1.88 -0.58 -2.38 sub(es11, )
+Finished block
+Processing block:E1       :bs21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  2.0 (3289879545703825422)
+
+Made Particle :pr25  :10252444569618612249: pdgid =    22, status =   1, q =  0, e =   2.0, theta =  1.11, phi =  1.02, mass =  0.00 from MergedCluster: em14  :3289879545703825422:    2.00  1.11  1.02 sub(es10, )
+Finished block
+Processing block:E1       :bs20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  2.8 (3289886970664189969)
+
+Made Particle :pr26  :10252451994578976794: pdgid =    22, status =   1, q =  0, e =   2.8, theta =  0.94, phi =  0.73, mass =  0.00 from MergedCluster: em17  :3289886970664189969:    2.85  0.94  0.73 sub(es7, )
+Finished block
+Processing block:E1       :bs19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em18      value=  2.9 (3289887808140869650)
+
+Made Particle :pr27  :10252452832055656475: pdgid =    22, status =   1, q =  0, e =   2.9, theta =  1.05, phi =  1.38, mass =  0.00 from MergedCluster: em18  :3289887808140869650:    2.94  1.05  1.38 sub(es9, )
+Finished block
+Processing block:E1       :bs18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  2.9 (3289887880370978835)
+
+Made Particle :pr28  :10252452904285765660: pdgid =    22, status =   1, q =  0, e =   2.9, theta =  0.40, phi =  0.44, mass =  0.00 from MergedCluster: em19  :3289887880370978835:    2.95  0.40  0.44 sub(es8, )
+Finished block
+Processing block:E1       :bs17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  3.1 (3289889048035852309)
+
+Made Particle :pr29  :10252454071950639133: pdgid =    22, status =   1, q =  0, e =   3.1, theta =  0.31, phi =  0.72, mass =  0.00 from MergedCluster: em21  :3289889048035852309:    3.08  0.31  0.72 sub(es5, )
+Finished block
+Processing block:E1       :bs16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  3.3 (3289891026384191510)
+
+Made Particle :pr30  :10252456050298978334: pdgid =    22, status =   1, q =  0, e =   3.3, theta = -0.63, phi = -2.38, mass =  0.00 from MergedCluster: em22  :3289891026384191510:    3.31 -0.63 -2.38 sub(es6, )
+Finished block
+Processing block:E1       :bs15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  6.4 (3289907695301165079)
+
+Made Particle :pr31  :10252472719215951903: pdgid =    22, status =   1, q =  0, e =   6.4, theta =  1.09, phi =  0.99, mass =  0.00 from MergedCluster: em23  :3289907695301165079:    6.40  1.09  0.99 sub(es1, )
+Finished block
+Processing block:H1       :bs14  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm2       value=  1.2 (5595708942643625986)
+
+Made Particle :pr32  :10252430957344718880: pdgid =   130, status =   1, q =  0, e =   1.2, theta =  0.31, phi =  0.72, mass =  0.50 from MergedCluster: hm2   :5595708942643625986:    1.23  0.31  0.72 sub(hs4, )
+Finished block
+Processing block:H1       :bs13  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  1.3 (5595709858165817349)
+
+Made Particle :pr33  :10252431872866910241: pdgid =   130, status =   1, q =  0, e =   1.3, theta = -0.92, phi =  2.50, mass =  0.50 from MergedCluster: hm5   :5595709858165817349:    1.28 -0.92  2.50 sub(hs8, )
+Finished block
+Processing block:T1       :bs12  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  0.6 (7955577729334640655)
+
+Made Particle :pr34  :10252414082013462562: pdgid =   211, status =   1, q =  1, e =   0.6, theta =  0.66, phi = -0.04, mass =  0.14 from SmearedTrack: ts15  :7955577729334640655:    0.62    0.49  0.66 -0.04
+Finished block
+Processing block:T1       :bs11  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.1 (7955592107270340620)
+
+Made Particle :pr35  :10252428077709656099: pdgid =   211, status =   1, q =  1, e =   1.1, theta =  1.04, phi =  1.06, mass =  0.14 from SmearedTrack: ts12  :7955592107270340620:    1.05    0.53  1.04  1.06
+Finished block
+Processing block:T1       :bs10  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  1.2 (7955594314055155723)
+
+Made Particle :pr36  :10252430267557871652: pdgid =  -211, status =   1, q = -1, e =   1.2, theta = -0.56, phi = -2.53, mass =  0.14 from SmearedTrack: ts11  :7955594314055155723:    1.18    1.00 -0.56 -2.53
+Finished block
+Finished reconstruction

--- a/test/data/required_cms_physics.txt
+++ b/test/data/required_cms_physics.txt
@@ -1,0 +1,13457 @@
+Event: 0
+Made Particle :ps0   :10261534350380105728: pdgid =   -13, status =   1, q =  1, e =  54.2, theta = -0.88, phi =  1.34, mass =  0.11
+Made Particle :ps1   :10261527063680778241: pdgid =    22, status =   1, q =  0, e =  41.0, theta =  1.07, phi = -0.51, mass =  0.00
+Made Particle :ps2   :10261501611587141634: pdgid =    22, status =   1, q =  0, e =  14.7, theta =  0.06, phi = -2.61, mass =  0.00
+Made Particle :ps3   :10261489765480136707: pdgid =  2212, status =   1, q =  1, e =   9.3, theta = -0.02, phi =  2.88, mass =  0.94
+Made Particle :ps4   :10261486152290664452: pdgid =    22, status =   1, q =  0, e =   7.8, theta =  1.54, phi = -2.10, mass =  0.00
+Made Particle :ps5   :10261477990403670021: pdgid =   321, status =   1, q =  1, e =   6.0, theta = -0.24, phi = -0.30, mass =  0.49
+Made Particle :ps6   :10261472449851817990: pdgid =  -321, status =   1, q = -1, e =   4.7, theta = -0.20, phi = -0.31, mass =  0.49
+Made Particle :ps7   :10261472347999436807: pdgid =   321, status =   1, q =  1, e =   4.7, theta = -0.20, phi = -0.22, mass =  0.49
+Made Particle :ps8   :10261472030165565448: pdgid =    22, status =   1, q =  0, e =   4.6, theta =  0.11, phi = -2.53, mass =  0.00
+Made Particle :ps9   :10261471666756386825: pdgid = -2212, status =   1, q = -1, e =   4.5, theta =  0.08, phi =  2.94, mass =  0.94
+Made Particle :ps10  :10261471062017441802: pdgid =   130, status =   1, q =  0, e =   4.4, theta =  0.01, phi = -2.54, mass =  0.50
+Made Particle :ps11  :10261469887780093963: pdgid =    22, status =   1, q =  0, e =   4.1, theta = -0.23, phi = -0.05, mass =  0.00
+Made Particle :ps12  :10261468365553926156: pdgid =    22, status =   1, q =  0, e =   3.9, theta =  0.08, phi = -2.61, mass =  0.00
+Made Particle :ps13  :10261464898007465997: pdgid = -2112, status =   1, q =  0, e =   3.5, theta =  0.14, phi =  3.14, mass =  0.94
+Made Particle :ps14  :10261463121797316622: pdgid =  2112, status =   1, q =  0, e =   3.3, theta = -0.03, phi =  2.84, mass =  0.94
+Made Particle :ps15  :10261462541098024975: pdgid =  2212, status =   1, q =  1, e =   3.2, theta =  0.09, phi = -2.92, mass =  0.94
+Made Particle :ps16  :10261462016044564496: pdgid =   211, status =   1, q =  1, e =   3.2, theta = -0.22, phi = -0.19, mass =  0.14
+Made Particle :ps17  :10261461241895583761: pdgid =    22, status =   1, q =  0, e =   3.1, theta =  0.15, phi = -2.51, mass =  0.00
+Made Particle :ps18  :10261460957129605138: pdgid =    13, status =   1, q = -1, e =   3.0, theta =  0.47, phi = -0.01, mass =  0.11
+Made Particle :ps19  :10261460099075670035: pdgid =   130, status =   1, q =  0, e =   2.9, theta = -0.18, phi = -0.20, mass =  0.50
+Made Particle :ps20  :10261459787113824276: pdgid =  -211, status =   1, q = -1, e =   2.9, theta =  0.02, phi = -2.61, mass =  0.14
+Made Particle :ps21  :10261459490517811221: pdgid =  2212, status =   1, q =  1, e =   2.9, theta =  0.24, phi =  2.94, mass =  0.94
+Made Particle :ps22  :10261458961779654678: pdgid =  -211, status =   1, q = -1, e =   2.8, theta = -0.14, phi = -0.18, mass =  0.14
+Made Particle :ps23  :10261458389611577367: pdgid = -2212, status =   1, q = -1, e =   2.8, theta = -0.25, phi =  2.97, mass =  0.94
+Made Particle :ps24  :10261455610841137176: pdgid =  -321, status =   1, q = -1, e =   2.4, theta = -0.01, phi = -2.50, mass =  0.49
+Made Particle :ps25  :10261455452506161177: pdgid =   211, status =   1, q =  1, e =   2.4, theta =  0.10, phi = -2.54, mass =  0.14
+Made Particle :ps26  :10261454020436557850: pdgid =   211, status =   1, q =  1, e =   2.3, theta = -0.06, phi = -0.13, mass =  0.14
+Made Particle :ps27  :10261453441312227355: pdgid =  -211, status =   1, q = -1, e =   2.2, theta = -0.35, phi = -0.09, mass =  0.14
+Made Particle :ps28  :10261453310332502044: pdgid =  -211, status =   1, q = -1, e =   2.2, theta =  0.12, phi =  2.86, mass =  0.14
+Made Particle :ps29  :10261451372803129373: pdgid = -2212, status =   1, q = -1, e =   2.0, theta =  0.49, phi =  0.38, mass =  0.94
+Made Particle :ps30  :10261449469633495070: pdgid =  -211, status =   1, q = -1, e =   1.9, theta = -0.17, phi = -2.46, mass =  0.14
+Made Particle :ps31  :10261448684793233439: pdgid =    22, status =   1, q =  0, e =   1.8, theta =  0.42, phi =  0.43, mass =  0.00
+Made Particle :ps32  :10261446856997339168: pdgid =  2112, status =   1, q =  0, e =   1.7, theta = -0.61, phi =  1.14, mass =  0.94
+Made Particle :ps33  :10261446419634192417: pdgid =   211, status =   1, q =  1, e =   1.7, theta =  0.13, phi = -2.46, mass =  0.14
+Made Particle :ps34  :10261444850387779618: pdgid = -2112, status =   1, q =  0, e =   1.6, theta =  0.46, phi =  0.80, mass =  0.94
+Made Particle :ps35  :10261444364431523875: pdgid =    22, status =   1, q =  0, e =   1.6, theta = -0.23, phi = -0.33, mass =  0.00
+Made Particle :ps36  :10261443453558718500: pdgid =   211, status =   1, q =  1, e =   1.5, theta = -0.32, phi =  0.10, mass =  0.14
+Made Particle :ps37  :10261441850275528741: pdgid =    22, status =   1, q =  0, e =   1.4, theta = -0.21, phi = -0.30, mass =  0.00
+Made Particle :ps38  :10261438191739338790: pdgid =  -211, status =   1, q = -1, e =   1.2, theta = -0.12, phi = -0.37, mass =  0.14
+Made Particle :ps39  :10261437544283504679: pdgid =   211, status =   1, q =  1, e =   1.2, theta =  0.04, phi = -2.63, mass =  0.14
+Made Particle :ps40  :10261436580604411944: pdgid =    22, status =   1, q =  0, e =   1.1, theta =  0.10, phi =  2.98, mass =  0.00
+Made Particle :ps41  :10261435427319709737: pdgid =    22, status =   1, q =  0, e =   1.1, theta = -1.52, phi =  0.54, mass =  0.00
+Made Particle :ps42  :10261429781302083626: pdgid =   211, status =   1, q =  1, e =   0.9, theta =  0.21, phi = -0.16, mass =  0.14
+Made Particle :ps43  :10261429301823930411: pdgid =  -211, status =   1, q = -1, e =   0.9, theta = -0.37, phi =  0.52, mass =  0.14
+Made Particle :ps44  :10261427928822710316: pdgid =    22, status =   1, q =  0, e =   0.8, theta = -0.16, phi = -0.34, mass =  0.00
+Made Particle :ps45  :10261423404196298797: pdgid =  -211, status =   1, q = -1, e =   0.7, theta =  0.06, phi =  2.19, mass =  0.14
+Made Particle :ps46  :10261421026057388078: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.07, phi = -2.45, mass =  0.00
+Made Particle :ps47  :10261420516491395119: pdgid =   211, status =   1, q =  1, e =   0.6, theta =  0.46, phi =  2.19, mass =  0.14
+Made Particle :ps48  :10261412857788760112: pdgid =  -211, status =   1, q = -1, e =   0.4, theta = -0.10, phi = -0.66, mass =  0.14
+Made Particle :ps49  :10261410625703903281: pdgid =  -211, status =   1, q = -1, e =   0.4, theta =  0.34, phi = -2.90, mass =  0.14
+Made Particle :ps50  :10261409580688867378: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.27, phi =  2.88, mass =  0.00
+Made Particle :ps51  :10261406887001980979: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.59, phi =  2.49, mass =  0.00
+Made Particle :ps52  :10261404450606284852: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.05, phi = -0.40, mass =  0.00
+Made Particle :ps53  :10261401228273516597: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.19, phi = -2.44, mass =  0.00
+Made Particle :ps54  :10261400902554353718: pdgid =   211, status =   1, q =  1, e =   0.3, theta = -0.34, phi =  2.18, mass =  0.14
+Made Particle :ps55  :10261398158812643383: pdgid =   211, status =   1, q =  1, e =   0.2, theta =  1.04, phi =  2.42, mass =  0.14
+Made Particle :ps56  :10261391255736942648: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.08, phi =  2.46, mass =  0.00
+Made Particle :ps57  :10261388651267096633: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.58, phi =  0.02, mass =  0.00
+Made Particle :ps58  :10261385607448100922: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.04, phi = -0.14, mass =  0.00
+Made Particle :ps59  :10261377219509092411: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.55, phi = -0.30, mass =  0.00
+Made Particle :ps60  :10261322061202849852: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  0.79, phi = -2.23, mass =  0.00
+Simulating Particle :ps0   :10261534350380105728: pdgid =   -13, status =   1, q =  1, e =  54.2, theta = -0.88, phi =  1.34, mass =  0.11
+Simulating Muon
+Made Track: tt0   :7964698540364529664:   54.25   34.59 -0.88  1.34
+Made SmearedTrack: ts0   :7955691035642822656:   53.69   34.23 -0.88  1.34
+Simulating Particle :ps1   :10261527063680778241: pdgid =    22, status =   1, q =  0, e =  41.0, theta =  1.07, phi = -0.51, mass =  0.00
+Simulating Photon
+Made Cluster: et0   :3353005235294437376:   40.99  1.07 -0.51 sub(et0, )
+Made SmearedCluster: es0   :3343998126076723200:   41.16  1.07 -0.51 sub(es0, )
+Simulating Particle :ps2   :10261501611587141634: pdgid =    22, status =   1, q =  0, e =  14.7, theta =  0.06, phi = -2.61, mass =  0.00
+Simulating Photon
+Made Cluster: et1   :3352979783200800769:   14.67  0.06 -2.61 sub(et1, )
+Made SmearedCluster: es1   :3343973101317652481:   14.91  0.06 -2.61 sub(es1, )
+Simulating Particle :ps3   :10261489765480136707: pdgid =  2212, status =   1, q =  1, e =   9.3, theta = -0.02, phi =  2.88, mass =  0.94
+Simulating Hadron
+Made Track: tt1   :7964653851026391041:    9.24    9.24 -0.02  2.88
+Made SmearedTrack: ts1   :7955646789218992129:    9.30    9.30 -0.02  2.88
+Made Cluster: ht0   :5658810946307489792:    9.29 -0.02  2.76 sub(ht0, )
+Made SmearedCluster: hs0   :5649806123528617984:   10.37 -0.02  2.76 sub(hs0, )
+Simulating Particle :ps4   :10261486152290664452: pdgid =    22, status =   1, q =  0, e =   7.8, theta =  1.54, phi = -2.10, mass =  0.00
+Simulating Photon
+Made Cluster: et2   :3352964323904323586:    7.82  1.54 -2.10 sub(et2, )
+Made SmearedCluster: es2   :3343957301007482882:    7.86  1.54 -2.10 sub(es2, )
+Rejected SmearedCluster: es2   :3343957301007482882:    7.86  1.54 -2.10 sub(es2, )
+Simulating Particle :ps5   :10261477990403670021: pdgid =   321, status =   1, q =  1, e =   6.0, theta = -0.24, phi = -0.30, mass =  0.49
+Simulating Hadron
+Made Track: tt2   :7964642090458021890:    5.95    5.77 -0.24 -0.30
+Made SmearedTrack: ts2   :7955634866280726530:    5.94    5.76 -0.24 -0.30
+Made Cluster: et3   :3352945382159024131:    3.76 -0.25 -0.43 sub(et3, )
+Made SmearedCluster: es2   :3343914087114342402:    1.51 -0.25 -0.43 sub(es2, )
+Made Cluster: ht1   :5658774766715142145:    2.21 -0.25 -0.49 sub(ht1, )
+Made SmearedCluster: hs1   :5647513932722601985:   -3.11 -0.25 -0.49 sub(hs1, )
+Rejected SmearedCluster: hs1   :5647513932722601985:   -3.11 -0.25 -0.49 sub(hs1, )
+Simulating Particle :ps6   :10261472449851817990: pdgid =  -321, status =   1, q = -1, e =   4.7, theta = -0.20, phi = -0.31, mass =  0.49
+Simulating Hadron
+Made Track: tt3   :7964636525700841475:    4.68    4.58 -0.20 -0.31
+Made SmearedTrack: ts3   :7955629336959123459:    4.68    4.59 -0.20 -0.31
+Made Cluster: et4   :3352889735025524740:    0.43 -0.20 -0.15 sub(et4, )
+Made SmearedCluster: es3   :3341670923508908035:   -0.99 -0.20 -0.15 sub(es3, )
+Rejected SmearedCluster: es3   :3341670923508908035:   -0.99 -0.20 -0.15 sub(es3, )
+Made Cluster: ht2   :5658791744353861634:    4.28 -0.21 -0.08 sub(ht2, )
+Made SmearedCluster: hs1   :5649714555385806849:    0.27 -0.21 -0.08 sub(hs1, )
+Rejected SmearedCluster: hs1   :5649714555385806849:    0.27 -0.21 -0.08 sub(hs1, )
+Simulating Particle :ps7   :10261472347999436807: pdgid =   321, status =   1, q =  1, e =   4.7, theta = -0.20, phi = -0.22, mass =  0.49
+Simulating Hadron
+Made Track: tt4   :7964636423280132100:    4.66    4.57 -0.20 -0.22
+Made SmearedTrack: ts4   :7955629105517428740:    4.63    4.54 -0.20 -0.22
+Made Cluster: ht3   :5658793528826789891:    4.68 -0.20 -0.46 sub(ht3, )
+Made SmearedCluster: hs1   :5649787057145380865:    4.85 -0.20 -0.46 sub(hs1, )
+Rejected SmearedCluster: hs1   :5649787057145380865:    4.85 -0.20 -0.46 sub(hs1, )
+Simulating Particle :ps8   :10261472030165565448: pdgid =    22, status =   1, q =  0, e =   4.6, theta =  0.11, phi = -2.53, mass =  0.00
+Simulating Photon
+Made Cluster: et5   :3352950201779224581:    4.61  0.11 -2.53 sub(et5, )
+Made SmearedCluster: es3   :3343943003631779843:    4.61  0.11 -2.53 sub(es3, )
+Simulating Particle :ps9   :10261471666756386825: pdgid = -2212, status =   1, q = -1, e =   4.5, theta =  0.08, phi =  2.94, mass =  0.94
+Simulating Hadron
+Made Track: tt5   :7964635424595378181:    4.43    4.42  0.08  2.94
+Made SmearedTrack: ts5   :7955628380766863365:    4.47    4.45  0.08  2.94
+Rejected SmearedTrack: ts5   :7955628380766863365:    4.47    4.45  0.08  2.94
+Made Cluster: et6   :3352937206697164806:    2.83  0.08  3.10 sub(et6, )
+Made SmearedCluster: es4   :3341670923508908036:   -0.87  0.08  3.10 sub(es4, )
+Rejected SmearedCluster: es4   :3341670923508908036:   -0.87  0.08  3.10 sub(es4, )
+Made Cluster: ht4   :5658767657975939076:    1.70  0.08 -3.10 sub(ht4, )
+Made SmearedCluster: hs1   :5647513932722601985:   -1.88  0.08 -3.10 sub(hs1, )
+Rejected SmearedCluster: hs1   :5647513932722601985:   -1.88  0.08 -3.10 sub(hs1, )
+Simulating Particle :ps10  :10261471062017441802: pdgid =   130, status =   1, q =  0, e =   4.4, theta =  0.01, phi = -2.54, mass =  0.50
+Simulating Hadron
+Made Cluster: et7   :3352931692730908679:    2.20  0.01 -2.54 sub(et7, )
+Made SmearedCluster: es4   :3343912152493719556:    1.40  0.01 -2.54 sub(es4, )
+Made Cluster: ht5   :5658774599370801157:    2.19  0.01 -2.54 sub(ht5, )
+Made SmearedCluster: hs1   :5649787913924247553:    5.04  0.01 -2.54 sub(hs1, )
+Simulating Particle :ps11  :10261469887780093963: pdgid =    22, status =   1, q =  0, e =   4.1, theta = -0.23, phi = -0.05, mass =  0.00
+Simulating Photon
+Made Cluster: et8   :3352948059393753096:    4.12 -0.23 -0.05 sub(et8, )
+Made SmearedCluster: es5   :3343941048326946821:    4.17 -0.23 -0.05 sub(es5, )
+Simulating Particle :ps12  :10261468365553926156: pdgid =    22, status =   1, q =  0, e =   3.9, theta =  0.08, phi = -2.61, mass =  0.00
+Simulating Photon
+Made Cluster: et9   :3352946537167585289:    3.89  0.08 -2.61 sub(et9, )
+Made SmearedCluster: es6   :3343937987957227526:    3.74  0.08 -2.61 sub(es6, )
+Simulating Particle :ps13  :10261464898007465997: pdgid = -2112, status =   1, q =  0, e =   3.5, theta =  0.14, phi =  3.14, mass =  0.94
+Simulating Hadron
+Made Cluster: ht6   :5658786078834819078:    3.49  0.14  3.14 sub(ht6, )
+Made SmearedCluster: hs2   :5647513932722601986:   -2.32  0.14  3.14 sub(hs2, )
+Rejected SmearedCluster: hs2   :5647513932722601986:   -2.32  0.14  3.14 sub(hs2, )
+Simulating Particle :ps14  :10261463121797316622: pdgid =  2112, status =   1, q =  0, e =   3.3, theta = -0.03, phi =  2.84, mass =  0.94
+Simulating Hadron
+Made Cluster: et10  :3352896133690032138:    0.54 -0.03  2.84 sub(et10, )
+Made SmearedCluster: es7   :3341670923508908039:   -2.95 -0.03  2.84 sub(es7, )
+Rejected SmearedCluster: es7   :3341670923508908039:   -2.95 -0.03  2.84 sub(es7, )
+Made Cluster: ht7   :5658779555706437639:    2.75 -0.03  2.84 sub(ht7, )
+Made SmearedCluster: hs2   :5647513932722601986:   -4.48 -0.03  2.84 sub(hs2, )
+Rejected SmearedCluster: hs2   :5647513932722601986:   -4.48 -0.03  2.84 sub(hs2, )
+Simulating Particle :ps15  :10261462541098024975: pdgid =  2212, status =   1, q =  1, e =   3.2, theta =  0.09, phi = -2.92, mass =  0.94
+Simulating Hadron
+Made Track: tt6   :7964625504707805190:    3.09    3.08  0.09 -2.92
+Made SmearedTrack: ts5   :7955618092806045701:    3.06    3.05  0.09 -2.92
+Made Cluster: et11  :3352886900212891659:    0.39  0.09  3.12 sub(et11, )
+Made SmearedCluster: es7   :3343933836598706183:    3.26  0.09  3.12 sub(es7, )
+Made Cluster: ht8   :5658780303628435464:    2.84  0.09  3.00 sub(ht8, )
+Made SmearedCluster: hs2   :5649801706475618306:    8.36  0.09  3.00 sub(hs2, )
+Simulating Particle :ps16  :10261462016044564496: pdgid =   211, status =   1, q =  1, e =   3.2, theta = -0.22, phi = -0.19, mass =  0.14
+Simulating Hadron
+Made Track: tt7   :7964626179019767815:    3.16    3.09 -0.22 -0.19
+Made SmearedTrack: ts6   :7955619528233189382:    3.23    3.15 -0.22 -0.19
+Made Cluster: et12  :3352925877571682316:    1.77 -0.22 -0.43 sub(et12, )
+Made SmearedCluster: es8   :3343929966413742088:    2.82 -0.22 -0.43 sub(es8, )
+Made Cluster: ht9   :5658762322586370057:    1.40 -0.22 -0.55 sub(ht9, )
+Made SmearedCluster: hs3   :5649773415442153475:    2.87 -0.22 -0.55 sub(hs3, )
+Rejected SmearedCluster: hs3   :5649773415442153475:    2.87 -0.22 -0.55 sub(hs3, )
+Simulating Particle :ps17  :10261461241895583761: pdgid =    22, status =   1, q =  0, e =   3.1, theta =  0.15, phi = -2.51, mass =  0.00
+Simulating Photon
+Made Cluster: et13  :3352939413509242893:    3.08  0.15 -2.51 sub(et13, )
+Made SmearedCluster: es9   :3343932385426145289:    3.10  0.15 -2.51 sub(es9, )
+Simulating Particle :ps18  :10261460957129605138: pdgid =    13, status =   1, q = -1, e =   3.0, theta =  0.47, phi = -0.01, mass =  0.11
+Simulating Muon
+Made Track: tt8   :7964625131049844744:    3.04    2.71  0.47 -0.01
+Made SmearedTrack: ts7   :7955618338214772743:    3.09    2.75  0.47 -0.01
+Rejected SmearedTrack: ts7   :7955618338214772743:    3.09    2.75  0.47 -0.01
+Simulating Particle :ps19  :10261460099075670035: pdgid =   130, status =   1, q =  0, e =   2.9, theta = -0.18, phi = -0.20, mass =  0.50
+Simulating Hadron
+Made Cluster: ht10  :5658781279903023114:    2.95 -0.18 -0.20 sub(ht10, )
+Made SmearedCluster: hs3   :5647513932722601987:   -3.14 -0.18 -0.20 sub(hs3, )
+Rejected SmearedCluster: hs3   :5647513932722601987:   -3.14 -0.18 -0.20 sub(hs3, )
+Simulating Particle :ps20  :10261459787113824276: pdgid =  -211, status =   1, q = -1, e =   2.9, theta =  0.02, phi = -2.61, mass =  0.14
+Simulating Hadron
+Made Track: tt9   :7964623947733925897:    2.91    2.91  0.02 -2.61
+Made SmearedTrack: ts7   :7955616663729078279:    2.90    2.90  0.02 -2.61
+Rejected SmearedTrack: ts7   :7955616663729078279:    2.90    2.90  0.02 -2.61
+Made Cluster: et14  :3352912552427257870:    1.01  0.03 -2.44 sub(et14, )
+Made SmearedCluster: es10  :3343931153185767434:    2.96  0.03 -2.44 sub(es10, )
+Made Cluster: ht11  :5658771189869314059:    1.90  0.02 -2.32 sub(ht11, )
+Made SmearedCluster: hs3   :5649780815748399107:    3.71  0.02 -2.32 sub(hs3, )
+Simulating Particle :ps21  :10261459490517811221: pdgid =  2212, status =   1, q =  1, e =   2.9, theta =  0.24, phi =  2.94, mass =  0.94
+Simulating Hadron
+Made Track: tt10  :7964622298416152586:    2.72    2.64  0.24  2.94
+Made SmearedTrack: ts7   :7955614862216790023:    2.70    2.62  0.24  2.94
+Made Cluster: et15  :3352861867006492687:    0.14  0.25  2.65 sub(et15, )
+Made SmearedCluster: es11  :3343907807555485707:    1.15  0.25  2.65 sub(es11, )
+Made Cluster: ht12  :5658779427260071948:    2.74  0.25  2.51 sub(ht12, )
+Made SmearedCluster: hs4   :5649772486500286468:    2.77  0.25  2.51 sub(hs4, )
+Rejected SmearedCluster: hs4   :5649772486500286468:    2.77  0.25  2.51 sub(hs4, )
+Simulating Particle :ps22  :10261458961779654678: pdgid =  -211, status =   1, q = -1, e =   2.8, theta = -0.14, phi = -0.18, mass =  0.14
+Simulating Hadron
+Made Track: tt11  :7964623121418289163:    2.82    2.79 -0.14 -0.18
+Made SmearedTrack: ts8   :7955616190252974088:    2.85    2.82 -0.14 -0.18
+Made Cluster: et16  :3352914901229109264:    1.15 -0.14  0.08 sub(et16, )
+Made SmearedCluster: es12  :3343927612878618636:    2.56 -0.14  0.08 sub(es12, )
+Made Cluster: ht13  :5658767190399123469:    1.67 -0.14  0.21 sub(ht13, )
+Made SmearedCluster: hs4   :5649783576437194756:    4.06 -0.14  0.21 sub(hs4, )
+Simulating Particle :ps23  :10261458389611577367: pdgid = -2212, status =   1, q = -1, e =   2.8, theta = -0.25, phi =  2.97, mass =  0.94
+Simulating Hadron
+Made Track: tt12  :7964621130818387980:    2.59    2.51 -0.25  2.97
+Made SmearedTrack: ts9   :7955614003762298889:    2.60    2.52 -0.25  2.97
+Made Cluster: ht14  :5658779570438930446:    2.75 -0.26 -2.87 sub(ht14, )
+Made SmearedCluster: hs5   :5647513932722601989:   -2.65 -0.26 -2.87 sub(hs5, )
+Rejected SmearedCluster: hs5   :5647513932722601989:   -2.65 -0.26 -2.87 sub(hs5, )
+Simulating Particle :ps24  :10261455610841137176: pdgid =  -321, status =   1, q = -1, e =   2.4, theta = -0.01, phi = -2.50, mass =  0.49
+Simulating Hadron
+Made Track: tt13  :7964619356772499469:    2.39    2.39 -0.01 -2.50
+Made SmearedTrack: ts10  :7955612027867627530:    2.37    2.37 -0.01 -2.50
+Made Cluster: et17  :3352890643616628753:    0.44 -0.01 -2.19 sub(et17, )
+Made SmearedCluster: es13  :3343924498790350861:    2.20 -0.01 -2.19 sub(es13, )
+Made Cluster: ht15  :5658772879100084239:    2.00 -0.02 -2.03 sub(ht15, )
+Made SmearedCluster: hs5   :5649728238017052677:    0.47 -0.02 -2.03 sub(hs5, )
+Rejected SmearedCluster: hs5   :5649728238017052677:    0.47 -0.02 -2.03 sub(hs5, )
+Simulating Particle :ps25  :10261455452506161177: pdgid =   211, status =   1, q =  1, e =   2.4, theta =  0.10, phi = -2.54, mass =  0.14
+Simulating Hadron
+Made Track: tt14  :7964619607128408078:    2.42    2.41  0.10 -2.54
+Made SmearedTrack: ts11  :7955612167328235531:    2.39    2.38  0.10 -2.54
+Made Cluster: ht16  :5658776633333514256:    2.42  0.10 -3.01 sub(ht16, )
+Made SmearedCluster: hs5   :5649753976604721157:    1.33  0.10 -3.01 sub(hs5, )
+Simulating Particle :ps26  :10261454020436557850: pdgid =   211, status =   1, q =  1, e =   2.3, theta = -0.06, phi = -0.13, mass =  0.14
+Simulating Hadron
+Made Track: tt15  :7964618172498182159:    2.25    2.25 -0.06 -0.13
+Made SmearedTrack: ts12  :7955610804236058636:    2.23    2.23 -0.06 -0.13
+Made Cluster: et18  :3352901642019143698:    0.70 -0.06 -0.46 sub(et18, )
+Made SmearedCluster: es14  :3341670923508908046:   -4.15 -0.06 -0.46 sub(es14, )
+Rejected SmearedCluster: es14  :3341670923508908046:   -4.15 -0.06 -0.46 sub(es14, )
+Made Cluster: ht17  :5658765222733676561:    1.56 -0.07 -0.63 sub(ht17, )
+Made SmearedCluster: hs6   :5649765330409488390:    1.98 -0.07 -0.63 sub(hs6, )
+Rejected SmearedCluster: hs6   :5649765330409488390:    1.98 -0.07 -0.63 sub(hs6, )
+Simulating Particle :ps27  :10261453441312227355: pdgid =  -211, status =   1, q = -1, e =   2.2, theta = -0.35, phi = -0.09, mass =  0.14
+Simulating Hadron
+Made Track: tt16  :7964617592233000976:    2.19    2.06 -0.35 -0.09
+Made SmearedTrack: ts13  :7955610444532547597:    2.19    2.06 -0.35 -0.09
+Made Cluster: et19  :3352905174497624083:    0.80 -0.36  0.28 sub(et19, )
+Made SmearedCluster: es14  :3341670923508908046:   -4.29 -0.36  0.28 sub(es14, )
+Rejected SmearedCluster: es14  :3341670923508908046:   -4.29 -0.36  0.28 sub(es14, )
+Made Cluster: ht18  :5658762298248921106:    1.40 -0.37  0.46 sub(ht18, )
+Made SmearedCluster: hs6   :5649779528996749318:    3.57 -0.37  0.46 sub(hs6, )
+Simulating Particle :ps28  :10261453310332502044: pdgid =  -211, status =   1, q = -1, e =   2.2, theta =  0.12, phi =  2.86, mass =  0.14
+Simulating Hadron
+Made Track: tt17  :7964617460984840209:    2.17    2.16  0.12  2.86
+Made SmearedTrack: ts14  :7955609983112970254:    2.14    2.12  0.12  2.86
+Made Cluster: et20  :3352889282898427924:    0.42  0.13 -3.07 sub(et20, )
+Made SmearedCluster: es14  :3341670923508908046:   -1.10  0.13 -3.07 sub(es14, )
+Rejected SmearedCluster: es14  :3341670923508908046:   -1.10  0.13 -3.07 sub(es14, )
+Made Cluster: ht19  :5658768618263937043:    1.75  0.13 -2.90 sub(ht19, )
+Made SmearedCluster: hs7   :5647513932722601991:   -6.40  0.13 -2.90 sub(hs7, )
+Rejected SmearedCluster: hs7   :5647513932722601991:   -6.40  0.13 -2.90 sub(hs7, )
+Simulating Particle :ps29  :10261451372803129373: pdgid = -2212, status =   1, q = -1, e =   2.0, theta =  0.49, phi =  0.38, mass =  0.94
+Simulating Hadron
+Made Track: tt18  :7964611400018427922:    1.74    1.54  0.49  0.38
+Made SmearedTrack: ts15  :7955603992185143311:    1.73    1.53  0.49  0.38
+Made Cluster: et21  :3352901241695895573:    0.68  0.50  0.88 sub(et21, )
+Made SmearedCluster: es14  :3343911124417380366:    1.34  0.50  0.88 sub(es14, )
+Made Cluster: ht20  :5658760505792135188:    1.29  0.53  1.16 sub(ht20, )
+Made SmearedCluster: hs7   :5649780101380833287:    3.63  0.53  1.16 sub(hs7, )
+Simulating Particle :ps30  :10261449469633495070: pdgid =  -211, status =   1, q = -1, e =   1.9, theta = -0.17, phi = -2.46, mass =  0.14
+Simulating Hadron
+Made Track: tt19  :7964613567934627859:    1.87    1.84 -0.17 -2.46
+Made SmearedTrack: ts16  :7955606251260346384:    1.86    1.83 -0.17 -2.46
+Made Cluster: et22  :3352877086848057366:    0.25 -0.17 -2.05 sub(et22, )
+Made SmearedCluster: es15  :3341670923508908047:   -1.31 -0.17 -2.05 sub(es15, )
+Rejected SmearedCluster: es15  :3341670923508908047:   -1.31 -0.17 -2.05 sub(es15, )
+Made Cluster: ht21  :5658766259810992149:    1.62 -0.18 -1.84 sub(ht21, )
+Made SmearedCluster: hs8   :5647513932722601992:   -4.65 -0.18 -1.84 sub(hs8, )
+Rejected SmearedCluster: hs8   :5647513932722601992:   -4.65 -0.18 -1.84 sub(hs8, )
+Simulating Particle :ps31  :10261448684793233439: pdgid =    22, status =   1, q =  0, e =   1.8, theta =  0.42, phi =  0.43, mass =  0.00
+Simulating Photon
+Made Cluster: et23  :3352926856406892567:    1.83  0.42  0.43 sub(et23, )
+Made SmearedCluster: es15  :3343919395031220239:    1.81  0.42  0.43 sub(es15, )
+Simulating Particle :ps32  :10261446856997339168: pdgid =  2112, status =   1, q =  0, e =   1.7, theta = -0.61, phi =  1.14, mass =  0.94
+Simulating Hadron
+Made Cluster: et24  :3352842966671556632:    0.07 -0.61  1.14 sub(et24, )
+Made SmearedCluster: es16  :3341670923508908048:   -2.31 -0.61  1.14 sub(es16, )
+Rejected SmearedCluster: es16  :3341670923508908048:   -2.31 -0.61  1.14 sub(es16, )
+Made Cluster: ht22  :5658766875499167766:    1.66 -0.61  1.14 sub(ht22, )
+Made SmearedCluster: hs8   :5649749744797351944:    1.09 -0.61  1.14 sub(hs8, )
+Simulating Particle :ps33  :10261446419634192417: pdgid =   211, status =   1, q =  1, e =   1.7, theta =  0.13, phi = -2.46, mass =  0.14
+Simulating Hadron
+Made Track: tt20  :7964610508531695636:    1.69    1.68  0.13 -2.46
+Made SmearedTrack: ts17  :7955603537891688465:    1.70    1.69  0.13 -2.46
+Made Cluster: ht23  :5658767600461545495:    1.70  0.13 -2.98 sub(ht23, )
+Made SmearedCluster: hs9   :5647513932722601993:   -2.94  0.13 -2.98 sub(hs9, )
+Rejected SmearedCluster: hs9   :5647513932722601993:   -2.94  0.13 -2.98 sub(hs9, )
+Simulating Particle :ps34  :10261444850387779618: pdgid = -2112, status =   1, q =  0, e =   1.6, theta =  0.46, phi =  0.80, mass =  0.94
+Simulating Hadron
+Made Cluster: ht24  :5658766031215132696:    1.61  0.46  0.80 sub(ht24, )
+Made SmearedCluster: hs9   :5647513932722601993:   -2.32  0.46  0.80 sub(hs9, )
+Rejected SmearedCluster: hs9   :5647513932722601993:   -2.32  0.46  0.80 sub(hs9, )
+Simulating Particle :ps35  :10261444364431523875: pdgid =    22, status =   1, q =  0, e =   1.6, theta = -0.23, phi = -0.33, mass =  0.00
+Simulating Photon
+Made Cluster: et25  :3352922536045183001:    1.58 -0.23 -0.33 sub(et25, )
+Made SmearedCluster: es16  :3343914141929701392:    1.51 -0.23 -0.33 sub(es16, )
+Simulating Particle :ps36  :10261443453558718500: pdgid =   211, status =   1, q =  1, e =   1.5, theta = -0.32, phi =  0.10, mass =  0.14
+Simulating Hadron
+Made Track: tt21  :7964607531253235733:    1.52    1.44 -0.32  0.10
+Made SmearedTrack: ts18  :7955600116646150162:    1.51    1.43 -0.32  0.10
+Made Cluster: et26  :3352905304036605978:    0.80 -0.34 -0.44 sub(et26, )
+Made SmearedCluster: es17  :3343909926155059217:    1.27 -0.34 -0.44 sub(es17, )
+Made Cluster: ht25  :5658745771147657241:    0.73 -0.36 -0.75 sub(ht25, )
+Made SmearedCluster: hs9   :5647513932722601993:   -0.19 -0.36 -0.75 sub(hs9, )
+Rejected SmearedCluster: hs9   :5647513932722601993:   -0.19 -0.36 -0.75 sub(hs9, )
+Simulating Particle :ps37  :10261441850275528741: pdgid =    22, status =   1, q =  0, e =   1.4, theta = -0.21, phi = -0.30, mass =  0.00
+Simulating Photon
+Made Cluster: et27  :3352920021889187867:    1.44 -0.21 -0.30 sub(et27, )
+Made SmearedCluster: es18  :3343914784069255186:    1.55 -0.21 -0.30 sub(es18, )
+Simulating Particle :ps38  :10261438191739338790: pdgid =  -211, status =   1, q = -1, e =   1.2, theta = -0.12, phi = -0.37, mass =  0.14
+Simulating Hadron
+Made Track: tt22  :7964602241935998998:    1.22    1.21 -0.12 -0.37
+Made SmearedTrack: ts19  :7955594706551832595:    1.20    1.19 -0.12 -0.37
+Made Cluster: et28  :3352882788865933340:    0.33 -0.12  0.28 sub(et28, )
+Made SmearedCluster: es19  :3343927026986778643:    2.49 -0.12  0.28 sub(es19, )
+Made Cluster: ht26  :5658751788010962970:    0.90 -0.14  0.72 sub(ht26, )
+Made SmearedCluster: hs9   :5647513932722601993:   -4.45 -0.14  0.72 sub(hs9, )
+Rejected SmearedCluster: hs9   :5647513932722601993:   -4.45 -0.14  0.72 sub(hs9, )
+Simulating Particle :ps39  :10261437544283504679: pdgid =   211, status =   1, q =  1, e =   1.2, theta =  0.04, phi = -2.63, mass =  0.14
+Simulating Hadron
+Made Track: tt23  :7964601590134865943:    1.18    1.18  0.04 -2.63
+Made SmearedTrack: ts20  :7955594298397818900:    1.18    1.18  0.04 -2.63
+Made Cluster: et29  :3352895587704897565:    0.52  0.04  2.97 sub(et29, )
+Made SmearedCluster: es20  :3341670923508908052:   -0.87  0.04  2.97 sub(es20, )
+Rejected SmearedCluster: es20  :3341670923508908052:   -0.87  0.04  2.97 sub(es20, )
+Made Cluster: ht27  :5658743668928938011:    0.67  0.05  2.49 sub(ht27, )
+Made SmearedCluster: hs9   :5647513932722601993:   -0.82  0.05  2.49 sub(hs9, )
+Rejected SmearedCluster: hs9   :5647513932722601993:   -0.82  0.05  2.49 sub(hs9, )
+Simulating Particle :ps40  :10261436580604411944: pdgid =    22, status =   1, q =  0, e =   1.1, theta =  0.10, phi =  2.98, mass =  0.00
+Simulating Photon
+Made Cluster: et30  :3352914752218071070:    1.14  0.10  2.98 sub(et30, )
+Made SmearedCluster: es20  :3343914664219115540:    1.54  0.10  2.98 sub(es20, )
+Simulating Particle :ps41  :10261435427319709737: pdgid =    22, status =   1, q =  0, e =   1.1, theta = -1.52, phi =  0.54, mass =  0.00
+Simulating Photon
+Made Cluster: et31  :3352913598933368863:    1.07 -1.52  0.54 sub(et31, )
+Made SmearedCluster: es21  :3343903595798986773:    0.96 -1.52  0.54 sub(es21, )
+Rejected SmearedCluster: es21  :3343903595798986773:    0.96 -1.52  0.54 sub(es21, )
+Simulating Particle :ps42  :10261429781302083626: pdgid =   211, status =   1, q =  1, e =   0.9, theta =  0.21, phi = -0.16, mass =  0.14
+Simulating Hadron
+Made Track: tt24  :7964593577437167640:    0.86    0.85  0.21 -0.16
+Made SmearedTrack: ts21  :7955585776914268181:    0.85    0.83  0.21 -0.16
+Made Cluster: et32  :3352888773221285920:    0.42  0.26 -1.23 sub(et32, )
+Made SmearedCluster: es21  :3341670923508908053:   -1.19  0.26 -1.23 sub(es21, )
+Rejected SmearedCluster: es21  :3341670923508908053:   -1.19  0.26 -1.23 sub(es21, )
+Made Cluster: ht28  :5658734957451804700:    0.46  1.07 -2.03 sub(ht28, )
+Made SmearedCluster: hs9   :5647513932722601993:  -10.80  1.07 -2.03 sub(hs9, )
+Rejected SmearedCluster: hs9   :5647513932722601993:  -10.80  1.07 -2.03 sub(hs9, )
+Simulating Particle :ps43  :10261429301823930411: pdgid =  -211, status =   1, q = -1, e =   0.9, theta = -0.37, phi =  0.52, mass =  0.14
+Simulating Hadron
+Made Track: tt25  :7964593091650781209:    0.85    0.79 -0.37  0.52
+Made SmearedTrack: ts22  :7955585819870232598:    0.85    0.79 -0.37  0.52
+Made Cluster: et33  :3352886684459991073:    0.39 -0.46  1.72 sub(et33, )
+Made SmearedCluster: es21  :3341670923508908053:   -3.07 -0.46  1.72 sub(es21, )
+Rejected SmearedCluster: es21  :3341670923508908053:   -3.07 -0.46  1.72 sub(es21, )
+Made Cluster: ht29  :5658736087256793117:    0.48 -1.08  2.24 sub(ht29, )
+Made SmearedCluster: hs9   :5649782178953822217:    3.87 -1.08  2.24 sub(hs9, )
+Simulating Particle :ps44  :10261427928822710316: pdgid =    22, status =   1, q =  0, e =   0.8, theta = -0.16, phi = -0.34, mass =  0.00
+Simulating Photon
+Made Cluster: et34  :3352906100436369442:    0.82 -0.16 -0.34 sub(et34, )
+Made SmearedCluster: es21  :3343900592033497109:    0.87 -0.16 -0.34 sub(es21, )
+Simulating Particle :ps45  :10261423404196298797: pdgid =  -211, status =   1, q = -1, e =   0.7, theta =  0.06, phi =  2.19, mass =  0.14
+Simulating Hadron
+Made Track: tt26  :7964587095595417626:    0.68    0.68  0.06  2.19
+Made SmearedTrack: ts23  :7955579945223192599:    0.68    0.68  0.06  2.19
+Made Cluster: et35  :3352892951079419939:    0.47  1.22  2.84 sub(et35, )
+Made SmearedCluster: es22  :3341670923508908054:   -5.71  1.22  2.84 sub(es22, )
+Rejected SmearedCluster: es22  :3341670923508908054:   -5.71  1.22  2.84 sub(es22, )
+Made Cluster: ht30  :5658715895535501342:    0.22  1.53 -1.04 sub(ht30, )
+Made SmearedCluster: hs10  :5649786532360355850:    4.73  1.53 -1.04 sub(hs10, )
+Rejected SmearedCluster: hs10  :5649786532360355850:    4.73  1.53 -1.04 sub(hs10, )
+Simulating Particle :ps46  :10261421026057388078: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.07, phi = -2.45, mass =  0.00
+Simulating Photon
+Made Cluster: et36  :3352899197671047204:    0.63  0.07 -2.45 sub(et36, )
+Made SmearedCluster: es22  :3343895820626821142:    0.74  0.07 -2.45 sub(es22, )
+Simulating Particle :ps47  :10261420516491395119: pdgid =   211, status =   1, q =  1, e =   0.6, theta =  0.46, phi =  2.19, mass =  0.14
+Simulating Hadron
+Made Track: tt27  :7964584139351392283:    0.60    0.54  0.46  2.19
+Made SmearedTrack: ts24  :7955576344725684248:    0.58    0.52  0.46  2.19
+Made Cluster: ht31  :5658741697318748191:    0.61  1.36 -0.30 sub(ht31, )
+Made SmearedCluster: hs10  :5649777246217437194:    3.31  1.36 -0.30 sub(hs10, )
+Simulating Particle :ps48  :10261412857788760112: pdgid =  -211, status =   1, q = -1, e =   0.4, theta = -0.10, phi = -0.66, mass =  0.14
+Simulating Hadron
+Made Track: tt28  :7964575476312178716:    0.42    0.42 -0.10 -0.66
+Made SmearedTrack: ts25  :7955568765748379673:    0.43    0.43 -0.10 -0.66
+Rejected SmearedTrack: ts25  :7955568765748379673:    0.43    0.43 -0.10 -0.66
+Made Cluster: et37  :3352879865234718757:    0.29 -1.31  1.66 sub(et37, )
+Made SmearedCluster: es23  :3343947580194160663:    5.65 -1.31  1.66 sub(es23, )
+Made Cluster: ht32  :5658707299196207136:    0.16 -1.31  0.49 sub(ht32, )
+Made SmearedCluster: hs11  :5647513932722601995:   -8.66 -1.31  0.49 sub(hs11, )
+Rejected SmearedCluster: hs11  :5647513932722601995:   -8.66 -1.31  0.49 sub(hs11, )
+Simulating Particle :ps49  :10261410625703903281: pdgid =  -211, status =   1, q = -1, e =   0.4, theta =  0.34, phi = -2.90, mass =  0.14
+Simulating Hadron
+Made Track: tt29  :7964573117171367965:    0.39    0.37  0.34 -2.90
+Made SmearedTrack: ts25  :7955565733279170585:    0.39    0.37  0.34 -2.90
+Rejected SmearedTrack: ts25  :7955565733279170585:    0.39    0.37  0.34 -2.90
+Made Cluster: et38  :3352828678118572070:    0.04  1.34 -0.57 sub(et38, )
+Made SmearedCluster: es24  :3343953640715976728:    7.03  1.34 -0.57 sub(es24, )
+Made Cluster: ht33  :5658729068925812769:    0.38  1.33 -1.13 sub(ht33, )
+Made SmearedCluster: hs11  :5647513932722601995:   -5.30  1.33 -1.13 sub(hs11, )
+Rejected SmearedCluster: hs11  :5647513932722601995:   -5.30  1.33 -1.13 sub(hs11, )
+Simulating Particle :ps50  :10261409580688867378: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.27, phi =  2.88, mass =  0.00
+Simulating Photon
+Made Cluster: et39  :3352887752302526503:    0.40  0.27  2.88 sub(et39, )
+Made SmearedCluster: es25  :3343880471074308121:    0.40  0.27  2.88 sub(es25, )
+Simulating Particle :ps51  :10261406887001980979: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.59, phi =  2.49, mass =  0.00
+Simulating Photon
+Made Cluster: et40  :3352885058615640104:    0.36  0.59  2.49 sub(et40, )
+Made SmearedCluster: es26  :3343882565424513050:    0.43  0.59  2.49 sub(es26, )
+Simulating Particle :ps52  :10261404450606284852: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.05, phi = -0.40, mass =  0.00
+Simulating Photon
+Made Cluster: et41  :3352882622219943977:    0.33 -0.05 -0.40 sub(et41, )
+Made SmearedCluster: es27  :3343885469812260891:    0.47 -0.05 -0.40 sub(es27, )
+Simulating Particle :ps53  :10261401228273516597: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.19, phi = -2.44, mass =  0.00
+Simulating Photon
+Made Cluster: et42  :3352879399887175722:    0.28  0.18 -2.44 sub(et42, )
+Made SmearedCluster: es28  :3343860115395575836:    0.18  0.18 -2.44 sub(es28, )
+Rejected SmearedCluster: es28  :3343860115395575836:    0.18  0.18 -2.44 sub(es28, )
+Simulating Particle :ps54  :10261400902554353718: pdgid =   211, status =   1, q =  1, e =   0.3, theta = -0.34, phi =  2.18, mass =  0.14
+Simulating Hadron
+Made Track: tt30  :7964561719326408734:    0.24    0.23 -0.34  2.18
+Made SmearedTrack: ts25  :7955553784323637273:    0.23    0.22 -0.34  2.18
+Rejected SmearedTrack: ts25  :7955553784323637273:    0.23    0.22 -0.34  2.18
+Made Cluster: et43  :3352868910293581867:    0.19 -1.38  0.44 sub(et43, )
+Made SmearedCluster: es28  :3341670923508908060:   -1.74 -1.38  0.44 sub(es28, )
+Rejected SmearedCluster: es28  :3341670923508908060:   -1.74 -1.38  0.44 sub(es28, )
+Made Cluster: ht34  :5658691562723344418:    0.09 -1.53 -0.72 sub(ht34, )
+Made SmearedCluster: hs11  :5647513932722601995:   -5.83 -1.53 -0.72 sub(hs11, )
+Rejected SmearedCluster: hs11  :5647513932722601995:   -5.83 -1.53 -0.72 sub(hs11, )
+Simulating Particle :ps56  :10261391255736942648: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.08, phi =  2.46, mass =  0.00
+Simulating Photon
+Made Cluster: et44  :3352869427350601772:    0.20  0.08  2.46 sub(et44, )
+Made SmearedCluster: es28  :3343874428648816668:    0.31  0.08  2.46 sub(es28, )
+Simulating Particle :ps57  :10261388651267096633: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.58, phi =  0.02, mass =  0.00
+Simulating Photon
+Made Cluster: et45  :3352866822880755757:    0.18  0.58  0.02 sub(et45, )
+Made SmearedCluster: es29  :3343861490066128925:    0.19  0.58  0.02 sub(es29, )
+Rejected SmearedCluster: es29  :3343861490066128925:    0.19  0.58  0.02 sub(es29, )
+Simulating Particle :ps58  :10261385607448100922: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.04, phi = -0.14, mass =  0.00
+Simulating Photon
+Made Cluster: et46  :3352863779061760046:    0.16  0.04 -0.14 sub(et46, )
+Made SmearedCluster: es29  :3343861238433054749:    0.19  0.04 -0.14 sub(es29, )
+Rejected SmearedCluster: es29  :3343861238433054749:    0.19  0.04 -0.14 sub(es29, )
+Simulating Particle :ps59  :10261377219509092411: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.55, phi = -0.30, mass =  0.00
+Simulating Photon
+Made Cluster: et47  :3352855391122751535:    0.11 -0.55 -0.30 sub(et47, )
+Made SmearedCluster: es29  :3343812649119907869:    0.03 -0.55 -0.30 sub(es29, )
+Rejected SmearedCluster: es29  :3343812649119907869:    0.03 -0.55 -0.30 sub(es29, )
+Simulating Particle :ps60  :10261322061202849852: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  0.79, phi = -2.23, mass =  0.00
+Simulating Photon
+Made Cluster: et48  :3352800232816508976:    0.01  0.79 -2.23 sub(et48, )
+Made SmearedCluster: es29  :3341670923508908061:   -0.33  0.79 -2.23 sub(es29, )
+Rejected SmearedCluster: es29  :3341670923508908061:   -0.33  0.79 -2.23 sub(es29, )
+Made MergedCluster: em0   :3289831233120370688:    0.31  0.08  2.46 sub(es28, )
+Made MergedCluster: em1   :3289837275545862145:    0.40  0.27  2.88 sub(es25, )
+Made MergedCluster: em2   :3289839369896067074:    0.43  0.59  2.49 sub(es26, )
+Made MergedCluster: em3   :3289842274283814915:    0.47 -0.05 -0.40 sub(es27, )
+Made MergedCluster: em4   :3289901926438666244:    5.09  0.03 -2.47 sub(es10, es4, es22, )
+Made MergedCluster: em5   :3289857396505051141:    0.87 -0.16 -0.34 sub(es21, )
+Made MergedCluster: em6   :3289864612027039750:    1.15  0.25  2.65 sub(es11, )
+Made MergedCluster: em7   :3289904179274842119:    5.61 -0.25 -0.43 sub(es8, es2, es17, )
+Made MergedCluster: em8   :3289867928888934408:    1.34  0.50  0.88 sub(es14, )
+Made MergedCluster: em9   :3289888859657076745:    3.06 -0.22 -0.32 sub(es18, es16, )
+Made MergedCluster: em10  :3289871468690669578:    1.54  0.10  2.98 sub(es20, )
+Made MergedCluster: em11  :3289876199502774283:    1.81  0.42  0.43 sub(es15, )
+Made MergedCluster: em12  :3289881303261904908:    2.20 -0.01 -2.19 sub(es13, )
+Made MergedCluster: em13  :3289883831458332685:    2.49 -0.12  0.28 sub(es19, )
+Made MergedCluster: em14  :3289884417350172686:    2.56 -0.14  0.08 sub(es12, )
+Made MergedCluster: em15  :3289913435248132111:    7.71  0.12 -2.52 sub(es3, es9, )
+Made MergedCluster: em16  :3289890641070260240:    3.26  0.09  3.12 sub(es7, )
+Made MergedCluster: em17  :3289935212173066257:   18.64  0.07 -2.61 sub(es1, es6, )
+Made MergedCluster: em18  :3289897852798500882:    4.17 -0.23 -0.05 sub(es5, )
+Made MergedCluster: em19  :3289904384665714707:    5.65 -1.31  1.66 sub(es23, )
+Made MergedCluster: em20  :3289910445187530772:    7.03  1.34 -0.57 sub(es24, )
+Made MergedCluster: em21  :3289954930548277269:   41.16  1.07 -0.51 sub(es0, )
+Made MergedCluster: hm0   :5595706549268905984:    1.09 -0.61  1.14 sub(hs8, )
+Made MergedCluster: hm1   :5595710781076275201:    1.33  0.10 -3.01 sub(hs5, )
+Made MergedCluster: hm2   :5595734050688991234:    3.31  1.36 -0.30 sub(hs10, )
+Made MergedCluster: hm3   :5595736333468303363:    3.57 -0.37  0.46 sub(hs6, )
+Made MergedCluster: hm4   :5595736905852387332:    3.63  0.53  1.16 sub(hs7, )
+Made MergedCluster: hm5   :5595737620219953157:    3.71  0.02 -2.32 sub(hs3, )
+Made MergedCluster: hm6   :5595738983425376262:    3.87 -1.08  2.24 sub(hs9, )
+Made MergedCluster: hm7   :5595740380908748807:    4.06 -0.14  0.21 sub(hs4, )
+Made MergedCluster: hm8   :5595744718395801608:    5.04  0.01 -2.54 sub(hs1, )
+Made MergedCluster: hm9   :5595758510947172361:    8.36  0.09  3.00 sub(hs2, )
+Made MergedCluster: hm10  :5595762928000172042:   10.37 -0.02  2.76 sub(hs0, )
+Made block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289831233120370688)
+
+Made block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.4 (3289837275545862145)
+
+Made block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.4 (3289839369896067074)
+
+Made block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.5 (3289842274283814915)
+
+Made block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.9 (3289857396505051141)
+
+Made block:E1T1     :br5   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts7       value=  2.7 (7955614862216790023)
+      e1 = em6       value=  1.2 (3289864612027039750)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1H1T1   :br6   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts15      value=  1.7 (7955603992185143311)
+      h1 = hm4       value=  3.6 (5595736905852387332)
+      e2 = em8       value=  1.3 (3289867928888934408)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  1.5 (3289871468690669578)
+
+Made block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.8 (3289876199502774283)
+
+Made block:E1T1     :br9   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  2.4 (7955612027867627530)
+      e1 = em12      value=  2.2 (3289881303261904908)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :br10  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts19      value=  1.2 (7955594706551832595)
+      e1 = em13      value=  2.5 (3289883831458332685)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1H1T1   :br11  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts8       value=  2.8 (7955616190252974088)
+      h1 = hm7       value=  4.1 (5595740380908748807)
+      e2 = em14      value=  2.6 (3289884417350172686)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  3.1 (3289888859657076745)
+
+Made block:E1H1T1   :br13  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  3.1 (7955618092806045701)
+      h1 = hm9       value=  8.4 (5595758510947172361)
+      e2 = em16      value=  3.3 (3289890641070260240)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em18      value=  4.2 (3289897852798500882)
+
+Made block:E1       :br15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  5.1 (3289901926438666244)
+
+Made block:E1T3     :br16  : ecals = 1 hcals = 0 tracks = 3
+    elements:
+      t0 = ts2       value=  5.9 (7955634866280726530)
+      t1 = ts6       value=  3.2 (7955619528233189382)
+      t2 = ts18      value=  1.5 (7955600116646150162)
+      e3 = em7       value=  5.6 (3289904179274842119)
+    distances:
+              t0      t1      t2      e3
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      e3  0.0000  0.0000  0.0000       .
+
+Made block:E1       :br17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  5.7 (3289904384665714707)
+
+Made block:E1       :br18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em20      value=  7.0 (3289910445187530772)
+
+Made block:E1       :br19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  7.7 (3289913435248132111)
+
+Made block:E1       :br20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value= 18.6 (3289935212173066257)
+
+Made block:E1       :br21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value= 41.2 (3289954930548277269)
+
+Made block:H1       :br22  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm0       value=  1.1 (5595706549268905984)
+
+Made block:H1T2     :br23  : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts11      value=  2.4 (7955612167328235531)
+      t1 = ts17      value=  1.7 (7955603537891688465)
+      h2 = hm1       value=  1.3 (5595710781076275201)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0677       .
+
+Made block:H1T1     :br24  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts24      value=  0.6 (7955576344725684248)
+      h1 = hm2       value=  3.3 (5595734050688991234)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br25  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  2.2 (7955610444532547597)
+      h1 = hm3       value=  3.6 (5595736333468303363)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1       :br26  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  3.7 (5595737620219953157)
+
+Made block:H1T1     :br27  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts22      value=  0.8 (7955585819870232598)
+      h1 = hm6       value=  3.9 (5595738983425376262)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1       :br28  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm8       value=  5.0 (5595744718395801608)
+
+Made block:H1T1     :br29  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts1       value=  9.3 (7955646789218992129)
+      h1 = hm10      value= 10.4 (5595762928000172042)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:T1       :br30  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts23      value=  0.7 (7955579945223192599)
+
+Made block:T1       :br31  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts21      value=  0.8 (7955585776914268181)
+
+Made block:T1       :br32  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts20      value=  1.2 (7955594298397818900)
+
+Made block:T1       :br33  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  1.9 (7955606251260346384)
+
+Made block:T1       :br34  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  2.1 (7955609983112970254)
+
+Made block:T1       :br35  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  2.2 (7955610804236058636)
+
+Made block:T1       :br36  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  2.6 (7955614003762298889)
+
+Made block:T1       :br37  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts4       value=  4.6 (7955629105517428740)
+
+Made block:T1       :br38  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts3       value=  4.7 (7955629336959123459)
+
+Made block:T1       :br39  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 53.7 (7955691035642822656)
+
+Splitting block:E1T3     :br16  : ecals = 1 hcals = 0 tracks = 3
+    elements:
+      t0 = ts2       value=  5.9 (7955634866280726530)
+      t1 = ts6       value=  3.2 (7955619528233189382)
+      t2 = ts18      value=  1.5 (7955600116646150162)
+      e3 = em7       value=  5.6 (3289904179274842119)
+    distances:
+              t0      t1      t2      e3
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      e3  0.0000  0.0000  0.0000       .
+
+Made block:E1T3     :bs0   : ecals = 1 hcals = 0 tracks = 3
+    elements:
+      t0 = ts2       value=  5.9 (7955634866280726530)
+      t1 = ts6       value=  3.2 (7955619528233189382)
+      t2 = ts18      value=  1.5 (7955600116646150162)
+      e3 = em7       value=  5.6 (3289904179274842119)
+    distances:
+              t0      t1      t2      e3
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      e3  0.0000  0.0000  0.0000       .
+
+Splitting block:H1T2     :br23  : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts11      value=  2.4 (7955612167328235531)
+      t1 = ts17      value=  1.7 (7955603537891688465)
+      h2 = hm1       value=  1.3 (5595710781076275201)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0677       .
+
+Made block:H1T2     :bs1   : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts11      value=  2.4 (7955612167328235531)
+      t1 = ts17      value=  1.7 (7955603537891688465)
+      h2 = hm1       value=  1.3 (5595710781076275201)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0677       .
+
+Splitting block:E1H1T1   :br13  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  3.1 (7955618092806045701)
+      h1 = hm9       value=  8.4 (5595758510947172361)
+      e2 = em16      value=  3.3 (3289890641070260240)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  3.1 (7955618092806045701)
+      h1 = hm9       value=  8.4 (5595758510947172361)
+      e2 = em16      value=  3.3 (3289890641070260240)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:E1H1T1   :br11  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts8       value=  2.8 (7955616190252974088)
+      h1 = hm7       value=  4.1 (5595740380908748807)
+      e2 = em14      value=  2.6 (3289884417350172686)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs3   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts8       value=  2.8 (7955616190252974088)
+      h1 = hm7       value=  4.1 (5595740380908748807)
+      e2 = em14      value=  2.6 (3289884417350172686)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:E1H1T1   :br6   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts15      value=  1.7 (7955603992185143311)
+      h1 = hm4       value=  3.6 (5595736905852387332)
+      e2 = em8       value=  1.3 (3289867928888934408)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs4   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts15      value=  1.7 (7955603992185143311)
+      h1 = hm4       value=  3.6 (5595736905852387332)
+      e2 = em8       value=  1.3 (3289867928888934408)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:H1T1     :br29  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts1       value=  9.3 (7955646789218992129)
+      h1 = hm10      value= 10.4 (5595762928000172042)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs5   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts1       value=  9.3 (7955646789218992129)
+      h1 = hm10      value= 10.4 (5595762928000172042)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br27  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts22      value=  0.8 (7955585819870232598)
+      h1 = hm6       value=  3.9 (5595738983425376262)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs6   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts22      value=  0.8 (7955585819870232598)
+      h1 = hm6       value=  3.9 (5595738983425376262)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br25  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  2.2 (7955610444532547597)
+      h1 = hm3       value=  3.6 (5595736333468303363)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs7   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  2.2 (7955610444532547597)
+      h1 = hm3       value=  3.6 (5595736333468303363)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br24  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts24      value=  0.6 (7955576344725684248)
+      h1 = hm2       value=  3.3 (5595734050688991234)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs8   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts24      value=  0.6 (7955576344725684248)
+      h1 = hm2       value=  3.3 (5595734050688991234)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:E1T1     :br10  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts19      value=  1.2 (7955594706551832595)
+      e1 = em13      value=  2.5 (3289883831458332685)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs9   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts19      value=  1.2 (7955594706551832595)
+      e1 = em13      value=  2.5 (3289883831458332685)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br9   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  2.4 (7955612027867627530)
+      e1 = em12      value=  2.2 (3289881303261904908)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs10  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  2.4 (7955612027867627530)
+      e1 = em12      value=  2.2 (3289881303261904908)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br5   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts7       value=  2.7 (7955614862216790023)
+      e1 = em6       value=  1.2 (3289864612027039750)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs11  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts7       value=  2.7 (7955614862216790023)
+      e1 = em6       value=  1.2 (3289864612027039750)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:T1       :br39  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 53.7 (7955691035642822656)
+
+Made block:T1       :bs12  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 53.7 (7955691035642822656)
+
+Splitting block:T1       :br38  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts3       value=  4.7 (7955629336959123459)
+
+Made block:T1       :bs13  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts3       value=  4.7 (7955629336959123459)
+
+Splitting block:T1       :br37  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts4       value=  4.6 (7955629105517428740)
+
+Made block:T1       :bs14  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts4       value=  4.6 (7955629105517428740)
+
+Splitting block:T1       :br36  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  2.6 (7955614003762298889)
+
+Made block:T1       :bs15  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  2.6 (7955614003762298889)
+
+Splitting block:T1       :br35  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  2.2 (7955610804236058636)
+
+Made block:T1       :bs16  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  2.2 (7955610804236058636)
+
+Splitting block:T1       :br34  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  2.1 (7955609983112970254)
+
+Made block:T1       :bs17  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  2.1 (7955609983112970254)
+
+Splitting block:T1       :br33  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  1.9 (7955606251260346384)
+
+Made block:T1       :bs18  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  1.9 (7955606251260346384)
+
+Splitting block:T1       :br32  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts20      value=  1.2 (7955594298397818900)
+
+Made block:T1       :bs19  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts20      value=  1.2 (7955594298397818900)
+
+Splitting block:T1       :br31  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts21      value=  0.8 (7955585776914268181)
+
+Made block:T1       :bs20  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts21      value=  0.8 (7955585776914268181)
+
+Splitting block:T1       :br30  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts23      value=  0.7 (7955579945223192599)
+
+Made block:T1       :bs21  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts23      value=  0.7 (7955579945223192599)
+
+Splitting block:H1       :br28  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm8       value=  5.0 (5595744718395801608)
+
+Made block:H1       :bs22  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm8       value=  5.0 (5595744718395801608)
+
+Splitting block:H1       :br26  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  3.7 (5595737620219953157)
+
+Made block:H1       :bs23  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  3.7 (5595737620219953157)
+
+Splitting block:H1       :br22  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm0       value=  1.1 (5595706549268905984)
+
+Made block:H1       :bs24  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm0       value=  1.1 (5595706549268905984)
+
+Splitting block:E1       :br21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value= 41.2 (3289954930548277269)
+
+Made block:E1       :bs25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value= 41.2 (3289954930548277269)
+
+Splitting block:E1       :br20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value= 18.6 (3289935212173066257)
+
+Made block:E1       :bs26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value= 18.6 (3289935212173066257)
+
+Splitting block:E1       :br19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  7.7 (3289913435248132111)
+
+Made block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  7.7 (3289913435248132111)
+
+Splitting block:E1       :br18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em20      value=  7.0 (3289910445187530772)
+
+Made block:E1       :bs28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em20      value=  7.0 (3289910445187530772)
+
+Splitting block:E1       :br17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  5.7 (3289904384665714707)
+
+Made block:E1       :bs29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  5.7 (3289904384665714707)
+
+Splitting block:E1       :br15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  5.1 (3289901926438666244)
+
+Made block:E1       :bs30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  5.1 (3289901926438666244)
+
+Splitting block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em18      value=  4.2 (3289897852798500882)
+
+Made block:E1       :bs31  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em18      value=  4.2 (3289897852798500882)
+
+Splitting block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  3.1 (3289888859657076745)
+
+Made block:E1       :bs32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  3.1 (3289888859657076745)
+
+Splitting block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.8 (3289876199502774283)
+
+Made block:E1       :bs33  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.8 (3289876199502774283)
+
+Splitting block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  1.5 (3289871468690669578)
+
+Made block:E1       :bs34  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  1.5 (3289871468690669578)
+
+Splitting block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.9 (3289857396505051141)
+
+Made block:E1       :bs35  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.9 (3289857396505051141)
+
+Splitting block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.5 (3289842274283814915)
+
+Made block:E1       :bs36  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.5 (3289842274283814915)
+
+Splitting block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.4 (3289839369896067074)
+
+Made block:E1       :bs37  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.4 (3289839369896067074)
+
+Splitting block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.4 (3289837275545862145)
+
+Made block:E1       :bs38  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.4 (3289837275545862145)
+
+Splitting block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289831233120370688)
+
+Made block:E1       :bs39  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289831233120370688)
+
+Processing block:E1T3     :bs0   : ecals = 1 hcals = 0 tracks = 3
+    elements:
+      t0 = ts2       value=  5.9 (7955634866280726530)
+      t1 = ts6       value=  3.2 (7955619528233189382)
+      t2 = ts18      value=  1.5 (7955600116646150162)
+      e3 = em7       value=  5.6 (3289904179274842119)
+    distances:
+              t0      t1      t2      e3
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      e3  0.0000  0.0000  0.0000       .
+
+Made Particle :pr0   :10252470683393064960: pdgid =   211, status =   1, q =  1, e =   5.9, theta = -0.24, phi = -0.30, mass =  0.14 from SmearedTrack: ts2   :7955634866280726530:    5.94    5.76 -0.24 -0.30
+Made Particle :pr1   :10252455364519788545: pdgid =   211, status =   1, q =  1, e =   3.2, theta = -0.22, phi = -0.19, mass =  0.14 from SmearedTrack: ts6   :7955619528233189382:    3.23    3.15 -0.22 -0.19
+Made Particle :pr2   :10252436038936952834: pdgid =   211, status =   1, q =  1, e =   1.5, theta = -0.32, phi =  0.10, mass =  0.14 from SmearedTrack: ts18  :7955600116646150162:    1.51    1.43 -0.32  0.10
+Finished block
+Processing block:E1H1T1   :bs4   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts15      value=  1.7 (7955603992185143311)
+      h1 = hm4       value=  3.6 (5595736905852387332)
+      e2 = em8       value=  1.3 (3289867928888934408)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr3   :10252439900221603843: pdgid =  -211, status =   1, q = -1, e =   1.7, theta =  0.49, phi =  0.38, mass =  0.14 from SmearedTrack: ts15  :7955603992185143311:    1.73    1.53  0.49  0.38
+Finished block
+Processing block:E1H1T1   :bs3   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts8       value=  2.8 (7955616190252974088)
+      h1 = hm7       value=  4.1 (5595740380908748807)
+      e2 = em14      value=  2.6 (3289884417350172686)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr4   :10252452030043914244: pdgid =  -211, status =   1, q = -1, e =   2.9, theta = -0.14, phi = -0.18, mass =  0.14 from SmearedTrack: ts8   :7955616190252974088:    2.85    2.82 -0.14 -0.18
+Finished block
+Processing block:E1H1T1   :bs2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  3.1 (7955618092806045701)
+      h1 = hm9       value=  8.4 (5595758510947172361)
+      e2 = em16      value=  3.3 (3289890641070260240)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr5   :10252453930491445253: pdgid =   211, status =   1, q =  1, e =   3.1, theta =  0.09, phi = -2.92, mass =  0.14 from SmearedTrack: ts5   :7955618092806045701:    3.06    3.05  0.09 -2.92
+Made Particle :pr6   :10252467843595501574: pdgid =   130, status =   1, q =  0, e =   5.3, theta =  0.09, phi =  3.00, mass =  0.50 from MergedCluster: hm9   :5595758510947172361:    8.36  0.09  3.00 sub(hs2, )
+Made Particle :pr7   :10252455664985047047: pdgid =    22, status =   1, q =  0, e =   3.3, theta =  0.09, phi =  3.00, mass =  0.00 from MergedCluster: hm9   :5595758510947172361:    8.36  0.09  3.00 sub(hs2, )
+Finished block
+Processing block:H1T2     :bs1   : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts11      value=  2.4 (7955612167328235531)
+      t1 = ts17      value=  1.7 (7955603537891688465)
+      h2 = hm1       value=  1.3 (5595710781076275201)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0677       .
+
+Made Particle :pr8   :10252448012819234824: pdgid =   211, status =   1, q =  1, e =   2.4, theta =  0.10, phi = -2.54, mass =  0.14 from SmearedTrack: ts11  :7955612167328235531:    2.39    2.38  0.10 -2.54
+Made Particle :pr9   :10252439447408738313: pdgid =   211, status =   1, q =  1, e =   1.7, theta =  0.13, phi = -2.46, mass =  0.14 from SmearedTrack: ts17  :7955603537891688465:    1.70    1.69  0.13 -2.46
+Finished block
+Processing block:E1T1     :bs11  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts7       value=  2.7 (7955614862216790023)
+      e1 = em6       value=  1.2 (3289864612027039750)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr10  :10252450703674966026: pdgid =   211, status =   1, q =  1, e =   2.7, theta =  0.24, phi =  2.94, mass =  0.14 from SmearedTrack: ts7   :7955614862216790023:    2.70    2.62  0.24  2.94
+Finished block
+Processing block:E1T1     :bs10  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  2.4 (7955612027867627530)
+      e1 = em12      value=  2.2 (3289881303261904908)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr11  :10252447873595605003: pdgid =  -211, status =   1, q = -1, e =   2.4, theta = -0.01, phi = -2.50, mass =  0.14 from SmearedTrack: ts10  :7955612027867627530:    2.37    2.37 -0.01 -2.50
+Finished block
+Processing block:E1T1     :bs9   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts19      value=  1.2 (7955594706551832595)
+      e1 = em13      value=  2.5 (3289883831458332685)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr12  :10252430657407942668: pdgid =  -211, status =   1, q = -1, e =   1.2, theta = -0.12, phi = -0.37, mass =  0.14 from SmearedTrack: ts19  :7955594706551832595:    1.20    1.19 -0.12 -0.37
+Finished block
+Processing block:H1T1     :bs8   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts24      value=  0.6 (7955576344725684248)
+      h1 = hm2       value=  3.3 (5595734050688991234)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr13  :10252412733290971149: pdgid =   211, status =   1, q =  1, e =   0.6, theta =  0.46, phi =  2.19, mass =  0.14 from SmearedTrack: ts24  :7955576344725684248:    0.58    0.52  0.46  2.19
+Finished block
+Processing block:H1T1     :bs7   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  2.2 (7955610444532547597)
+      h1 = hm3       value=  3.6 (5595736333468303363)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr14  :10252446293190246414: pdgid =  -211, status =   1, q = -1, e =   2.2, theta = -0.35, phi = -0.09, mass =  0.14 from SmearedTrack: ts13  :7955610444532547597:    2.19    2.06 -0.35 -0.09
+Finished block
+Processing block:H1T1     :bs6   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts22      value=  0.8 (7955585819870232598)
+      h1 = hm6       value=  3.9 (5595738983425376262)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr15  :10252422027753291791: pdgid =  -211, status =   1, q = -1, e =   0.9, theta = -0.37, phi =  0.52, mass =  0.14 from SmearedTrack: ts22  :7955585819870232598:    0.85    0.79 -0.37  0.52
+Finished block
+Processing block:H1T1     :bs5   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts1       value=  9.3 (7955646789218992129)
+      h1 = hm10      value= 10.4 (5595762928000172042)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr16  :10252482601461743632: pdgid =   211, status =   1, q =  1, e =   9.3, theta = -0.02, phi =  2.88, mass =  0.14 from SmearedTrack: ts1   :7955646789218992129:    9.30    9.30 -0.02  2.88
+Finished block
+Processing block:E1       :bs39  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289831233120370688)
+
+Made Particle :pr17  :10252396257035157521: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.08, phi =  2.46, mass =  0.00 from MergedCluster: em0   :3289831233120370688:    0.31  0.08  2.46 sub(es28, )
+Finished block
+Processing block:E1       :bs38  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.4 (3289837275545862145)
+
+Made Particle :pr18  :10252402299460648978: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.27, phi =  2.88, mass =  0.00 from MergedCluster: em1   :3289837275545862145:    0.40  0.27  2.88 sub(es25, )
+Finished block
+Processing block:E1       :bs37  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.4 (3289839369896067074)
+
+Made Particle :pr19  :10252404393810853907: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.59, phi =  2.49, mass =  0.00 from MergedCluster: em2   :3289839369896067074:    0.43  0.59  2.49 sub(es26, )
+Finished block
+Processing block:E1       :bs36  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.5 (3289842274283814915)
+
+Made Particle :pr20  :10252407298198601748: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.05, phi = -0.40, mass =  0.00 from MergedCluster: em3   :3289842274283814915:    0.47 -0.05 -0.40 sub(es27, )
+Finished block
+Processing block:E1       :bs35  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.9 (3289857396505051141)
+
+Made Particle :pr21  :10252422420419837973: pdgid =    22, status =   1, q =  0, e =   0.9, theta = -0.16, phi = -0.34, mass =  0.00 from MergedCluster: em5   :3289857396505051141:    0.87 -0.16 -0.34 sub(es21, )
+Finished block
+Processing block:E1       :bs34  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  1.5 (3289871468690669578)
+
+Made Particle :pr22  :10252436492605456406: pdgid =    22, status =   1, q =  0, e =   1.5, theta =  0.10, phi =  2.98, mass =  0.00 from MergedCluster: em10  :3289871468690669578:    1.54  0.10  2.98 sub(es20, )
+Finished block
+Processing block:E1       :bs33  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.8 (3289876199502774283)
+
+Made Particle :pr23  :10252441223417561111: pdgid =    22, status =   1, q =  0, e =   1.8, theta =  0.42, phi =  0.43, mass =  0.00 from MergedCluster: em11  :3289876199502774283:    1.81  0.42  0.43 sub(es15, )
+Finished block
+Processing block:E1       :bs32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  3.1 (3289888859657076745)
+
+Made Particle :pr24  :10252453883571863576: pdgid =    22, status =   1, q =  0, e =   3.1, theta = -0.22, phi = -0.32, mass =  0.00 from MergedCluster: em9   :3289888859657076745:    3.06 -0.22 -0.32 sub(es18, es16, )
+Finished block
+Processing block:E1       :bs31  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em18      value=  4.2 (3289897852798500882)
+
+Made Particle :pr25  :10252462876713287705: pdgid =    22, status =   1, q =  0, e =   4.2, theta = -0.23, phi = -0.05, mass =  0.00 from MergedCluster: em18  :3289897852798500882:    4.17 -0.23 -0.05 sub(es5, )
+Finished block
+Processing block:E1       :bs30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  5.1 (3289901926438666244)
+
+Made Particle :pr26  :10252466950353453082: pdgid =    22, status =   1, q =  0, e =   5.1, theta =  0.03, phi = -2.47, mass =  0.00 from MergedCluster: em4   :3289901926438666244:    5.09  0.03 -2.47 sub(es10, es4, es22, )
+Finished block
+Processing block:E1       :bs29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  5.7 (3289904384665714707)
+
+Made Particle :pr27  :10252469408580501531: pdgid =    22, status =   1, q =  0, e =   5.7, theta = -1.31, phi =  1.66, mass =  0.00 from MergedCluster: em19  :3289904384665714707:    5.65 -1.31  1.66 sub(es23, )
+Finished block
+Processing block:E1       :bs28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em20      value=  7.0 (3289910445187530772)
+
+Made Particle :pr28  :10252475469102317596: pdgid =    22, status =   1, q =  0, e =   7.0, theta =  1.34, phi = -0.57, mass =  0.00 from MergedCluster: em20  :3289910445187530772:    7.03  1.34 -0.57 sub(es24, )
+Finished block
+Processing block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  7.7 (3289913435248132111)
+
+Made Particle :pr29  :10252478459162918941: pdgid =    22, status =   1, q =  0, e =   7.7, theta =  0.12, phi = -2.52, mass =  0.00 from MergedCluster: em15  :3289913435248132111:    7.71  0.12 -2.52 sub(es3, es9, )
+Finished block
+Processing block:E1       :bs26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value= 18.6 (3289935212173066257)
+
+Made Particle :pr30  :10252500236087853086: pdgid =    22, status =   1, q =  0, e =  18.6, theta =  0.07, phi = -2.61, mass =  0.00 from MergedCluster: em17  :3289935212173066257:   18.64  0.07 -2.61 sub(es1, es6, )
+Finished block
+Processing block:E1       :bs25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value= 41.2 (3289954930548277269)
+
+Made Particle :pr31  :10252519954463064095: pdgid =    22, status =   1, q =  0, e =  41.2, theta =  1.07, phi = -0.51, mass =  0.00 from MergedCluster: em21  :3289954930548277269:   41.16  1.07 -0.51 sub(es0, )
+Finished block
+Processing block:H1       :bs24  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm0       value=  1.1 (5595706549268905984)
+
+Made Particle :pr32  :10252428563969998880: pdgid =   130, status =   1, q =  0, e =   1.1, theta = -0.61, phi =  1.14, mass =  0.50 from MergedCluster: hm0   :5595706549268905984:    1.09 -0.61  1.14 sub(hs8, )
+Finished block
+Processing block:H1       :bs23  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  3.7 (5595737620219953157)
+
+Made Particle :pr33  :10252459634921046049: pdgid =   130, status =   1, q =  0, e =   3.7, theta =  0.02, phi = -2.32, mass =  0.50 from MergedCluster: hm5   :5595737620219953157:    3.71  0.02 -2.32 sub(hs3, )
+Finished block
+Processing block:H1       :bs22  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm8       value=  5.0 (5595744718395801608)
+
+Made Particle :pr34  :10252466733096894498: pdgid =   130, status =   1, q =  0, e =   5.0, theta =  0.01, phi = -2.54, mass =  0.50 from MergedCluster: hm8   :5595744718395801608:    5.04  0.01 -2.54 sub(hs1, )
+Finished block
+Processing block:T1       :bs21  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts23      value=  0.7 (7955579945223192599)
+
+Made Particle :pr35  :10252416248811880483: pdgid =  -211, status =   1, q = -1, e =   0.7, theta =  0.06, phi =  2.19, mass =  0.14 from SmearedTrack: ts23  :7955579945223192599:    0.68    0.68  0.06  2.19
+Finished block
+Processing block:T1       :bs20  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts21      value=  0.8 (7955585776914268181)
+
+Made Particle :pr36  :10252421985365655588: pdgid =   211, status =   1, q =  1, e =   0.9, theta =  0.21, phi = -0.16, mass =  0.14 from SmearedTrack: ts21  :7955585776914268181:    0.85    0.83  0.21 -0.16
+Finished block
+Processing block:T1       :bs19  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts20      value=  1.2 (7955594298397818900)
+
+Made Particle :pr37  :10252430252007489573: pdgid =   211, status =   1, q =  1, e =   1.2, theta =  0.04, phi = -2.63, mass =  0.14 from SmearedTrack: ts20  :7955594298397818900:    1.18    1.18  0.04 -2.63
+Finished block
+Processing block:T1       :bs18  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  1.9 (7955606251260346384)
+
+Made Particle :pr38  :10252442152539783206: pdgid =  -211, status =   1, q = -1, e =   1.9, theta = -0.17, phi = -2.46, mass =  0.14 from SmearedTrack: ts16  :7955606251260346384:    1.86    1.83 -0.17 -2.46
+Finished block
+Processing block:T1       :bs17  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  2.1 (7955609983112970254)
+
+Made Particle :pr39  :10252445832718581799: pdgid =  -211, status =   1, q = -1, e =   2.1, theta =  0.12, phi =  2.86, mass =  0.14 from SmearedTrack: ts14  :7955609983112970254:    2.14    2.12  0.12  2.86
+Finished block
+Processing block:T1       :bs16  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  2.2 (7955610804236058636)
+
+Made Particle :pr40  :10252446652187017256: pdgid =   211, status =   1, q =  1, e =   2.2, theta = -0.06, phi = -0.13, mass =  0.14 from SmearedTrack: ts12  :7955610804236058636:    2.23    2.23 -0.06 -0.13
+Finished block
+Processing block:T1       :bs15  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  2.6 (7955614003762298889)
+
+Made Particle :pr41  :10252449846403268649: pdgid =  -211, status =   1, q = -1, e =   2.6, theta = -0.25, phi =  2.97, mass =  0.14 from SmearedTrack: ts9   :7955614003762298889:    2.60    2.52 -0.25  2.97
+Finished block
+Processing block:T1       :bs14  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts4       value=  4.6 (7955629105517428740)
+
+Made Particle :pr42  :10252464924651421738: pdgid =   211, status =   1, q =  1, e =   4.6, theta = -0.20, phi = -0.22, mass =  0.14 from SmearedTrack: ts4   :7955629105517428740:    4.63    4.54 -0.20 -0.22
+Finished block
+Processing block:T1       :bs13  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts3       value=  4.7 (7955629336959123459)
+
+Made Particle :pr43  :10252465155990356011: pdgid =  -211, status =   1, q = -1, e =   4.7, theta = -0.20, phi = -0.31, mass =  0.14 from SmearedTrack: ts3   :7955629336959123459:    4.68    4.59 -0.20 -0.31
+Finished block
+Processing block:T1       :bs12  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 53.7 (7955691035642822656)
+
+Made Particle :pr44  :10252526845658398764: pdgid =    13, status =   1, q =  1, e =  53.7, theta = -0.88, phi =  1.34, mass =  0.11 from SmearedTrack: ts0   :7955691035642822656:   53.69   34.23 -0.88  1.34
+Finished block
+Finished reconstruction
+Event: 1
+Made Particle :ps0   :10261538516949270528: pdgid =    13, status =   1, q = -1, e =  61.8, theta =  0.48, phi =  1.52, mass =  0.11
+Made Particle :ps1   :10261525040717627393: pdgid =   -13, status =   1, q =  1, e =  37.3, theta =  0.01, phi = -0.75, mass =  0.11
+Made Particle :ps2   :10261491264203522050: pdgid =   -13, status =   1, q =  1, e =  10.0, theta = -0.26, phi =  2.91, mass =  0.11
+Made Particle :ps3   :10261488162658320387: pdgid =   321, status =   1, q =  1, e =   8.6, theta = -0.40, phi = -1.03, mass =  0.49
+Made Particle :ps4   :10261486774521954308: pdgid =  -211, status =   1, q = -1, e =   8.0, theta = -0.21, phi =  2.74, mass =  0.14
+Made Particle :ps5   :10261481799230160901: pdgid =   211, status =   1, q =  1, e =   6.8, theta = -0.42, phi = -1.01, mass =  0.14
+Made Particle :ps6   :10261476714278289414: pdgid =    22, status =   1, q =  0, e =   5.7, theta =  0.00, phi = -0.75, mass =  0.00
+Made Particle :ps7   :10261473911415767047: pdgid =   211, status =   1, q =  1, e =   5.0, theta = -0.14, phi =  2.71, mass =  0.14
+Made Particle :ps8   :10261472553862168584: pdgid =  -211, status =   1, q = -1, e =   4.7, theta = -0.31, phi = -1.07, mass =  0.14
+Made Particle :ps9   :10261467815127023625: pdgid =    22, status =   1, q =  0, e =   3.8, theta = -0.39, phi = -1.00, mass =  0.00
+Made Particle :ps10  :10261464473470500874: pdgid = -2112, status =   1, q =  0, e =   3.4, theta = -0.27, phi =  2.77, mass =  0.94
+Made Particle :ps11  :10261461887027773451: pdgid =    22, status =   1, q =  0, e =   3.2, theta = -0.33, phi = -1.04, mass =  0.00
+Made Particle :ps12  :10261461236442988556: pdgid =  -321, status =   1, q = -1, e =   3.1, theta = -0.26, phi = -1.23, mass =  0.49
+Made Particle :ps13  :10261460680047591437: pdgid =    22, status =   1, q =  0, e =   3.0, theta = -0.39, phi = -1.07, mass =  0.00
+Made Particle :ps14  :10261460258052374542: pdgid =    22, status =   1, q =  0, e =   3.0, theta = -0.16, phi =  2.82, mass =  0.00
+Made Particle :ps15  :10261458530364030991: pdgid =  -211, status =   1, q = -1, e =   2.8, theta = -0.53, phi = -1.14, mass =  0.14
+Made Particle :ps16  :10261458087525220368: pdgid =    22, status =   1, q =  0, e =   2.7, theta = -0.41, phi = -1.20, mass =  0.00
+Made Particle :ps17  :10261457351900921873: pdgid =  2112, status =   1, q =  0, e =   2.6, theta =  0.83, phi = -1.62, mass =  0.94
+Made Particle :ps18  :10261456410554400786: pdgid =  -211, status =   1, q = -1, e =   2.5, theta = -0.19, phi =  2.71, mass =  0.14
+Made Particle :ps19  :10261455937428520979: pdgid =    22, status =   1, q =  0, e =   2.5, theta = -0.36, phi = -1.00, mass =  0.00
+Made Particle :ps20  :10261454705376886804: pdgid =    22, status =   1, q =  0, e =   2.3, theta = -0.24, phi = -1.05, mass =  0.00
+Made Particle :ps21  :10261449618006999061: pdgid =  -211, status =   1, q = -1, e =   1.9, theta = -0.23, phi = -1.00, mass =  0.14
+Made Particle :ps22  :10261444512855359510: pdgid =   211, status =   1, q =  1, e =   1.6, theta = -0.38, phi = -0.95, mass =  0.14
+Made Particle :ps23  :10261442288125214743: pdgid =  2112, status =   1, q =  0, e =   1.5, theta = -1.05, phi =  2.37, mass =  0.94
+Made Particle :ps24  :10261441337064685592: pdgid =   211, status =   1, q =  1, e =   1.4, theta = -0.13, phi =  2.69, mass =  0.14
+Made Particle :ps25  :10261440707942154265: pdgid =    22, status =   1, q =  0, e =   1.4, theta = -0.27, phi = -0.72, mass =  0.00
+Made Particle :ps26  :10261440451718414362: pdgid =    22, status =   1, q =  0, e =   1.4, theta = -0.06, phi =  2.69, mass =  0.00
+Made Particle :ps27  :10261439778377433115: pdgid =    22, status =   1, q =  0, e =   1.3, theta =  0.62, phi = -1.05, mass =  0.00
+Made Particle :ps28  :10261438059138514972: pdgid =    22, status =   1, q =  0, e =   1.2, theta = -0.45, phi = -1.04, mass =  0.00
+Made Particle :ps29  :10261436153104171037: pdgid =  -211, status =   1, q = -1, e =   1.1, theta = -0.51, phi = -1.05, mass =  0.14
+Made Particle :ps30  :10261435864710119454: pdgid = -2212, status =   1, q = -1, e =   1.1, theta =  0.86, phi =  2.85, mass =  0.94
+Made Particle :ps31  :10261434363474346015: pdgid =   211, status =   1, q =  1, e =   1.0, theta = -0.52, phi = -1.23, mass =  0.14
+Made Particle :ps32  :10261432221923541024: pdgid =    22, status =   1, q =  0, e =   0.9, theta = -0.12, phi =  2.75, mass =  0.00
+Made Particle :ps33  :10261423057946017825: pdgid =    22, status =   1, q =  0, e =   0.7, theta = -0.03, phi =  2.71, mass =  0.00
+Made Particle :ps34  :10261421608761557026: pdgid =  -211, status =   1, q = -1, e =   0.6, theta =  1.13, phi = -2.23, mass =  0.14
+Made Particle :ps35  :10261421598646992931: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.22, phi =  2.61, mass =  0.00
+Made Particle :ps36  :10261420562460966948: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  1.16, phi = -1.40, mass =  0.00
+Made Particle :ps37  :10261419246447755301: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.74, phi =  2.17, mass =  0.00
+Made Particle :ps38  :10261418298342113318: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.39, phi =  2.52, mass =  0.00
+Made Particle :ps39  :10261418000357785639: pdgid =  -211, status =   1, q = -1, e =   0.5, theta =  0.73, phi = -2.96, mass =  0.14
+Made Particle :ps40  :10261416992900644904: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.55, phi = -1.04, mass =  0.00
+Made Particle :ps41  :10261416662766977065: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.69, phi = -1.63, mass =  0.00
+Made Particle :ps42  :10261416660751613994: pdgid =   211, status =   1, q =  1, e =   0.5, theta = -1.32, phi = -2.73, mass =  0.14
+Made Particle :ps43  :10261416642854518827: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.29, phi = -1.12, mass =  0.00
+Made Particle :ps44  :10261416199971668012: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.12, phi = -1.54, mass =  0.00
+Made Particle :ps45  :10261416118396649517: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.06, phi = -1.34, mass =  0.00
+Made Particle :ps46  :10261415871253577774: pdgid =   211, status =   1, q =  1, e =   0.5, theta =  0.80, phi = -0.77, mass =  0.14
+Made Particle :ps47  :10261414640263102511: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.06, phi = -1.11, mass =  0.00
+Made Particle :ps48  :10261413913851592752: pdgid =  -211, status =   1, q = -1, e =   0.5, theta =  1.18, phi = -3.03, mass =  0.14
+Made Particle :ps49  :10261412406022373425: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.39, phi = -1.24, mass =  0.00
+Made Particle :ps50  :10261410836509622322: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.16, phi = -1.06, mass =  0.00
+Made Particle :ps51  :10261408620075810867: pdgid =  -211, status =   1, q = -1, e =   0.4, theta = -0.07, phi = -1.14, mass =  0.14
+Made Particle :ps52  :10261407951352758324: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.36, phi = -1.05, mass =  0.00
+Made Particle :ps53  :10261406940433219637: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.27, phi = -2.55, mass =  0.00
+Made Particle :ps54  :10261406622309941302: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.35, phi = -0.54, mass =  0.00
+Made Particle :ps55  :10261406119882653751: pdgid =   211, status =   1, q =  1, e =   0.4, theta = -0.07, phi = -3.03, mass =  0.14
+Made Particle :ps56  :10261405910865805368: pdgid =  -211, status =   1, q = -1, e =   0.3, theta = -0.18, phi =  2.30, mass =  0.14
+Made Particle :ps57  :10261405343456165945: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.14, phi =  2.95, mass =  0.00
+Made Particle :ps58  :10261403950401978426: pdgid =   211, status =   1, q =  1, e =   0.3, theta = -0.30, phi = -0.41, mass =  0.14
+Made Particle :ps59  :10261403901318135867: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.26, phi =  2.92, mass =  0.00
+Made Particle :ps60  :10261403339484823612: pdgid =   211, status =   1, q =  1, e =   0.3, theta = -0.36, phi =  0.44, mass =  0.14
+Made Particle :ps61  :10261398904415191101: pdgid =   211, status =   1, q =  1, e =   0.2, theta = -0.90, phi = -0.42, mass =  0.14
+Made Particle :ps62  :10261398616262311998: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.44, phi =  2.77, mass =  0.00
+Made Particle :ps63  :10261398368083247167: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.30, phi =  2.67, mass =  0.00
+Made Particle :ps64  :10261397773530169408: pdgid =  -211, status =   1, q = -1, e =   0.2, theta = -1.22, phi =  2.51, mass =  0.14
+Made Particle :ps65  :10261394078222516289: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.02, phi = -0.99, mass =  0.00
+Made Particle :ps66  :10261393611620876354: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.38, phi = -0.83, mass =  0.00
+Made Particle :ps67  :10261392443853242435: pdgid =   211, status =   1, q =  1, e =   0.2, theta = -0.41, phi =  3.05, mass =  0.14
+Made Particle :ps68  :10261389810547556420: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.29, phi = -1.86, mass =  0.00
+Made Particle :ps69  :10261387795792658501: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.76, phi = -0.73, mass =  0.00
+Made Particle :ps70  :10261386872959795270: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.25, phi =  2.81, mass =  0.00
+Made Particle :ps71  :10261376439953653831: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -1.07, phi =  3.14, mass =  0.00
+Made Particle :ps72  :10261370039150051400: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.46, phi =  2.67, mass =  0.00
+Made Particle :ps73  :10261365258144710729: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.58, phi =  2.37, mass =  0.00
+Made Particle :ps74  :10261364150678585418: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.05, phi =  1.92, mass =  0.00
+Made Particle :ps75  :10261362047459524683: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.31, phi = -0.38, mass =  0.00
+Made Particle :ps76  :10261361438771642444: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.05, phi = -1.62, mass =  0.00
+Made Particle :ps77  :10261360554786422861: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  1.17, phi =  2.57, mass =  0.00
+Made Particle :ps78  :10261355666601934926: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  0.96, phi = -1.14, mass =  0.00
+Made Particle :ps79  :10261351772700278863: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.37, phi = -0.18, mass =  0.00
+Made Particle :ps80  :10261350594285404240: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  0.38, phi =  1.79, mass =  0.00
+Simulating Particle :ps0   :10261538516949270528: pdgid =    13, status =   1, q = -1, e =  61.8, theta =  0.48, phi =  1.52, mass =  0.11
+Simulating Muon
+Made Track: tt0   :7964702706942083072:   61.83   54.72  0.48  1.52
+Made SmearedTrack: ts0   :7955695523466313728:   61.86   54.74  0.48  1.52
+Simulating Particle :ps1   :10261525040717627393: pdgid =   -13, status =   1, q =  1, e =  37.3, theta =  0.01, phi = -0.75, mass =  0.11
+Simulating Muon
+Made Track: tt1   :7964689230676885505:   37.31   37.31  0.01 -0.75
+Made SmearedTrack: ts1   :7955682357703344129:   37.91   37.91  0.01 -0.75
+Simulating Particle :ps2   :10261491264203522050: pdgid =   -13, status =   1, q =  1, e =  10.0, theta = -0.26, phi =  2.91, mass =  0.11
+Simulating Muon
+Made Track: tt2   :7964655453011443714:    9.97    9.64 -0.26  2.91
+Made SmearedTrack: ts2   :7955648034205859842:    9.87    9.55 -0.26  2.91
+Simulating Particle :ps3   :10261488162658320387: pdgid =   321, status =   1, q =  1, e =   8.6, theta = -0.40, phi = -1.03, mass =  0.49
+Simulating Hadron
+Made Track: tt3   :7964652321361625091:    8.54    7.88 -0.40 -1.03
+Made SmearedTrack: ts3   :7955644897858420739:    8.44    7.78 -0.40 -1.03
+Made Cluster: ht0   :5658809343485673472:    8.56 -0.40 -1.17 sub(ht0, )
+Made SmearedCluster: hs0   :5649785651514572800:    4.53 -0.40 -1.17 sub(hs0, )
+Simulating Particle :ps4   :10261486774521954308: pdgid =  -211, status =   1, q = -1, e =   8.0, theta = -0.21, phi =  2.74, mass =  0.14
+Simulating Hadron
+Made Track: tt4   :7964650959183806468:    7.96    7.78 -0.21  2.74
+Made SmearedTrack: ts4   :7955644005954355204:    8.04    7.85 -0.21  2.74
+Made Cluster: et0   :3352944967447216128:    3.71 -0.21  2.79 sub(et0, )
+Made SmearedCluster: es0   :3343939165419995136:    3.87 -0.21  2.79 sub(es0, )
+Made Cluster: ht1   :5658791636820295681:    4.25 -0.21  2.83 sub(ht1, )
+Made SmearedCluster: hs1   :5647513932722601985:   -2.02 -0.21  2.83 sub(hs1, )
+Rejected SmearedCluster: hs1   :5647513932722601985:   -2.02 -0.21  2.83 sub(hs1, )
+Simulating Particle :ps5   :10261481799230160901: pdgid =   211, status =   1, q =  1, e =   6.8, theta = -0.42, phi = -1.01, mass =  0.14
+Simulating Hadron
+Made Track: tt5   :7964645983000723461:    6.83    6.24 -0.42 -1.01
+Made SmearedTrack: ts5   :7955639328760135685:    6.95    6.36 -0.42 -1.01
+Made Cluster: ht2   :5658802980057513986:    6.83 -0.42 -1.18 sub(ht2, )
+Made SmearedCluster: hs1   :5649737293886390273:    0.69 -0.42 -1.18 sub(hs1, )
+Rejected SmearedCluster: hs1   :5649737293886390273:    0.69 -0.42 -1.18 sub(hs1, )
+Simulating Particle :ps6   :10261476714278289414: pdgid =    22, status =   1, q =  0, e =   5.7, theta =  0.00, phi = -0.75, mass =  0.00
+Simulating Photon
+Made Cluster: et1   :3352954885891948545:    5.68  0.00 -0.75 sub(et1, )
+Made SmearedCluster: es1   :3343947461124161537:    5.62  0.00 -0.75 sub(es1, )
+Simulating Particle :ps7   :10261473911415767047: pdgid =   211, status =   1, q =  1, e =   5.0, theta = -0.14, phi =  2.71, mass =  0.14
+Simulating Hadron
+Made Track: tt6   :7964638092954959878:    5.04    4.99 -0.14  2.71
+Made SmearedTrack: ts6   :7955630394817118214:    4.92    4.87 -0.14  2.71
+Made Cluster: et2   :3352860625796595714:    0.13 -0.14  2.56 sub(et2, )
+Made SmearedCluster: es2   :3343928579703439362:    2.67 -0.14  2.56 sub(es2, )
+Made Cluster: ht3   :5658794508989497347:    4.91 -0.14  2.49 sub(ht3, )
+Made SmearedCluster: hs1   :5647513932722601985:   -3.64 -0.14  2.49 sub(hs1, )
+Rejected SmearedCluster: hs1   :5647513932722601985:   -3.64 -0.14  2.49 sub(hs1, )
+Simulating Particle :ps8   :10261472553862168584: pdgid =  -211, status =   1, q = -1, e =   4.7, theta = -0.31, phi = -1.07, mass =  0.14
+Simulating Hadron
+Made Track: tt7   :7964636734845616135:    4.73    4.50 -0.31 -1.07
+Made SmearedTrack: ts7   :7955629133919158279:    4.64    4.42 -0.31 -1.07
+Made Cluster: ht4   :5658793734689521668:    4.73 -0.32 -1.01 sub(ht4, )
+Made SmearedCluster: hs1   :5649789742181515265:    5.46 -0.32 -1.01 sub(hs1, )
+Simulating Particle :ps9   :10261467815127023625: pdgid =    22, status =   1, q =  0, e =   3.8, theta = -0.39, phi = -1.00, mass =  0.00
+Simulating Photon
+Made Cluster: et3   :3352945986740682755:    3.83 -0.39 -1.00 sub(et3, )
+Made SmearedCluster: es3   :3343939111695155203:    3.86 -0.39 -1.00 sub(es3, )
+Simulating Particle :ps10  :10261464473470500874: pdgid = -2112, status =   1, q =  0, e =   3.4, theta = -0.27, phi =  2.77, mass =  0.94
+Simulating Hadron
+Made Cluster: ht5   :5658785654297853957:    3.45 -0.27  2.77 sub(ht5, )
+Made SmearedCluster: hs2   :5647513932722601986:   -3.50 -0.27  2.77 sub(hs2, )
+Rejected SmearedCluster: hs2   :5647513932722601986:   -3.50 -0.27  2.77 sub(hs2, )
+Simulating Particle :ps11  :10261461887027773451: pdgid =    22, status =   1, q =  0, e =   3.2, theta = -0.33, phi = -1.04, mass =  0.00
+Simulating Photon
+Made Cluster: et4   :3352940058641432580:    3.15 -0.33 -1.04 sub(et4, )
+Made SmearedCluster: es4   :3343934524644917252:    3.34 -0.33 -1.04 sub(es4, )
+Simulating Particle :ps12  :10261461236442988556: pdgid =  -321, status =   1, q = -1, e =   3.1, theta = -0.26, phi = -1.23, mass =  0.49
+Simulating Hadron
+Made Track: tt8   :7964625076014284808:    3.04    2.94 -0.26 -1.23
+Made SmearedTrack: ts8   :7955617951218925576:    3.05    2.95 -0.26 -1.23
+Made Cluster: et5   :3352930310894387205:    2.04 -0.26 -0.98 sub(et5, )
+Made SmearedCluster: es5   :3341670923508908037:   -0.14 -0.26 -0.98 sub(es5, )
+Rejected SmearedCluster: es5   :3341670923508908037:   -0.14 -0.26 -0.98 sub(es5, )
+Made Cluster: ht6   :5658755941741363206:    1.03 -0.26 -0.86 sub(ht6, )
+Made SmearedCluster: hs2   :5647513932722601986:   -3.01 -0.26 -0.86 sub(hs2, )
+Rejected SmearedCluster: hs2   :5647513932722601986:   -3.01 -0.26 -0.86 sub(hs2, )
+Simulating Particle :ps13  :10261460680047591437: pdgid =    22, status =   1, q =  0, e =   3.0, theta = -0.39, phi = -1.07, mass =  0.00
+Simulating Photon
+Made Cluster: et6   :3352938851661250566:    3.02 -0.39 -1.07 sub(et6, )
+Made SmearedCluster: es5   :3343932468729217029:    3.11 -0.39 -1.07 sub(es5, )
+Simulating Particle :ps14  :10261460258052374542: pdgid =    22, status =   1, q =  0, e =   3.0, theta = -0.16, phi =  2.82, mass =  0.00
+Simulating Photon
+Made Cluster: et7   :3352938429666033671:    2.97 -0.16  2.82 sub(et7, )
+Made SmearedCluster: es6   :3343928003869540358:    2.60 -0.16  2.82 sub(es6, )
+Simulating Particle :ps15  :10261458530364030991: pdgid =  -211, status =   1, q = -1, e =   2.8, theta = -0.53, phi = -1.14, mass =  0.14
+Simulating Hadron
+Made Track: tt9   :7964622689463697417:    2.77    2.39 -0.53 -1.14
+Made SmearedTrack: ts9   :7955615398085263369:    2.76    2.38 -0.53 -1.14
+Made Cluster: et8   :3352922557501145096:    1.58 -0.53 -0.83 sub(et8, )
+Made SmearedCluster: es7   :3341670923508908039:   -0.94 -0.53 -0.83 sub(es7, )
+Rejected SmearedCluster: es7   :3341670923508908039:   -0.94 -0.53 -0.83 sub(es7, )
+Made Cluster: ht7   :5658758671295840263:    1.19 -0.54 -0.67 sub(ht7, )
+Made SmearedCluster: hs2   :5649772402314313730:    2.76 -0.54 -0.67 sub(hs2, )
+Simulating Particle :ps16  :10261458087525220368: pdgid =    22, status =   1, q =  0, e =   2.7, theta = -0.41, phi = -1.20, mass =  0.00
+Simulating Photon
+Made Cluster: et9   :3352936259138879497:    2.72 -0.41 -1.20 sub(et9, )
+Made SmearedCluster: es7   :3343931925558460423:    3.05 -0.41 -1.20 sub(es7, )
+Simulating Particle :ps17  :10261457351900921873: pdgid =  2112, status =   1, q =  0, e =   2.6, theta =  0.83, phi = -1.62, mass =  0.94
+Simulating Hadron
+Made Cluster: ht8   :5658778532728274952:    2.64  0.83 -1.62 sub(ht8, )
+Made SmearedCluster: hs3   :5649767325186916355:    2.18  0.83 -1.62 sub(hs3, )
+Rejected SmearedCluster: hs3   :5649767325186916355:    2.18  0.83 -1.62 sub(hs3, )
+Simulating Particle :ps18  :10261456410554400786: pdgid =  -211, status =   1, q = -1, e =   2.5, theta = -0.19, phi =  2.71, mass =  0.14
+Simulating Hadron
+Made Track: tt10  :7964620566703374346:    2.53    2.48 -0.19  2.71
+Made SmearedTrack: ts10  :7955613361371086858:    2.53    2.48 -0.19  2.71
+Made Cluster: et10  :3352917972866826250:    1.32 -0.19  3.02 sub(et10, )
+Made SmearedCluster: es8   :3343948029265707016:    5.75 -0.19  3.02 sub(es8, )
+Made Cluster: ht9   :5658759016310898697:    1.21 -0.20 -3.12 sub(ht9, )
+Made SmearedCluster: hs3   :5647513932722601987:   -0.51 -0.20 -3.12 sub(hs3, )
+Rejected SmearedCluster: hs3   :5647513932722601987:   -0.51 -0.20 -3.12 sub(hs3, )
+Simulating Particle :ps19  :10261455937428520979: pdgid =    22, status =   1, q =  0, e =   2.5, theta = -0.36, phi = -1.00, mass =  0.00
+Simulating Photon
+Made Cluster: et11  :3352934109042180107:    2.48 -0.36 -1.00 sub(et11, )
+Made SmearedCluster: es9   :3343924316216492041:    2.18 -0.36 -1.00 sub(es9, )
+Simulating Particle :ps20  :10261454705376886804: pdgid =    22, status =   1, q =  0, e =   2.3, theta = -0.24, phi = -1.05, mass =  0.00
+Simulating Photon
+Made Cluster: et12  :3352932876990545932:    2.34 -0.24 -1.05 sub(et12, )
+Made SmearedCluster: es10  :3343926409069330442:    2.42 -0.24 -1.05 sub(es10, )
+Simulating Particle :ps21  :10261449618006999061: pdgid =  -211, status =   1, q = -1, e =   1.9, theta = -0.23, phi = -1.00, mass =  0.14
+Simulating Hadron
+Made Track: tt11  :7964613716719173643:    1.87    1.82 -0.23 -1.00
+Made SmearedTrack: ts11  :7955606689468645387:    1.88    1.83 -0.23 -1.00
+Made Cluster: ht10  :5658770798834352138:    1.88 -0.25 -0.37 sub(ht10, )
+Made SmearedCluster: hs3   :5649786806447636483:    4.79 -0.25 -0.37 sub(hs3, )
+Simulating Particle :ps22  :10261444512855359510: pdgid =   211, status =   1, q =  1, e =   1.6, theta = -0.38, phi = -0.95, mass =  0.14
+Simulating Hadron
+Made Track: tt12  :7964608594825969676:    1.58    1.47 -0.38 -0.95
+Made SmearedTrack: ts12  :7955601440165068812:    1.58    1.47 -0.38 -0.95
+Made Cluster: et13  :3352892668131672077:    0.47 -0.34 -1.04 sub(et13, )
+Made SmearedCluster: es11  :3341670923508908043:   -1.17 -0.34 -1.04 sub(es11, )
+Rejected SmearedCluster: es11  :3341670923508908043:   -1.17 -0.34 -1.04 sub(es11, )
+Made Cluster: ht11  :5658757415108083723:    1.12 -0.35 -1.13 sub(ht11, )
+Made SmearedCluster: hs4   :5647513932722601988:   -2.18 -0.35 -1.13 sub(hs4, )
+Rejected SmearedCluster: hs4   :5647513932722601988:   -2.18 -0.35 -1.13 sub(hs4, )
+Simulating Particle :ps23  :10261442288125214743: pdgid =  2112, status =   1, q =  0, e =   1.5, theta = -1.05, phi =  2.37, mass =  0.94
+Simulating Hadron
+Made Cluster: et14  :3352875927703912462:    0.24 -1.05  2.37 sub(et14, )
+Made SmearedCluster: es11  :3341670923508908043:   -3.18 -1.05  2.37 sub(es11, )
+Rejected SmearedCluster: es11  :3341670923508908043:   -3.18 -1.05  2.37 sub(es11, )
+Made Cluster: ht12  :5658759223194943500:    1.22 -1.05  2.37 sub(ht12, )
+Made SmearedCluster: hs4   :5647513932722601988:   -4.67 -1.05  2.37 sub(hs4, )
+Rejected SmearedCluster: hs4   :5647513932722601988:   -4.67 -1.05  2.37 sub(hs4, )
+Simulating Particle :ps24  :10261441337064685592: pdgid =   211, status =   1, q =  1, e =   1.4, theta = -0.13, phi =  2.69, mass =  0.14
+Simulating Hadron
+Made Track: tt13  :7964605405114400781:    1.40    1.39 -0.13  2.69
+Made SmearedTrack: ts13  :7955598229314207757:    1.40    1.39 -0.13  2.69
+Made Cluster: ht13  :5658762517892038669:    1.41 -0.16  2.06 sub(ht13, )
+Made SmearedCluster: hs4   :5649761047689560068:    1.73 -0.16  2.06 sub(hs4, )
+Rejected SmearedCluster: hs4   :5649761047689560068:    1.73 -0.16  2.06 sub(hs4, )
+Simulating Particle :ps25  :10261440707942154265: pdgid =    22, status =   1, q =  0, e =   1.4, theta = -0.27, phi = -0.72, mass =  0.00
+Simulating Photon
+Made Cluster: et15  :3352918879555813391:    1.37 -0.27 -0.72 sub(et15, )
+Made SmearedCluster: es11  :3343909411629301771:    1.24 -0.27 -0.72 sub(es11, )
+Simulating Particle :ps26  :10261440451718414362: pdgid =    22, status =   1, q =  0, e =   1.4, theta = -0.06, phi =  2.69, mass =  0.00
+Simulating Photon
+Made Cluster: et16  :3352918623332073488:    1.36 -0.06  2.69 sub(et16, )
+Made SmearedCluster: es12  :3343915792201678860:    1.61 -0.06  2.69 sub(es12, )
+Simulating Particle :ps27  :10261439778377433115: pdgid =    22, status =   1, q =  0, e =   1.3, theta =  0.62, phi = -1.05, mass =  0.00
+Simulating Photon
+Made Cluster: et17  :3352917949991092241:    1.32  0.62 -1.05 sub(et17, )
+Made SmearedCluster: es13  :3343912539919482893:    1.42  0.62 -1.05 sub(es13, )
+Simulating Particle :ps28  :10261438059138514972: pdgid =    22, status =   1, q =  0, e =   1.2, theta = -0.45, phi = -1.04, mass =  0.00
+Simulating Photon
+Made Cluster: et18  :3352916230752174098:    1.22 -0.45 -1.04 sub(et18, )
+Made SmearedCluster: es14  :3343910898705104910:    1.33 -0.45 -1.04 sub(es14, )
+Simulating Particle :ps29  :10261436153104171037: pdgid =  -211, status =   1, q = -1, e =   1.1, theta = -0.51, phi = -1.05, mass =  0.14
+Simulating Hadron
+Made Track: tt14  :7964600188635447310:    1.10    0.96 -0.51 -1.05
+Made SmearedTrack: ts14  :7955592902948683790:    1.10    0.96 -0.51 -1.05
+Made Cluster: et19  :3352900771694772243:    0.67 -0.57 -0.17 sub(et19, )
+Made SmearedCluster: es15  :3343921816235147279:    1.95 -0.57 -0.17 sub(es15, )
+Made Cluster: ht14  :5658733657741852686:    0.44 -1.33  1.70 sub(ht14, )
+Made SmearedCluster: hs4   :5649805647038906372:   10.15 -1.33  1.70 sub(hs4, )
+Simulating Particle :ps30  :10261435864710119454: pdgid = -2212, status =   1, q = -1, e =   1.1, theta =  0.86, phi =  2.85, mass =  0.94
+Simulating Hadron
+Made Track: tt15  :7964583160650399759:    0.57    0.37  0.86  2.85
+Made SmearedTrack: ts15  :7955576133380997135:    0.57    0.37  0.86  2.85
+Rejected SmearedTrack: ts15  :7955576133380997135:    0.57    0.37  0.86  2.85
+Made Cluster: ht15  :5658757045537472527:    1.10  1.50  3.13 sub(ht15, )
+Made SmearedCluster: hs5   :5649808975831498757:   11.66  1.50  3.13 sub(hs5, )
+Simulating Particle :ps31  :10261434363474346015: pdgid =   211, status =   1, q =  1, e =   1.0, theta = -0.52, phi = -1.23, mass =  0.14
+Simulating Hadron
+Made Track: tt16  :7964598383325216784:    1.00    0.87 -0.52 -1.23
+Made SmearedTrack: ts15  :7955591154718736399:    1.00    0.87 -0.52 -1.23
+Made Cluster: et20  :3352893799966703636:    0.49 -0.60 -2.25 sub(et20, )
+Made SmearedCluster: es16  :3341670923508908048:   -1.01 -0.60 -2.25 sub(es16, )
+Rejected SmearedCluster: es16  :3341670923508908048:   -1.01 -0.60 -2.25 sub(es16, )
+Made Cluster: ht16  :5658738625930592272:    0.52 -1.48  2.07 sub(ht16, )
+Made SmearedCluster: hs6   :5647513932722601990:  -18.43 -1.48  2.07 sub(hs6, )
+Rejected SmearedCluster: hs6   :5647513932722601990:  -18.43 -1.48  2.07 sub(hs6, )
+Simulating Particle :ps32  :10261432221923541024: pdgid =    22, status =   1, q =  0, e =   0.9, theta = -0.12, phi =  2.75, mass =  0.00
+Simulating Photon
+Made Cluster: et21  :3352910393537200149:    0.94 -0.12  2.75 sub(et21, )
+Made SmearedCluster: es16  :3343904753355587600:    0.99 -0.12  2.75 sub(es16, )
+Simulating Particle :ps33  :10261423057946017825: pdgid =    22, status =   1, q =  0, e =   0.7, theta = -0.03, phi =  2.71, mass =  0.00
+Simulating Photon
+Made Cluster: et22  :3352901229559676950:    0.68 -0.03  2.71 sub(et22, )
+Made SmearedCluster: es17  :3343892186715389969:    0.63 -0.03  2.71 sub(es17, )
+Simulating Particle :ps34  :10261421608761557026: pdgid =  -211, status =   1, q = -1, e =   0.6, theta =  1.13, phi = -2.23, mass =  0.14
+Simulating Hadron
+Made Track: tt17  :7964585259679350801:    0.63    0.27  1.13 -2.23
+Made SmearedTrack: ts16  :7955578127667691536:    0.63    0.27  1.13 -2.23
+Rejected SmearedTrack: ts16  :7955578127667691536:    0.63    0.27  1.13 -2.23
+Made Cluster: ht17  :5658742789588910097:    0.64  1.48  0.37 sub(ht17, )
+Made SmearedCluster: hs6   :5647513932722601990:   -4.13  1.48  0.37 sub(hs6, )
+Rejected SmearedCluster: hs6   :5647513932722601990:   -4.13  1.48  0.37 sub(hs6, )
+Simulating Particle :ps35  :10261421598646992931: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.22, phi =  2.61, mass =  0.00
+Simulating Photon
+Made Cluster: et23  :3352899770260652055:    0.64 -0.22  2.61 sub(et23, )
+Made SmearedCluster: es18  :3343897159557709842:    0.77 -0.22  2.61 sub(es18, )
+Simulating Particle :ps36  :10261420562460966948: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  1.16, phi = -1.40, mass =  0.00
+Simulating Photon
+Made Cluster: et24  :3352898734074626072:    0.61  1.16 -1.40 sub(et24, )
+Made SmearedCluster: es19  :3343895331474505747:    0.72  1.16 -1.40 sub(es19, )
+Rejected SmearedCluster: es19  :3343895331474505747:    0.72  1.16 -1.40 sub(es19, )
+Simulating Particle :ps37  :10261419246447755301: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.74, phi =  2.17, mass =  0.00
+Simulating Photon
+Made Cluster: et25  :3352897418061414425:    0.58  0.74  2.17 sub(et25, )
+Made SmearedCluster: es19  :3343881600877199379:    0.42  0.74  2.17 sub(es19, )
+Simulating Particle :ps38  :10261418298342113318: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.39, phi =  2.52, mass =  0.00
+Simulating Photon
+Made Cluster: et26  :3352896469955772442:    0.55  0.39  2.52 sub(et26, )
+Made SmearedCluster: es20  :3343883827327008788:    0.45  0.39  2.52 sub(es20, )
+Simulating Particle :ps39  :10261418000357785639: pdgid =  -211, status =   1, q = -1, e =   0.5, theta =  0.73, phi = -2.96, mass =  0.14
+Simulating Hadron
+Made Track: tt18  :7964581545742696466:    0.52    0.39  0.73 -2.96
+Made SmearedTrack: ts16  :7955573886664310800:    0.51    0.38  0.73 -2.96
+Rejected SmearedTrack: ts16  :7955573886664310800:    0.51    0.38  0.73 -2.96
+Made Cluster: et27  :3352876973421494299:    0.25  1.53 -2.83 sub(et27, )
+Made SmearedCluster: es21  :3343946878868783125:    5.49  1.53 -2.83 sub(es21, )
+Rejected SmearedCluster: es21  :3343946878868783125:    5.49  1.53 -2.83 sub(es21, )
+Made Cluster: ht18  :5658723109063098386:    0.29  1.34 -1.85 sub(ht18, )
+Made SmearedCluster: hs6   :5647513932722601990:   -0.39  1.34 -1.85 sub(hs6, )
+Rejected SmearedCluster: hs6   :5647513932722601990:   -0.39  1.34 -1.85 sub(hs6, )
+Simulating Particle :ps40  :10261416992900644904: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.55, phi = -1.04, mass =  0.00
+Simulating Photon
+Made Cluster: et28  :3352895164514304028:    0.51 -0.55 -1.04 sub(et28, )
+Made SmearedCluster: es21  :3343877908318912533:    0.36 -0.55 -1.04 sub(es21, )
+Simulating Particle :ps41  :10261416662766977065: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.69, phi = -1.63, mass =  0.00
+Simulating Photon
+Made Cluster: et29  :3352894834380636189:    0.50 -0.69 -1.63 sub(et29, )
+Made SmearedCluster: es22  :3343896349641801750:    0.75 -0.69 -1.63 sub(es22, )
+Simulating Particle :ps43  :10261416642854518827: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.29, phi = -1.12, mass =  0.00
+Simulating Photon
+Made Cluster: et30  :3352894814468177950:    0.50 -0.29 -1.12 sub(et30, )
+Made SmearedCluster: es23  :3343894324537458711:    0.69 -0.29 -1.12 sub(es23, )
+Simulating Particle :ps44  :10261416199971668012: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.12, phi = -1.54, mass =  0.00
+Simulating Photon
+Made Cluster: et31  :3352894371585327135:    0.49  0.12 -1.54 sub(et31, )
+Made SmearedCluster: es24  :3343887167999967256:    0.49  0.12 -1.54 sub(es24, )
+Simulating Particle :ps45  :10261416118396649517: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.06, phi = -1.34, mass =  0.00
+Simulating Photon
+Made Cluster: et32  :3352894290010308640:    0.49  0.06 -1.34 sub(et32, )
+Made SmearedCluster: es25  :3343877481116467225:    0.36  0.06 -1.34 sub(es25, )
+Simulating Particle :ps46  :10261415871253577774: pdgid =   211, status =   1, q =  1, e =   0.5, theta =  0.80, phi = -0.77, mass =  0.14
+Simulating Hadron
+Made Track: tt19  :7964578633329147923:    0.47    0.33  0.80 -0.77
+Made SmearedTrack: ts16  :7955571485502865424:    0.47    0.33  0.80 -0.77
+Rejected SmearedTrack: ts16  :7955571485502865424:    0.47    0.33  0.80 -0.77
+Made Cluster: ht19  :5658737052080930835:    0.49  1.36 -2.03 sub(ht19, )
+Made SmearedCluster: hs6   :5649789538613067782:    5.41  1.36 -2.03 sub(hs6, )
+Rejected SmearedCluster: hs6   :5649789538613067782:    5.41  1.36 -2.03 sub(hs6, )
+Simulating Particle :ps47  :10261414640263102511: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.06, phi = -1.11, mass =  0.00
+Simulating Photon
+Made Cluster: et33  :3352892811876761633:    0.47  0.06 -1.11 sub(et33, )
+Made SmearedCluster: es26  :3343889840541270042:    0.57  0.06 -1.11 sub(es26, )
+Simulating Particle :ps49  :10261412406022373425: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.39, phi = -1.24, mass =  0.00
+Simulating Photon
+Made Cluster: et34  :3352890577636032546:    0.44  0.39 -1.24 sub(et34, )
+Made SmearedCluster: es27  :3343861926399574043:    0.19  0.39 -1.24 sub(es27, )
+Rejected SmearedCluster: es27  :3343861926399574043:    0.19  0.39 -1.24 sub(es27, )
+Simulating Particle :ps50  :10261410836509622322: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.16, phi = -1.06, mass =  0.00
+Simulating Photon
+Made Cluster: et35  :3352889008123281443:    0.42  0.16 -1.06 sub(et35, )
+Made SmearedCluster: es27  :3343886588860956699:    0.49  0.16 -1.06 sub(es27, )
+Simulating Particle :ps51  :10261408620075810867: pdgid =  -211, status =   1, q = -1, e =   0.4, theta = -0.07, phi = -1.14, mass =  0.14
+Simulating Hadron
+Made Track: tt20  :7964570977803698196:    0.36    0.36 -0.07 -1.14
+Made SmearedTrack: ts16  :7955563744040321040:    0.36    0.36 -0.07 -1.14
+Rejected SmearedTrack: ts16  :7955563744040321040:    0.36    0.36 -0.07 -1.14
+Made Cluster: et36  :3352862935620780068:    0.15 -1.42  1.48 sub(et36, )
+Made SmearedCluster: es28  :3341670923508908060:   -2.96 -1.42  1.48 sub(es28, )
+Rejected SmearedCluster: es28  :3341670923508908060:   -2.96 -1.42  1.48 sub(es28, )
+Made Cluster: ht20  :5658718472601862164:    0.24 -1.38 -0.24 sub(ht20, )
+Made SmearedCluster: hs6   :5647513932722601990:   -8.08 -1.38 -0.24 sub(hs6, )
+Rejected SmearedCluster: hs6   :5647513932722601990:   -8.08 -1.38 -0.24 sub(hs6, )
+Simulating Particle :ps52  :10261407951352758324: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.36, phi = -1.05, mass =  0.00
+Simulating Photon
+Made Cluster: et37  :3352886122966417445:    0.38 -0.36 -1.05 sub(et37, )
+Made SmearedCluster: es28  :3343871626044243996:    0.27 -0.36 -1.05 sub(es28, )
+Rejected SmearedCluster: es28  :3343871626044243996:    0.27 -0.36 -1.05 sub(es28, )
+Simulating Particle :ps53  :10261406940433219637: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.27, phi = -2.55, mass =  0.00
+Simulating Photon
+Made Cluster: et38  :3352885112046878758:    0.36 -0.27 -2.55 sub(et38, )
+Made SmearedCluster: es28  :3343879261856464924:    0.38 -0.27 -2.55 sub(es28, )
+Simulating Particle :ps54  :10261406622309941302: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.35, phi = -0.54, mass =  0.00
+Simulating Photon
+Made Cluster: et39  :3352884793923600423:    0.36 -0.35 -0.54 sub(et39, )
+Made SmearedCluster: es29  :3343830950357237789:    0.06 -0.35 -0.54 sub(es29, )
+Rejected SmearedCluster: es29  :3343830950357237789:    0.06 -0.35 -0.54 sub(es29, )
+Simulating Particle :ps55  :10261406119882653751: pdgid =   211, status =   1, q =  1, e =   0.4, theta = -0.07, phi = -3.03, mass =  0.14
+Simulating Hadron
+Made Track: tt21  :7964568276726448149:    0.32    0.32 -0.07 -3.03
+Made SmearedTrack: ts16  :7955560791193681936:    0.32    0.32 -0.07 -3.03
+Rejected SmearedTrack: ts16  :7955560791193681936:    0.32    0.32 -0.07 -3.03
+Made Cluster: et40  :3352859037570957352:    0.12 -1.32  1.28 sub(et40, )
+Made SmearedCluster: es29  :3343905655300816925:    1.03 -1.32  1.28 sub(es29, )
+Made Cluster: ht21  :5658717112131125269:    0.23 -1.39  2.25 sub(ht21, )
+Made SmearedCluster: hs6   :5647513932722601990:   -8.03 -1.39  2.25 sub(hs6, )
+Rejected SmearedCluster: hs6   :5647513932722601990:   -8.03 -1.39  2.25 sub(hs6, )
+Simulating Particle :ps56  :10261405910865805368: pdgid =  -211, status =   1, q = -1, e =   0.3, theta = -0.18, phi =  2.30, mass =  0.14
+Simulating Hadron
+Made Track: tt22  :7964568048807968790:    0.32    0.31 -0.18  2.30
+Made SmearedTrack: ts16  :7955560917968617488:    0.32    0.32 -0.18  2.30
+Rejected SmearedTrack: ts16  :7955560917968617488:    0.32    0.32 -0.18  2.30
+Made Cluster: et41  :3352872229743362089:    0.22 -1.28 -2.81 sub(et41, )
+Made SmearedCluster: es30  :3343931676146270238:    3.02 -1.28 -2.81 sub(es30, )
+Made Cluster: ht22  :5658703760055074838:    0.13 -1.35 -2.95 sub(ht22, )
+Made SmearedCluster: hs6   :5647513932722601990:   -1.26 -1.35 -2.95 sub(hs6, )
+Rejected SmearedCluster: hs6   :5647513932722601990:   -1.26 -1.35 -2.95 sub(hs6, )
+Simulating Particle :ps57  :10261405343456165945: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.14, phi =  2.95, mass =  0.00
+Simulating Photon
+Made Cluster: et42  :3352883515069825066:    0.34 -0.14  2.95 sub(et42, )
+Made SmearedCluster: es31  :3343867264152633375:    0.23 -0.14  2.95 sub(es31, )
+Rejected SmearedCluster: es31  :3343867264152633375:    0.23 -0.14  2.95 sub(es31, )
+Simulating Particle :ps58  :10261403950401978426: pdgid =   211, status =   1, q =  1, e =   0.3, theta = -0.30, phi = -0.41, mass =  0.14
+Simulating Hadron
+Made Track: tt23  :7964565891306225687:    0.29    0.28 -0.30 -0.41
+Made SmearedTrack: ts16  :7955558682108887056:    0.29    0.28 -0.30 -0.41
+Rejected SmearedTrack: ts16  :7955558682108887056:    0.29    0.28 -0.30 -0.41
+Made Cluster: et43  :3352840264105328683:    0.06 -1.44 -1.00 sub(et43, )
+Made SmearedCluster: es31  :3343908782536130591:    1.21 -1.44 -1.00 sub(es31, )
+Rejected SmearedCluster: es31  :3343908782536130591:    1.21 -1.44 -1.00 sub(es31, )
+Made Cluster: ht23  :5658720945374756887:    0.26 -1.39 -1.80 sub(ht23, )
+Made SmearedCluster: hs6   :5649777450622648326:    3.33 -1.39 -1.80 sub(hs6, )
+Simulating Particle :ps59  :10261403901318135867: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.26, phi =  2.92, mass =  0.00
+Simulating Photon
+Made Cluster: et44  :3352882072931794988:    0.32 -0.26  2.92 sub(et44, )
+Made SmearedCluster: es31  :3343875525165711391:    0.33 -0.26  2.92 sub(es31, )
+Simulating Particle :ps60  :10261403339484823612: pdgid =   211, status =   1, q =  1, e =   0.3, theta = -0.36, phi =  0.44, mass =  0.14
+Simulating Hadron
+Made Track: tt24  :7964565210547617816:    0.28    0.26 -0.36  0.44
+Made SmearedTrack: ts16  :7955557784414584848:    0.28    0.26 -0.36  0.44
+Rejected SmearedTrack: ts16  :7955557784414584848:    0.28    0.26 -0.36  0.44
+Made Cluster: et45  :3352863721780150317:    0.15 -1.38 -1.72 sub(et45, )
+Made SmearedCluster: es32  :3343950414734164000:    6.30 -1.38 -1.72 sub(es32, )
+Made Cluster: ht24  :5658707125258420248:    0.16 -1.46 -2.05 sub(ht24, )
+Made SmearedCluster: hs7   :5647513932722601991:   -3.82 -1.46 -2.05 sub(hs7, )
+Rejected SmearedCluster: hs7   :5647513932722601991:   -3.82 -1.46 -2.05 sub(hs7, )
+Simulating Particle :ps62  :10261398616262311998: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.44, phi =  2.77, mass =  0.00
+Simulating Photon
+Made Cluster: et46  :3352876787875971118:    0.25 -0.44  2.77 sub(et46, )
+Made SmearedCluster: es33  :3343866999978590241:    0.23 -0.44  2.77 sub(es33, )
+Rejected SmearedCluster: es33  :3343866999978590241:    0.23 -0.44  2.77 sub(es33, )
+Simulating Particle :ps63  :10261398368083247167: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.30, phi =  2.67, mass =  0.00
+Simulating Photon
+Made Cluster: et47  :3352876539696906287:    0.25 -0.30  2.67 sub(et47, )
+Made SmearedCluster: es33  :3343859203086221345:    0.17 -0.30  2.67 sub(es33, )
+Rejected SmearedCluster: es33  :3343859203086221345:    0.17 -0.30  2.67 sub(es33, )
+Simulating Particle :ps65  :10261394078222516289: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.02, phi = -0.99, mass =  0.00
+Simulating Photon
+Made Cluster: et48  :3352872249836175408:    0.22  0.02 -0.99 sub(et48, )
+Made SmearedCluster: es33  :3343858103077568545:    0.17  0.02 -0.99 sub(es33, )
+Rejected SmearedCluster: es33  :3343858103077568545:    0.17  0.02 -0.99 sub(es33, )
+Simulating Particle :ps66  :10261393611620876354: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.38, phi = -0.83, mass =  0.00
+Simulating Photon
+Made Cluster: et49  :3352871783234535473:    0.21 -0.38 -0.83 sub(et49, )
+Made SmearedCluster: es33  :3343851792931749921:    0.12 -0.38 -0.83 sub(es33, )
+Rejected SmearedCluster: es33  :3343851792931749921:    0.12 -0.38 -0.83 sub(es33, )
+Simulating Particle :ps68  :10261389810547556420: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.29, phi = -1.86, mass =  0.00
+Simulating Photon
+Made Cluster: et50  :3352867982161215538:    0.18 -0.29 -1.86 sub(et50, )
+Made SmearedCluster: es33  :3343833113395462177:    0.06 -0.29 -1.86 sub(es33, )
+Rejected SmearedCluster: es33  :3343833113395462177:    0.06 -0.29 -1.86 sub(es33, )
+Simulating Particle :ps69  :10261387795792658501: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.76, phi = -0.73, mass =  0.00
+Simulating Photon
+Made Cluster: et51  :3352865967406317619:    0.17  0.76 -0.73 sub(et51, )
+Made SmearedCluster: es33  :3341670923508908065:   -0.09  0.76 -0.73 sub(es33, )
+Rejected SmearedCluster: es33  :3341670923508908065:   -0.09  0.76 -0.73 sub(es33, )
+Simulating Particle :ps70  :10261386872959795270: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.25, phi =  2.81, mass =  0.00
+Simulating Photon
+Made Cluster: et52  :3352865044573454388:    0.16  0.24  2.81 sub(et52, )
+Made SmearedCluster: es33  :3343829834783522849:    0.05  0.24  2.81 sub(es33, )
+Rejected SmearedCluster: es33  :3343829834783522849:    0.05  0.24  2.81 sub(es33, )
+Simulating Particle :ps71  :10261376439953653831: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -1.07, phi =  3.14, mass =  0.00
+Simulating Photon
+Made Cluster: et53  :3352854611567312949:    0.11 -1.07  3.14 sub(et53, )
+Made SmearedCluster: es33  :3343838163272466465:    0.07 -1.07  3.14 sub(es33, )
+Rejected SmearedCluster: es33  :3343838163272466465:    0.07 -1.07  3.14 sub(es33, )
+Simulating Particle :ps72  :10261370039150051400: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.46, phi =  2.67, mass =  0.00
+Simulating Photon
+Made Cluster: et54  :3352848210763710518:    0.08  0.46  2.67 sub(et54, )
+Made SmearedCluster: es33  :3343855921557143585:    0.15  0.46  2.67 sub(es33, )
+Rejected SmearedCluster: es33  :3343855921557143585:    0.15  0.46  2.67 sub(es33, )
+Simulating Particle :ps73  :10261365258144710729: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.58, phi =  2.37, mass =  0.00
+Simulating Photon
+Made Cluster: et55  :3352843429758369847:    0.07 -0.58  2.37 sub(et55, )
+Made SmearedCluster: es33  :3343820918894886945:    0.04 -0.58  2.37 sub(es33, )
+Rejected SmearedCluster: es33  :3343820918894886945:    0.04 -0.58  2.37 sub(es33, )
+Simulating Particle :ps74  :10261364150678585418: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.05, phi =  1.92, mass =  0.00
+Simulating Photon
+Made Cluster: et56  :3352842322292244536:    0.06  0.05  1.92 sub(et56, )
+Made SmearedCluster: es33  :3343864489872195617:    0.21  0.05  1.92 sub(es33, )
+Rejected SmearedCluster: es33  :3343864489872195617:    0.21  0.05  1.92 sub(es33, )
+Simulating Particle :ps75  :10261362047459524683: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.31, phi = -0.38, mass =  0.00
+Simulating Photon
+Made Cluster: et57  :3352840219073183801:    0.06  0.31 -0.38 sub(et57, )
+Made SmearedCluster: es33  :3343826337084211233:    0.05  0.31 -0.38 sub(es33, )
+Rejected SmearedCluster: es33  :3343826337084211233:    0.05  0.31 -0.38 sub(es33, )
+Simulating Particle :ps76  :10261361438771642444: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.05, phi = -1.62, mass =  0.00
+Simulating Photon
+Made Cluster: et58  :3352839610385301562:    0.06  0.05 -1.62 sub(et58, )
+Made SmearedCluster: es33  :3343862397088563233:    0.20  0.05 -1.62 sub(es33, )
+Rejected SmearedCluster: es33  :3343862397088563233:    0.20  0.05 -1.62 sub(es33, )
+Simulating Particle :ps77  :10261360554786422861: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  1.17, phi =  2.57, mass =  0.00
+Simulating Photon
+Made Cluster: et59  :3352838726400081979:    0.06  1.17  2.57 sub(et59, )
+Made SmearedCluster: es33  :3341670923508908065:   -0.11  1.17  2.57 sub(es33, )
+Rejected SmearedCluster: es33  :3341670923508908065:   -0.11  1.17  2.57 sub(es33, )
+Simulating Particle :ps78  :10261355666601934926: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  0.96, phi = -1.14, mass =  0.00
+Simulating Photon
+Made Cluster: et60  :3352833838215594044:    0.05  0.96 -1.14 sub(et60, )
+Made SmearedCluster: es33  :3343874250879533089:    0.31  0.96 -1.14 sub(es33, )
+Simulating Particle :ps79  :10261351772700278863: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.37, phi = -0.18, mass =  0.00
+Simulating Photon
+Made Cluster: et61  :3352829944313937981:    0.04 -0.37 -0.18 sub(et61, )
+Made SmearedCluster: es34  :3341670923508908066:   -0.13 -0.37 -0.18 sub(es34, )
+Rejected SmearedCluster: es34  :3341670923508908066:   -0.13 -0.37 -0.18 sub(es34, )
+Simulating Particle :ps80  :10261350594285404240: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  0.38, phi =  1.79, mass =  0.00
+Simulating Photon
+Made Cluster: et62  :3352828765899063358:    0.04  0.38  1.79 sub(et62, )
+Made SmearedCluster: es34  :3343867289521881122:    0.23  0.38  1.79 sub(es34, )
+Rejected SmearedCluster: es34  :3343867289521881122:    0.23  0.38  1.79 sub(es34, )
+Made MergedCluster: em0   :3289831055351087104:    0.31  0.96 -1.14 sub(es33, )
+Made MergedCluster: em1   :3289832329637265409:    0.33 -0.26  2.92 sub(es31, )
+Made MergedCluster: em2   :3289834285588021250:    0.36  0.06 -1.34 sub(es25, )
+Made MergedCluster: em3   :3289834712790466563:    0.36 -0.55 -1.04 sub(es21, )
+Made MergedCluster: em4   :3289836066328018948:    0.38 -0.27 -2.55 sub(es28, )
+Made MergedCluster: em5   :3289838405348753413:    0.42  0.74  2.17 sub(es19, )
+Made MergedCluster: em6   :3289840631798562822:    0.45  0.39  2.52 sub(es20, )
+Made MergedCluster: em7   :3289843393332510727:    0.49  0.16 -1.06 sub(es27, )
+Made MergedCluster: em8   :3289843972471521288:    0.49  0.12 -1.54 sub(es24, )
+Made MergedCluster: em9   :3289846645012824073:    0.57  0.06 -1.11 sub(es26, )
+Made MergedCluster: em10  :3289881622221946890:    2.24 -0.05  2.69 sub(es12, es17, )
+Made MergedCluster: em11  :3289851129009012747:    0.69 -0.29 -1.12 sub(es23, )
+Made MergedCluster: em12  :3289853154113355788:    0.75 -0.69 -1.63 sub(es22, )
+Made MergedCluster: em13  :3289853964029263885:    0.77 -0.22  2.61 sub(es18, )
+Made MergedCluster: em14  :3289861557827141646:    0.99 -0.12  2.75 sub(es16, )
+Made MergedCluster: em15  :3289862459772370959:    1.03 -1.32  1.28 sub(es29, )
+Made MergedCluster: em16  :3289866216100855824:    1.24 -0.27 -0.72 sub(es11, )
+Made MergedCluster: em17  :3289867703176658961:    1.33 -0.45 -1.04 sub(es14, )
+Made MergedCluster: em18  :3289869344391036946:    1.42  0.62 -1.05 sub(es13, )
+Made MergedCluster: em19  :3289878620706701331:    1.95 -0.57 -0.17 sub(es15, )
+Made MergedCluster: em20  :3289917759766396948:    9.39 -0.36 -1.01 sub(es3, es4, es9, )
+Made MergedCluster: em21  :3289883213540884501:    2.42 -0.24 -1.05 sub(es10, )
+Made MergedCluster: em22  :3289907981302366230:    6.47 -0.19  2.80 sub(es0, es6, )
+Made MergedCluster: em23  :3289885384174993431:    2.67 -0.14  2.56 sub(es2, )
+Made MergedCluster: em24  :3289888480617824280:    3.02 -1.28 -2.81 sub(es30, )
+Made MergedCluster: em25  :3289888730030014489:    3.05 -0.41 -1.20 sub(es7, )
+Made MergedCluster: em26  :3289889273200771098:    3.11 -0.39 -1.07 sub(es5, )
+Made MergedCluster: em27  :3289904265595715611:    5.62  0.00 -0.75 sub(es1, )
+Made MergedCluster: em28  :3289904833737261084:    5.75 -0.19  3.02 sub(es8, )
+Made MergedCluster: em29  :3289907219205718045:    6.30 -1.38 -1.72 sub(es32, )
+Made MergedCluster: hm0   :5595729206785867776:    2.76 -0.54 -0.67 sub(hs2, )
+Made MergedCluster: hm1   :5595734255094202369:    3.33 -1.39 -1.80 sub(hs6, )
+Made MergedCluster: hm2   :5595762093505642498:    9.99 -0.36 -1.09 sub(hs1, hs0, )
+Made MergedCluster: hm3   :5595743610919190531:    4.79 -0.25 -0.37 sub(hs3, )
+Made MergedCluster: hm4   :5595762451510460420:   10.15 -1.33  1.70 sub(hs4, )
+Made MergedCluster: hm5   :5595765780303052805:   11.66  1.50  3.13 sub(hs5, )
+Made block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289831055351087104)
+
+Made block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.3 (3289832329637265409)
+
+Made block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.4 (3289834285588021250)
+
+Made block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.4 (3289834712790466563)
+
+Made block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.4 (3289836066328018948)
+
+Made block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.4 (3289838405348753413)
+
+Made block:E1       :br6   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.4 (3289840631798562822)
+
+Made block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.5 (3289843393332510727)
+
+Made block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.5 (3289843972471521288)
+
+Made block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  0.6 (3289846645012824073)
+
+Made block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  0.7 (3289851129009012747)
+
+Made block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  0.8 (3289853154113355788)
+
+Made block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  0.8 (3289853964029263885)
+
+Made block:E1       :br13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  1.0 (3289861557827141646)
+
+Made block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  1.0 (3289862459772370959)
+
+Made block:E1       :br15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  1.2 (3289866216100855824)
+
+Made block:E1       :br16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  1.3 (3289867703176658961)
+
+Made block:E1       :br17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em18      value=  1.4 (3289869344391036946)
+
+Made block:E1H1T1   :br18  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts14      value=  1.1 (7955592902948683790)
+      h1 = hm4       value= 10.2 (5595762451510460420)
+      e2 = em19      value=  1.9 (3289878620706701331)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1       :br19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  2.2 (3289881622221946890)
+
+Made block:E1       :br20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  2.4 (3289883213540884501)
+
+Made block:E1T1     :br21  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts6       value=  4.9 (7955630394817118214)
+      e1 = em23      value=  2.7 (3289885384174993431)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em24      value=  3.0 (3289888480617824280)
+
+Made block:E1       :br23  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em25      value=  3.0 (3289888730030014489)
+
+Made block:E1       :br24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em26      value=  3.1 (3289889273200771098)
+
+Made block:E1T1     :br25  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 37.9 (7955682357703344129)
+      e1 = em27      value=  5.6 (3289904265595715611)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0177       .
+
+Made block:E1T1     :br26  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  2.5 (7955613361371086858)
+      e1 = em28      value=  5.8 (3289904833737261084)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em29      value=  6.3 (3289907219205718045)
+
+Made block:E1T1     :br28  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts4       value=  8.0 (7955644005954355204)
+      e1 = em22      value=  6.5 (3289907981302366230)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1H1T4   :br29  : ecals = 1 hcals = 1 tracks = 4
+    elements:
+      t0 = ts3       value=  8.4 (7955644897858420739)
+      t1 = ts5       value=  7.0 (7955639328760135685)
+      t2 = ts7       value=  4.6 (7955629133919158279)
+      t3 = ts12      value=  1.6 (7955601440165068812)
+      h4 = hm2       value= 10.0 (5595762093505642498)
+      e5 = em20      value=  9.4 (3289917759766396948)
+    distances:
+              t0      t1      t2      t3      h4      e5
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      t3     ---     ---     ---       .
+      h4  0.0000  0.0518  0.0000  0.1264       .
+      e5     ---     ---  0.0088  0.0078     ---       .
+
+Made block:H1T1     :br30  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  2.8 (7955615398085263369)
+      h1 = hm0       value=  2.8 (5595729206785867776)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1       :br31  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm1       value=  3.3 (5595734255094202369)
+
+Made block:H1T1     :br32  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts11      value=  1.9 (7955606689468645387)
+      h1 = hm3       value=  4.8 (5595743610919190531)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1       :br33  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value= 11.7 (5595765780303052805)
+
+Made block:T1       :br34  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  1.0 (7955591154718736399)
+
+Made block:T1       :br35  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.4 (7955598229314207757)
+
+Made block:T1       :br36  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  3.0 (7955617951218925576)
+
+Made block:T1       :br37  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts2       value=  9.9 (7955648034205859842)
+
+Made block:T1       :br38  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 61.9 (7955695523466313728)
+
+Splitting block:E1H1T4   :br29  : ecals = 1 hcals = 1 tracks = 4
+    elements:
+      t0 = ts3       value=  8.4 (7955644897858420739)
+      t1 = ts5       value=  7.0 (7955639328760135685)
+      t2 = ts7       value=  4.6 (7955629133919158279)
+      t3 = ts12      value=  1.6 (7955601440165068812)
+      h4 = hm2       value= 10.0 (5595762093505642498)
+      e5 = em20      value=  9.4 (3289917759766396948)
+    distances:
+              t0      t1      t2      t3      h4      e5
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      t3     ---     ---     ---       .
+      h4  0.0000  0.0518  0.0000  0.1264       .
+      e5     ---     ---  0.0088  0.0078     ---       .
+
+Made block:E1H1T4   :bs0   : ecals = 1 hcals = 1 tracks = 4
+    elements:
+      t0 = ts3       value=  8.4 (7955644897858420739)
+      t1 = ts5       value=  7.0 (7955639328760135685)
+      t2 = ts7       value=  4.6 (7955629133919158279)
+      t3 = ts12      value=  1.6 (7955601440165068812)
+      h4 = hm2       value= 10.0 (5595762093505642498)
+      e5 = em20      value=  9.4 (3289917759766396948)
+    distances:
+              t0      t1      t2      t3      h4      e5
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      t3     ---     ---     ---       .
+      h4  0.0000  0.0518  0.0000  0.1264       .
+      e5     ---     ---  0.0088  0.0078     ---       .
+
+Splitting block:E1H1T1   :br18  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts14      value=  1.1 (7955592902948683790)
+      h1 = hm4       value= 10.2 (5595762451510460420)
+      e2 = em19      value=  1.9 (3289878620706701331)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs1   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts14      value=  1.1 (7955592902948683790)
+      h1 = hm4       value= 10.2 (5595762451510460420)
+      e2 = em19      value=  1.9 (3289878620706701331)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:H1T1     :br32  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts11      value=  1.9 (7955606689468645387)
+      h1 = hm3       value=  4.8 (5595743610919190531)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs2   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts11      value=  1.9 (7955606689468645387)
+      h1 = hm3       value=  4.8 (5595743610919190531)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br30  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  2.8 (7955615398085263369)
+      h1 = hm0       value=  2.8 (5595729206785867776)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs3   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  2.8 (7955615398085263369)
+      h1 = hm0       value=  2.8 (5595729206785867776)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:E1T1     :br28  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts4       value=  8.0 (7955644005954355204)
+      e1 = em22      value=  6.5 (3289907981302366230)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs4   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts4       value=  8.0 (7955644005954355204)
+      e1 = em22      value=  6.5 (3289907981302366230)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br26  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  2.5 (7955613361371086858)
+      e1 = em28      value=  5.8 (3289904833737261084)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs5   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  2.5 (7955613361371086858)
+      e1 = em28      value=  5.8 (3289904833737261084)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br25  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 37.9 (7955682357703344129)
+      e1 = em27      value=  5.6 (3289904265595715611)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0177       .
+
+Made block:E1T1     :bs6   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 37.9 (7955682357703344129)
+      e1 = em27      value=  5.6 (3289904265595715611)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0177       .
+
+Splitting block:E1T1     :br21  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts6       value=  4.9 (7955630394817118214)
+      e1 = em23      value=  2.7 (3289885384174993431)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs7   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts6       value=  4.9 (7955630394817118214)
+      e1 = em23      value=  2.7 (3289885384174993431)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:T1       :br38  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 61.9 (7955695523466313728)
+
+Made block:T1       :bs8   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 61.9 (7955695523466313728)
+
+Splitting block:T1       :br37  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts2       value=  9.9 (7955648034205859842)
+
+Made block:T1       :bs9   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts2       value=  9.9 (7955648034205859842)
+
+Splitting block:T1       :br36  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  3.0 (7955617951218925576)
+
+Made block:T1       :bs10  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  3.0 (7955617951218925576)
+
+Splitting block:T1       :br35  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.4 (7955598229314207757)
+
+Made block:T1       :bs11  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.4 (7955598229314207757)
+
+Splitting block:T1       :br34  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  1.0 (7955591154718736399)
+
+Made block:T1       :bs12  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  1.0 (7955591154718736399)
+
+Splitting block:H1       :br33  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value= 11.7 (5595765780303052805)
+
+Made block:H1       :bs13  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value= 11.7 (5595765780303052805)
+
+Splitting block:H1       :br31  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm1       value=  3.3 (5595734255094202369)
+
+Made block:H1       :bs14  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm1       value=  3.3 (5595734255094202369)
+
+Splitting block:E1       :br27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em29      value=  6.3 (3289907219205718045)
+
+Made block:E1       :bs15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em29      value=  6.3 (3289907219205718045)
+
+Splitting block:E1       :br24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em26      value=  3.1 (3289889273200771098)
+
+Made block:E1       :bs16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em26      value=  3.1 (3289889273200771098)
+
+Splitting block:E1       :br23  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em25      value=  3.0 (3289888730030014489)
+
+Made block:E1       :bs17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em25      value=  3.0 (3289888730030014489)
+
+Splitting block:E1       :br22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em24      value=  3.0 (3289888480617824280)
+
+Made block:E1       :bs18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em24      value=  3.0 (3289888480617824280)
+
+Splitting block:E1       :br20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  2.4 (3289883213540884501)
+
+Made block:E1       :bs19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  2.4 (3289883213540884501)
+
+Splitting block:E1       :br19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  2.2 (3289881622221946890)
+
+Made block:E1       :bs20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  2.2 (3289881622221946890)
+
+Splitting block:E1       :br17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em18      value=  1.4 (3289869344391036946)
+
+Made block:E1       :bs21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em18      value=  1.4 (3289869344391036946)
+
+Splitting block:E1       :br16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  1.3 (3289867703176658961)
+
+Made block:E1       :bs22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  1.3 (3289867703176658961)
+
+Splitting block:E1       :br15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  1.2 (3289866216100855824)
+
+Made block:E1       :bs23  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  1.2 (3289866216100855824)
+
+Splitting block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  1.0 (3289862459772370959)
+
+Made block:E1       :bs24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  1.0 (3289862459772370959)
+
+Splitting block:E1       :br13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  1.0 (3289861557827141646)
+
+Made block:E1       :bs25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  1.0 (3289861557827141646)
+
+Splitting block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  0.8 (3289853964029263885)
+
+Made block:E1       :bs26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  0.8 (3289853964029263885)
+
+Splitting block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  0.8 (3289853154113355788)
+
+Made block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  0.8 (3289853154113355788)
+
+Splitting block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  0.7 (3289851129009012747)
+
+Made block:E1       :bs28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  0.7 (3289851129009012747)
+
+Splitting block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  0.6 (3289846645012824073)
+
+Made block:E1       :bs29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  0.6 (3289846645012824073)
+
+Splitting block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.5 (3289843972471521288)
+
+Made block:E1       :bs30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.5 (3289843972471521288)
+
+Splitting block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.5 (3289843393332510727)
+
+Made block:E1       :bs31  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.5 (3289843393332510727)
+
+Splitting block:E1       :br6   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.4 (3289840631798562822)
+
+Made block:E1       :bs32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.4 (3289840631798562822)
+
+Splitting block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.4 (3289838405348753413)
+
+Made block:E1       :bs33  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.4 (3289838405348753413)
+
+Splitting block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.4 (3289836066328018948)
+
+Made block:E1       :bs34  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.4 (3289836066328018948)
+
+Splitting block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.4 (3289834712790466563)
+
+Made block:E1       :bs35  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.4 (3289834712790466563)
+
+Splitting block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.4 (3289834285588021250)
+
+Made block:E1       :bs36  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.4 (3289834285588021250)
+
+Splitting block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.3 (3289832329637265409)
+
+Made block:E1       :bs37  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.3 (3289832329637265409)
+
+Splitting block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289831055351087104)
+
+Made block:E1       :bs38  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289831055351087104)
+
+Processing block:E1H1T4   :bs0   : ecals = 1 hcals = 1 tracks = 4
+    elements:
+      t0 = ts3       value=  8.4 (7955644897858420739)
+      t1 = ts5       value=  7.0 (7955639328760135685)
+      t2 = ts7       value=  4.6 (7955629133919158279)
+      t3 = ts12      value=  1.6 (7955601440165068812)
+      h4 = hm2       value= 10.0 (5595762093505642498)
+      e5 = em20      value=  9.4 (3289917759766396948)
+    distances:
+              t0      t1      t2      t3      h4      e5
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      t3     ---     ---     ---       .
+      h4  0.0000  0.0518  0.0000  0.1264       .
+      e5     ---     ---  0.0088  0.0078     ---       .
+
+Made Particle :pr0   :10252480710333956096: pdgid =   211, status =   1, q =  1, e =   8.4, theta = -0.40, phi = -1.03, mass =  0.14 from SmearedTrack: ts3   :7955644897858420739:    8.44    7.78 -0.40 -1.03
+Made Particle :pr1   :10252475144825995265: pdgid =   211, status =   1, q =  1, e =   7.0, theta = -0.42, phi = -1.01, mass =  0.14 from SmearedTrack: ts5   :7955639328760135685:    6.95    6.36 -0.42 -1.01
+Made Particle :pr2   :10252464953040568322: pdgid =  -211, status =   1, q = -1, e =   4.6, theta = -0.31, phi = -1.07, mass =  0.14 from SmearedTrack: ts7   :7955629133919158279:    4.64    4.42 -0.31 -1.07
+Made Particle :pr3   :10252437357145882627: pdgid =   211, status =   1, q =  1, e =   1.6, theta = -0.38, phi = -0.95, mass =  0.14 from SmearedTrack: ts12  :7955601440165068812:    1.58    1.47 -0.38 -0.95
+Finished block
+Processing block:E1H1T1   :bs1   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts14      value=  1.1 (7955592902948683790)
+      h1 = hm4       value= 10.2 (5595762451510460420)
+      e2 = em19      value=  1.9 (3289878620706701331)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr4   :10252428866840690692: pdgid =  -211, status =   1, q = -1, e =   1.1, theta = -0.51, phi = -1.05, mass =  0.14 from SmearedTrack: ts14  :7955592902948683790:    1.10    0.96 -0.51 -1.05
+Finished block
+Processing block:E1T1     :bs7   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts6       value=  4.9 (7955630394817118214)
+      e1 = em23      value=  2.7 (3289885384174993431)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr5   :10252466213403754501: pdgid =   211, status =   1, q =  1, e =   4.9, theta = -0.14, phi =  2.71, mass =  0.14 from SmearedTrack: ts6   :7955630394817118214:    4.92    4.87 -0.14  2.71
+Finished block
+Processing block:E1T1     :bs6   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 37.9 (7955682357703344129)
+      e1 = em27      value=  5.6 (3289904265595715611)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0177       .
+
+Made Particle :pr6   :10252518167741988870: pdgid =    13, status =   1, q =  1, e =  37.9, theta =  0.01, phi = -0.75, mass =  0.11 from SmearedTrack: ts1   :7955682357703344129:   37.91   37.91  0.01 -0.75
+Made Particle :pr7   :10252469289510502407: pdgid =    22, status =   1, q =  0, e =   5.6, theta =  0.00, phi = -0.75, mass =  0.00 from MergedCluster: em27  :3289904265595715611:    5.62  0.00 -0.75 sub(es1, )
+Finished block
+Processing block:E1T1     :bs5   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  2.5 (7955613361371086858)
+      e1 = em28      value=  5.8 (3289904833737261084)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr8   :10252449204955774984: pdgid =  -211, status =   1, q = -1, e =   2.5, theta = -0.19, phi =  2.71, mass =  0.14 from SmearedTrack: ts10  :7955613361371086858:    2.53    2.48 -0.19  2.71
+Finished block
+Processing block:E1T1     :bs4   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts4       value=  8.0 (7955644005954355204)
+      e1 = em22      value=  6.5 (3289907981302366230)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr9   :10252479818557816841: pdgid =  -211, status =   1, q = -1, e =   8.0, theta = -0.21, phi =  2.74, mass =  0.14 from SmearedTrack: ts4   :7955644005954355204:    8.04    7.85 -0.21  2.74
+Finished block
+Processing block:H1T1     :bs3   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  2.8 (7955615398085263369)
+      h1 = hm0       value=  2.8 (5595729206785867776)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr10  :10252451238849282058: pdgid =  -211, status =   1, q = -1, e =   2.8, theta = -0.53, phi = -1.14, mass =  0.14 from SmearedTrack: ts9   :7955615398085263369:    2.76    2.38 -0.53 -1.14
+Finished block
+Processing block:H1T1     :bs2   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts11      value=  1.9 (7955606689468645387)
+      h1 = hm3       value=  4.8 (5595743610919190531)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr11  :10252442589542219787: pdgid =  -211, status =   1, q = -1, e =   1.9, theta = -0.23, phi = -1.00, mass =  0.14 from SmearedTrack: ts11  :7955606689468645387:    1.88    1.83 -0.23 -1.00
+Finished block
+Processing block:E1       :bs38  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289831055351087104)
+
+Made Particle :pr12  :10252396079265873932: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.96, phi = -1.14, mass =  0.00 from MergedCluster: em0   :3289831055351087104:    0.31  0.96 -1.14 sub(es33, )
+Finished block
+Processing block:E1       :bs37  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.3 (3289832329637265409)
+
+Made Particle :pr13  :10252397353552052237: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.26, phi =  2.92, mass =  0.00 from MergedCluster: em1   :3289832329637265409:    0.33 -0.26  2.92 sub(es31, )
+Finished block
+Processing block:E1       :bs36  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.4 (3289834285588021250)
+
+Made Particle :pr14  :10252399309502808078: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.06, phi = -1.34, mass =  0.00 from MergedCluster: em2   :3289834285588021250:    0.36  0.06 -1.34 sub(es25, )
+Finished block
+Processing block:E1       :bs35  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.4 (3289834712790466563)
+
+Made Particle :pr15  :10252399736705253391: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.55, phi = -1.04, mass =  0.00 from MergedCluster: em3   :3289834712790466563:    0.36 -0.55 -1.04 sub(es21, )
+Finished block
+Processing block:E1       :bs34  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.4 (3289836066328018948)
+
+Made Particle :pr16  :10252401090242805776: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.27, phi = -2.55, mass =  0.00 from MergedCluster: em4   :3289836066328018948:    0.38 -0.27 -2.55 sub(es28, )
+Finished block
+Processing block:E1       :bs33  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.4 (3289838405348753413)
+
+Made Particle :pr17  :10252403429263540241: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.74, phi =  2.17, mass =  0.00 from MergedCluster: em5   :3289838405348753413:    0.42  0.74  2.17 sub(es19, )
+Finished block
+Processing block:E1       :bs32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.4 (3289840631798562822)
+
+Made Particle :pr18  :10252405655713349650: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.39, phi =  2.52, mass =  0.00 from MergedCluster: em6   :3289840631798562822:    0.45  0.39  2.52 sub(es20, )
+Finished block
+Processing block:E1       :bs31  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.5 (3289843393332510727)
+
+Made Particle :pr19  :10252408417247297555: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.16, phi = -1.06, mass =  0.00 from MergedCluster: em7   :3289843393332510727:    0.49  0.16 -1.06 sub(es27, )
+Finished block
+Processing block:E1       :bs30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.5 (3289843972471521288)
+
+Made Particle :pr20  :10252408996386308116: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.12, phi = -1.54, mass =  0.00 from MergedCluster: em8   :3289843972471521288:    0.49  0.12 -1.54 sub(es24, )
+Finished block
+Processing block:E1       :bs29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  0.6 (3289846645012824073)
+
+Made Particle :pr21  :10252411668927610901: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.06, phi = -1.11, mass =  0.00 from MergedCluster: em9   :3289846645012824073:    0.57  0.06 -1.11 sub(es26, )
+Finished block
+Processing block:E1       :bs28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  0.7 (3289851129009012747)
+
+Made Particle :pr22  :10252416152923799574: pdgid =    22, status =   1, q =  0, e =   0.7, theta = -0.29, phi = -1.12, mass =  0.00 from MergedCluster: em11  :3289851129009012747:    0.69 -0.29 -1.12 sub(es23, )
+Finished block
+Processing block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  0.8 (3289853154113355788)
+
+Made Particle :pr23  :10252418178028142615: pdgid =    22, status =   1, q =  0, e =   0.8, theta = -0.69, phi = -1.63, mass =  0.00 from MergedCluster: em12  :3289853154113355788:    0.75 -0.69 -1.63 sub(es22, )
+Finished block
+Processing block:E1       :bs26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  0.8 (3289853964029263885)
+
+Made Particle :pr24  :10252418987944050712: pdgid =    22, status =   1, q =  0, e =   0.8, theta = -0.22, phi =  2.61, mass =  0.00 from MergedCluster: em13  :3289853964029263885:    0.77 -0.22  2.61 sub(es18, )
+Finished block
+Processing block:E1       :bs25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  1.0 (3289861557827141646)
+
+Made Particle :pr25  :10252426581741928473: pdgid =    22, status =   1, q =  0, e =   1.0, theta = -0.12, phi =  2.75, mass =  0.00 from MergedCluster: em14  :3289861557827141646:    0.99 -0.12  2.75 sub(es16, )
+Finished block
+Processing block:E1       :bs24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  1.0 (3289862459772370959)
+
+Made Particle :pr26  :10252427483687157786: pdgid =    22, status =   1, q =  0, e =   1.0, theta = -1.32, phi =  1.28, mass =  0.00 from MergedCluster: em15  :3289862459772370959:    1.03 -1.32  1.28 sub(es29, )
+Finished block
+Processing block:E1       :bs23  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  1.2 (3289866216100855824)
+
+Made Particle :pr27  :10252431240015642651: pdgid =    22, status =   1, q =  0, e =   1.2, theta = -0.27, phi = -0.72, mass =  0.00 from MergedCluster: em16  :3289866216100855824:    1.24 -0.27 -0.72 sub(es11, )
+Finished block
+Processing block:E1       :bs22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  1.3 (3289867703176658961)
+
+Made Particle :pr28  :10252432727091445788: pdgid =    22, status =   1, q =  0, e =   1.3, theta = -0.45, phi = -1.04, mass =  0.00 from MergedCluster: em17  :3289867703176658961:    1.33 -0.45 -1.04 sub(es14, )
+Finished block
+Processing block:E1       :bs21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em18      value=  1.4 (3289869344391036946)
+
+Made Particle :pr29  :10252434368305823773: pdgid =    22, status =   1, q =  0, e =   1.4, theta =  0.62, phi = -1.05, mass =  0.00 from MergedCluster: em18  :3289869344391036946:    1.42  0.62 -1.05 sub(es13, )
+Finished block
+Processing block:E1       :bs20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  2.2 (3289881622221946890)
+
+Made Particle :pr30  :10252446646136733726: pdgid =    22, status =   1, q =  0, e =   2.2, theta = -0.05, phi =  2.69, mass =  0.00 from MergedCluster: em10  :3289881622221946890:    2.24 -0.05  2.69 sub(es12, es17, )
+Finished block
+Processing block:E1       :bs19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  2.4 (3289883213540884501)
+
+Made Particle :pr31  :10252448237455671327: pdgid =    22, status =   1, q =  0, e =   2.4, theta = -0.24, phi = -1.05, mass =  0.00 from MergedCluster: em21  :3289883213540884501:    2.42 -0.24 -1.05 sub(es10, )
+Finished block
+Processing block:E1       :bs18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em24      value=  3.0 (3289888480617824280)
+
+Made Particle :pr32  :10252453504532611104: pdgid =    22, status =   1, q =  0, e =   3.0, theta = -1.28, phi = -2.81, mass =  0.00 from MergedCluster: em24  :3289888480617824280:    3.02 -1.28 -2.81 sub(es30, )
+Finished block
+Processing block:E1       :bs17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em25      value=  3.0 (3289888730030014489)
+
+Made Particle :pr33  :10252453753944801313: pdgid =    22, status =   1, q =  0, e =   3.0, theta = -0.41, phi = -1.20, mass =  0.00 from MergedCluster: em25  :3289888730030014489:    3.05 -0.41 -1.20 sub(es7, )
+Finished block
+Processing block:E1       :bs16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em26      value=  3.1 (3289889273200771098)
+
+Made Particle :pr34  :10252454297115557922: pdgid =    22, status =   1, q =  0, e =   3.1, theta = -0.39, phi = -1.07, mass =  0.00 from MergedCluster: em26  :3289889273200771098:    3.11 -0.39 -1.07 sub(es5, )
+Finished block
+Processing block:E1       :bs15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em29      value=  6.3 (3289907219205718045)
+
+Made Particle :pr35  :10252472243120504867: pdgid =    22, status =   1, q =  0, e =   6.3, theta = -1.38, phi = -1.72, mass =  0.00 from MergedCluster: em29  :3289907219205718045:    6.30 -1.38 -1.72 sub(es32, )
+Finished block
+Processing block:H1       :bs14  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm1       value=  3.3 (5595734255094202369)
+
+Made Particle :pr36  :10252456269795295268: pdgid =   130, status =   1, q =  0, e =   3.3, theta = -1.39, phi = -1.80, mass =  0.50 from MergedCluster: hm1   :5595734255094202369:    3.33 -1.39 -1.80 sub(hs6, )
+Finished block
+Processing block:H1       :bs13  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value= 11.7 (5595765780303052805)
+
+Made Particle :pr37  :10252487795004145701: pdgid =   130, status =   1, q =  0, e =  11.7, theta =  1.50, phi =  3.13, mass =  0.50 from MergedCluster: hm5   :5595765780303052805:   11.66  1.50  3.13 sub(hs5, )
+Finished block
+Processing block:T1       :bs12  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  1.0 (7955591154718736399)
+
+Made Particle :pr38  :10252427133764763686: pdgid =   211, status =   1, q =  1, e =   1.0, theta = -0.52, phi = -1.23, mass =  0.14 from SmearedTrack: ts15  :7955591154718736399:    1.00    0.87 -0.52 -1.23
+Finished block
+Processing block:T1       :bs11  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.4 (7955598229314207757)
+
+Made Particle :pr39  :10252434160159293479: pdgid =   211, status =   1, q =  1, e =   1.4, theta = -0.13, phi =  2.69, mass =  0.14 from SmearedTrack: ts13  :7955598229314207757:    1.40    1.39 -0.13  2.69
+Finished block
+Processing block:T1       :bs10  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  3.0 (7955617951218925576)
+
+Made Particle :pr40  :10252453789051125800: pdgid =  -211, status =   1, q = -1, e =   3.1, theta = -0.26, phi = -1.23, mass =  0.14 from SmearedTrack: ts8   :7955617951218925576:    3.05    2.95 -0.26 -1.23
+Finished block
+Processing block:T1       :bs9   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts2       value=  9.9 (7955648034205859842)
+
+Made Particle :pr41  :10252483845393743913: pdgid =    13, status =   1, q =  1, e =   9.9, theta = -0.26, phi =  2.91, mass =  0.11 from SmearedTrack: ts2   :7955648034205859842:    9.87    9.55 -0.26  2.91
+Finished block
+Processing block:T1       :bs8   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 61.9 (7955695523466313728)
+
+Made Particle :pr42  :10252531333473501226: pdgid =   -13, status =   1, q = -1, e =  61.9, theta =  0.48, phi =  1.52, mass =  0.10 from SmearedTrack: ts0   :7955695523466313728:   61.86   54.74  0.48  1.52
+Finished block
+Finished reconstruction
+Event: 2
+Made Particle :ps0   :10261535975219920896: pdgid =    13, status =   1, q = -1, e =  57.2, theta =  0.50, phi =  0.44, mass =  0.11
+Made Particle :ps1   :10261529332111376385: pdgid =   -13, status =   1, q =  1, e =  45.1, theta = -0.26, phi = -1.44, mass =  0.11
+Made Particle :ps2   :10261512631124754434: pdgid =    22, status =   1, q =  0, e =  23.4, theta =  0.24, phi =  2.75, mass =  0.00
+Made Particle :ps3   :10261491649794277379: pdgid =  -211, status =   1, q = -1, e =  10.1, theta =  0.14, phi =  2.80, mass =  0.14
+Made Particle :ps4   :10261487801935593476: pdgid =    22, status =   1, q =  0, e =   8.4, theta =  0.16, phi =  2.81, mass =  0.00
+Made Particle :ps5   :10261487264464896005: pdgid =    22, status =   1, q =  0, e =   8.1, theta =  0.25, phi =  2.75, mass =  0.00
+Made Particle :ps6   :10261484759574118406: pdgid =  -321, status =   1, q = -1, e =   7.5, theta = -0.65, phi = -0.21, mass =  0.49
+Made Particle :ps7   :10261484072198995975: pdgid =    22, status =   1, q =  0, e =   7.3, theta =  0.07, phi =  2.61, mass =  0.00
+Made Particle :ps8   :10261482093777256456: pdgid =   211, status =   1, q =  1, e =   6.9, theta =  0.19, phi =  2.90, mass =  0.14
+Made Particle :ps9   :10261471955274170377: pdgid =    22, status =   1, q =  0, e =   4.6, theta =  0.12, phi =  2.46, mass =  0.00
+Made Particle :ps10  :10261471324419391498: pdgid =  -211, status =   1, q = -1, e =   4.5, theta =  0.19, phi =  2.86, mass =  0.14
+Made Particle :ps11  :10261470026156474379: pdgid =  -211, status =   1, q = -1, e =   4.2, theta = -0.70, phi = -0.37, mass =  0.14
+Made Particle :ps12  :10261467779628531724: pdgid =   130, status =   1, q =  0, e =   3.8, theta = -0.74, phi = -0.27, mass =  0.50
+Made Particle :ps13  :10261465629676535821: pdgid =  -211, status =   1, q = -1, e =   3.6, theta = -0.54, phi = -0.31, mass =  0.14
+Made Particle :ps14  :10261464348463464462: pdgid =   321, status =   1, q =  1, e =   3.4, theta = -0.70, phi = -0.47, mass =  0.49
+Made Particle :ps15  :10261461985210138639: pdgid =    22, status =   1, q =  0, e =   3.2, theta =  0.11, phi =  2.43, mass =  0.00
+Made Particle :ps16  :10261460641971699728: pdgid =   211, status =   1, q =  1, e =   3.0, theta = -0.60, phi = -0.45, mass =  0.14
+Made Particle :ps17  :10261457419095769105: pdgid =    22, status =   1, q =  0, e =   2.6, theta = -0.76, phi = -0.32, mass =  0.00
+Made Particle :ps18  :10261457253433344018: pdgid =    22, status =   1, q =  0, e =   2.6, theta = -0.61, phi =  3.12, mass =  0.00
+Made Particle :ps19  :10261455735757996051: pdgid =    22, status =   1, q =  0, e =   2.5, theta = -0.61, phi = -0.40, mass =  0.00
+Made Particle :ps20  :10261451390867996692: pdgid =   211, status =   1, q =  1, e =   2.0, theta =  0.16, phi =  2.73, mass =  0.14
+Made Particle :ps21  :10261445004775915541: pdgid =   211, status =   1, q =  1, e =   1.6, theta = -0.82, phi = -0.36, mass =  0.14
+Made Particle :ps22  :10261443114858184726: pdgid =    22, status =   1, q =  0, e =   1.5, theta = -0.67, phi = -0.31, mass =  0.00
+Made Particle :ps23  :10261443083914706967: pdgid =   211, status =   1, q =  1, e =   1.5, theta = -0.76, phi = -0.30, mass =  0.14
+Made Particle :ps24  :10261442909863673880: pdgid =  -211, status =   1, q = -1, e =   1.5, theta =  0.21, phi =  2.70, mass =  0.14
+Made Particle :ps25  :10261438909963567129: pdgid =   211, status =   1, q =  1, e =   1.3, theta = -0.14, phi =  2.89, mass =  0.14
+Made Particle :ps26  :10261437589294678042: pdgid =    22, status =   1, q =  0, e =   1.2, theta =  0.02, phi =  2.93, mass =  0.00
+Made Particle :ps27  :10261436722038439963: pdgid =    22, status =   1, q =  0, e =   1.1, theta = -0.71, phi =  3.07, mass =  0.00
+Made Particle :ps28  :10261436413492854812: pdgid =    22, status =   1, q =  0, e =   1.1, theta = -0.79, phi = -0.23, mass =  0.00
+Made Particle :ps29  :10261436236665192477: pdgid =    22, status =   1, q =  0, e =   1.1, theta =  0.12, phi =  2.81, mass =  0.00
+Made Particle :ps30  :10261436130182299678: pdgid =   211, status =   1, q =  1, e =   1.1, theta = -0.61, phi = -0.92, mass =  0.14
+Made Particle :ps31  :10261434548866777119: pdgid =    22, status =   1, q =  0, e =   1.0, theta = -0.58, phi = -3.07, mass =  0.00
+Made Particle :ps32  :10261433842193661984: pdgid =    22, status =   1, q =  0, e =   1.0, theta = -0.42, phi = -0.07, mass =  0.00
+Made Particle :ps33  :10261433813569634337: pdgid =    22, status =   1, q =  0, e =   1.0, theta = -0.68, phi = -0.34, mass =  0.00
+Made Particle :ps34  :10261431755399495714: pdgid =    22, status =   1, q =  0, e =   0.9, theta =  0.37, phi =  2.90, mass =  0.00
+Made Particle :ps35  :10261429365449424931: pdgid =    22, status =   1, q =  0, e =   0.9, theta = -0.71, phi = -0.33, mass =  0.00
+Made Particle :ps36  :10261429338654113828: pdgid =    22, status =   1, q =  0, e =   0.9, theta = -0.57, phi = -0.24, mass =  0.00
+Made Particle :ps37  :10261428084626423845: pdgid =  -211, status =   1, q = -1, e =   0.8, theta = -1.08, phi =  0.81, mass =  0.14
+Made Particle :ps38  :10261425284882366502: pdgid =   211, status =   1, q =  1, e =   0.7, theta =  0.04, phi =  2.86, mass =  0.14
+Made Particle :ps39  :10261423917751074855: pdgid =  -211, status =   1, q = -1, e =   0.7, theta = -0.41, phi = -2.99, mass =  0.14
+Made Particle :ps40  :10261421557058371624: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.26, phi =  2.83, mass =  0.00
+Made Particle :ps41  :10261417804867567657: pdgid =  -211, status =   1, q = -1, e =   0.5, theta = -0.03, phi =  2.84, mass =  0.14
+Made Particle :ps42  :10261416577991704618: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.80, phi =  0.22, mass =  0.00
+Made Particle :ps43  :10261416479326994475: pdgid =  -211, status =   1, q = -1, e =   0.5, theta = -0.44, phi = -1.48, mass =  0.14
+Made Particle :ps44  :10261415204292132908: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.83, phi = -0.35, mass =  0.00
+Made Particle :ps45  :10261413296393420845: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.57, phi = -0.22, mass =  0.00
+Made Particle :ps46  :10261405678669135918: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.79, phi = -0.25, mass =  0.00
+Made Particle :ps47  :10261402429268426799: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.50, phi = -3.11, mass =  0.00
+Made Particle :ps48  :10261402378360062000: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.61, phi = -0.49, mass =  0.00
+Made Particle :ps49  :10261399060011286577: pdgid =   211, status =   1, q =  1, e =   0.3, theta = -0.71, phi =  2.31, mass =  0.14
+Made Particle :ps50  :10261394495188762674: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.89, phi =  0.14, mass =  0.00
+Made Particle :ps51  :10261389229011501107: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.00, phi =  2.70, mass =  0.00
+Made Particle :ps52  :10261381954599387188: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.02, phi =  2.59, mass =  0.00
+Made Particle :ps53  :10261352414030331957: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  0.89, phi =  2.31, mass =  0.00
+Made Particle :ps54  :10261349092034609206: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.46, phi = -2.49, mass =  0.00
+Made Particle :ps55  :10261254474039296055: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.46, phi = -1.35, mass =  0.00
+Simulating Particle :ps0   :10261535975219920896: pdgid =    13, status =   1, q = -1, e =  57.2, theta =  0.50, phi =  0.44, mass =  0.11
+Simulating Muon
+Made Track: tt0   :7964700165206441984:   57.20   50.07  0.50  0.44
+Made SmearedTrack: ts0   :7955692883646873600:   57.05   49.94  0.50  0.44
+Simulating Particle :ps1   :10261529332111376385: pdgid =   -13, status =   1, q =  1, e =  45.1, theta = -0.26, phi = -1.44, mass =  0.11
+Simulating Muon
+Made Track: tt1   :7964693522085314561:   45.12   43.66 -0.26 -1.44
+Made SmearedTrack: ts1   :7955686987520802817:   46.33   44.83 -0.26 -1.44
+Simulating Particle :ps2   :10261512631124754434: pdgid =    22, status =   1, q =  0, e =  23.4, theta =  0.24, phi =  2.75, mass =  0.00
+Simulating Photon
+Made Cluster: et0   :3352990802738413568:   23.37  0.24  2.75 sub(et0, )
+Made SmearedCluster: es0   :3343983519601786880:   23.29  0.24  2.75 sub(es0, )
+Simulating Particle :ps3   :10261491649794277379: pdgid =  -211, status =   1, q = -1, e =  10.1, theta =  0.14, phi =  2.80, mass =  0.14
+Simulating Hadron
+Made Track: tt2   :7964655837723492354:   10.14   10.04  0.14  2.80
+Made SmearedTrack: ts2   :7955648440134795266:   10.05    9.95  0.14  2.80
+Made Cluster: ht0   :5658812830621630464:   10.14  0.15  2.91 sub(ht0, )
+Made SmearedCluster: hs0   :5649800976073228288:    8.03  0.15  2.91 sub(hs0, )
+Simulating Particle :ps4   :10261487801935593476: pdgid =    22, status =   1, q =  0, e =   8.4, theta =  0.16, phi =  2.81, mass =  0.00
+Simulating Photon
+Made Cluster: et1   :3352965973549252609:    8.39  0.16  2.81 sub(et1, )
+Made SmearedCluster: es1   :3343958481488052225:    8.26  0.16  2.81 sub(es1, )
+Simulating Particle :ps5   :10261487264464896005: pdgid =    22, status =   1, q =  0, e =   8.1, theta =  0.25, phi =  2.75, mass =  0.00
+Simulating Photon
+Made Cluster: et2   :3352965436078555138:    8.15  0.25  2.75 sub(et2, )
+Made SmearedCluster: es2   :3343958456525651970:    8.25  0.25  2.75 sub(es2, )
+Simulating Particle :ps6   :10261484759574118406: pdgid =  -321, status =   1, q = -1, e =   7.5, theta = -0.65, phi = -0.21, mass =  0.49
+Simulating Hadron
+Made Track: tt3   :7964648878129545219:    7.49    5.98 -0.65 -0.21
+Made SmearedTrack: ts3   :7955641978884980739:    7.56    6.04 -0.65 -0.21
+Made Cluster: et3   :3352932031846678531:    2.24 -0.65 -0.08 sub(et3, )
+Made SmearedCluster: es3   :3343941298370379779:    4.22 -0.65 -0.08 sub(es3, )
+Made Cluster: ht1   :5658796089675874305:    5.27 -0.65 -0.02 sub(ht1, )
+Made SmearedCluster: hs1   :5649789712527785985:    5.45 -0.65 -0.02 sub(hs1, )
+Simulating Particle :ps7   :10261484072198995975: pdgid =    22, status =   1, q =  0, e =   7.3, theta =  0.07, phi =  2.61, mass =  0.00
+Simulating Photon
+Made Cluster: et4   :3352962243812655108:    7.35  0.07  2.61 sub(et4, )
+Made SmearedCluster: es4   :3343953410406744068:    6.98  0.07  2.61 sub(es4, )
+Simulating Particle :ps8   :10261482093777256456: pdgid =   211, status =   1, q =  1, e =   6.9, theta =  0.19, phi =  2.90, mass =  0.14
+Simulating Hadron
+Made Track: tt4   :7964646277608636420:    6.90    6.78  0.19  2.90
+Made SmearedTrack: ts4   :7955639308832997380:    6.95    6.83  0.19  2.90
+Made Cluster: et5   :3352920414281007109:    1.46  0.19  2.79 sub(et5, )
+Made SmearedCluster: es5   :3341670923508908037:   -0.86  0.19  2.79 sub(es5, )
+Rejected SmearedCluster: es5   :3341670923508908037:   -0.86  0.19  2.79 sub(es5, )
+Made Cluster: ht2   :5658796855585144834:    5.44  0.19  2.74 sub(ht2, )
+Made SmearedCluster: hs2   :5649748538706362370:    1.02  0.19  2.74 sub(hs2, )
+Simulating Particle :ps9   :10261471955274170377: pdgid =    22, status =   1, q =  0, e =   4.6, theta =  0.12, phi =  2.46, mass =  0.00
+Simulating Photon
+Made Cluster: et6   :3352950126887829510:    4.59  0.12  2.46 sub(et6, )
+Made SmearedCluster: es5   :3343942594240446469:    4.52  0.12  2.46 sub(es5, )
+Simulating Particle :ps10  :10261471324419391498: pdgid =  -211, status =   1, q = -1, e =   4.5, theta =  0.19, phi =  2.86, mass =  0.14
+Simulating Hadron
+Made Track: tt5   :7964635504832413701:    4.45    4.37  0.19  2.86
+Made SmearedTrack: ts5   :7955628252465201157:    4.44    4.36  0.19  2.86
+Made Cluster: ht3   :5658792505246744579:    4.45  0.19  3.07 sub(ht3, )
+Made SmearedCluster: hs3   :5649753050330431491:    1.28  0.19  3.07 sub(hs3, )
+Simulating Particle :ps11  :10261470026156474379: pdgid =  -211, status =   1, q = -1, e =   4.2, theta = -0.70, phi = -0.37, mass =  0.14
+Simulating Hadron
+Made Track: tt6   :7964634205885825030:    4.15    3.19 -0.70 -0.37
+Made SmearedTrack: ts6   :7955627143409434630:    4.18    3.21 -0.70 -0.37
+Made Cluster: ht4   :5658791206983827460:    4.16 -0.71 -0.03 sub(ht4, )
+Made SmearedCluster: hs4   :5649748606920425476:    1.03 -0.71 -0.03 sub(hs4, )
+Rejected SmearedCluster: hs4   :5649748606920425476:    1.03 -0.71 -0.03 sub(hs4, )
+Simulating Particle :ps12  :10261467779628531724: pdgid =   130, status =   1, q =  0, e =   3.8, theta = -0.74, phi = -0.27, mass =  0.50
+Simulating Hadron
+Made Cluster: ht5   :5658788960455884805:    3.82 -0.74 -0.27 sub(ht5, )
+Made SmearedCluster: hs4   :5647513932722601988:   -0.01 -0.74 -0.27 sub(hs4, )
+Rejected SmearedCluster: hs4   :5647513932722601988:   -0.01 -0.74 -0.27 sub(hs4, )
+Simulating Particle :ps13  :10261465629676535821: pdgid =  -211, status =   1, q = -1, e =   3.6, theta = -0.54, phi = -0.31, mass =  0.14
+Simulating Hadron
+Made Track: tt7   :7964629795761815559:    3.58    3.07 -0.54 -0.31
+Made SmearedTrack: ts7   :7955622675496304647:    3.58    3.08 -0.54 -0.31
+Made Cluster: et7   :3352932942664957959:    2.34 -0.54 -0.06 sub(et7, )
+Made SmearedCluster: es6   :3341670923508908038:   -5.64 -0.54 -0.06 sub(es6, )
+Rejected SmearedCluster: es6   :3341670923508908038:   -5.64 -0.54 -0.06 sub(es6, )
+Made Cluster: ht6   :5658759464667316230:    1.23 -0.55  0.05 sub(ht6, )
+Made SmearedCluster: hs4   :5647513932722601988:   -0.23 -0.55  0.05 sub(hs4, )
+Rejected SmearedCluster: hs4   :5647513932722601988:   -0.23 -0.55  0.05 sub(hs4, )
+Simulating Particle :ps14  :10261464348463464462: pdgid =   321, status =   1, q =  1, e =   3.4, theta = -0.70, phi = -0.47, mass =  0.49
+Simulating Hadron
+Made Track: tt8   :7964628224565051400:    3.40    2.59 -0.70 -0.47
+Made SmearedTrack: ts8   :7955620965883314184:    3.39    2.58 -0.70 -0.47
+Made Cluster: et8   :3352912400406806536:    1.00 -0.71 -0.76 sub(et8, )
+Made SmearedCluster: es6   :3343943370482384902:    4.69 -0.71 -0.76 sub(es6, )
+Made Cluster: ht7   :5658776698190036999:    2.43 -0.72 -0.90 sub(ht7, )
+Made SmearedCluster: hs4   :5647513932722601988:   -1.22 -0.72 -0.90 sub(hs4, )
+Rejected SmearedCluster: hs4   :5647513932722601988:   -1.22 -0.72 -0.90 sub(hs4, )
+Simulating Particle :ps15  :10261461985210138639: pdgid =    22, status =   1, q =  0, e =   3.2, theta =  0.11, phi =  2.43, mass =  0.00
+Simulating Photon
+Made Cluster: et9   :3352940156823797769:    3.16  0.11  2.43 sub(et9, )
+Made SmearedCluster: es7   :3343934313266675719:    3.32  0.11  2.43 sub(es7, )
+Simulating Particle :ps16  :10261460641971699728: pdgid =   211, status =   1, q =  1, e =   3.0, theta = -0.60, phi = -0.45, mass =  0.14
+Simulating Hadron
+Made Track: tt9   :7964624803541811209:    3.01    2.48 -0.60 -0.45
+Made SmearedTrack: ts9   :7955617946552762377:    3.05    2.51 -0.60 -0.45
+Made Cluster: et10  :3352877665894793226:    0.26 -0.61 -0.75 sub(et10, )
+Made SmearedCluster: es8   :3341670923508908040:   -2.78 -0.61 -0.75 sub(es8, )
+Rejected SmearedCluster: es8   :3341670923508908040:   -2.78 -0.61 -0.75 sub(es8, )
+Made Cluster: ht8   :5658779558791348232:    2.75 -0.62 -0.90 sub(ht8, )
+Made SmearedCluster: hs4   :5649786954703699972:    4.83 -0.62 -0.90 sub(hs4, )
+Simulating Particle :ps17  :10261457419095769105: pdgid =    22, status =   1, q =  0, e =   2.6, theta = -0.76, phi = -0.32, mass =  0.00
+Simulating Photon
+Made Cluster: et11  :3352935590709428235:    2.64 -0.76 -0.32 sub(et11, )
+Made SmearedCluster: es8   :3343927413554806792:    2.53 -0.76 -0.32 sub(es8, )
+Simulating Particle :ps18  :10261457253433344018: pdgid =    22, status =   1, q =  0, e =   2.6, theta = -0.61, phi =  3.12, mass =  0.00
+Simulating Photon
+Made Cluster: et12  :3352935425047003148:    2.63 -0.61  3.12 sub(et12, )
+Made SmearedCluster: es9   :3343929606779437065:    2.78 -0.61  3.12 sub(es9, )
+Simulating Particle :ps19  :10261455735757996051: pdgid =    22, status =   1, q =  0, e =   2.5, theta = -0.61, phi = -0.40, mass =  0.00
+Simulating Photon
+Made Cluster: et13  :3352933907371655181:    2.45 -0.61 -0.40 sub(et13, )
+Made SmearedCluster: es10  :3343927798891806730:    2.58 -0.61 -0.40 sub(es10, )
+Simulating Particle :ps20  :10261451390867996692: pdgid =   211, status =   1, q =  1, e =   2.0, theta =  0.16, phi =  2.73, mass =  0.14
+Simulating Hadron
+Made Track: tt10  :7964615494242140170:    1.97    1.95  0.16  2.73
+Made SmearedTrack: ts10  :7955608478267998218:    1.99    1.96  0.16  2.73
+Rejected SmearedTrack: ts10  :7955608478267998218:    1.99    1.96  0.16  2.73
+Made Cluster: et14  :3352917014946512910:    1.27  0.16  2.42 sub(et14, )
+Made SmearedCluster: es11  :3343907767990616075:    1.15  0.16  2.42 sub(es11, )
+Made Cluster: ht9   :5658745250305277961:    0.71  0.17  2.22 sub(ht9, )
+Made SmearedCluster: hs5   :5647513932722601989:   -0.04  0.17  2.22 sub(hs5, )
+Rejected SmearedCluster: hs5   :5647513932722601989:   -0.04  0.17  2.22 sub(hs5, )
+Simulating Particle :ps21  :10261445004775915541: pdgid =   211, status =   1, q =  1, e =   1.6, theta = -0.82, phi = -0.36, mass =  0.14
+Simulating Hadron
+Made Track: tt11  :7964609088621379595:    1.61    1.10 -0.82 -0.36
+Made SmearedTrack: ts10  :7955601713296048138:    1.60    1.10 -0.82 -0.36
+Made Cluster: ht10  :5658766185603268618:    1.62 -0.95 -1.62 sub(ht10, )
+Made SmearedCluster: hs5   :5649769648585965573:    2.45 -0.95 -1.62 sub(hs5, )
+Rejected SmearedCluster: hs5   :5649769648585965573:    2.45 -0.95 -1.62 sub(hs5, )
+Simulating Particle :ps22  :10261443114858184726: pdgid =    22, status =   1, q =  0, e =   1.5, theta = -0.67, phi = -0.31, mass =  0.00
+Simulating Photon
+Made Cluster: et15  :3352921286471843855:    1.51 -0.67 -0.31 sub(et15, )
+Made SmearedCluster: es12  :3343912340599865356:    1.41 -0.67 -0.31 sub(es12, )
+Simulating Particle :ps23  :10261443083914706967: pdgid =   211, status =   1, q =  1, e =   1.5, theta = -0.76, phi = -0.30, mass =  0.14
+Simulating Hadron
+Made Track: tt12  :7964607160036360204:    1.50    1.09 -0.76 -0.30
+Made SmearedTrack: ts11  :7955599831840325643:    1.49    1.09 -0.76 -0.30
+Made Cluster: et16  :3352912983928864784:    1.04 -0.80 -1.04 sub(et16, )
+Made SmearedCluster: es13  :3343942400448921613:    4.47 -0.80 -1.04 sub(es13, )
+Made Cluster: ht11  :5658735649440661515:    0.47 -0.94 -1.73 sub(ht11, )
+Made SmearedCluster: hs5   :5649791920877076485:    5.95 -0.94 -1.73 sub(hs5, )
+Simulating Particle :ps24  :10261442909863673880: pdgid =  -211, status =   1, q = -1, e =   1.5, theta =  0.21, phi =  2.70, mass =  0.14
+Simulating Hadron
+Made Track: tt13  :7964606985228255245:    1.49    1.46  0.21  2.70
+Made SmearedTrack: ts12  :7955599796339736588:    1.49    1.46  0.21  2.70
+Made Cluster: ht12  :5658764090691026956:    1.50  0.23 -2.75 sub(ht12, )
+Made SmearedCluster: hs6   :5647513932722601990:   -3.20  0.23 -2.75 sub(hs6, )
+Rejected SmearedCluster: hs6   :5647513932722601990:   -3.20  0.23 -2.75 sub(hs6, )
+Simulating Particle :ps25  :10261438909963567129: pdgid =   211, status =   1, q =  1, e =   1.3, theta = -0.14, phi =  2.89, mass =  0.14
+Simulating Hadron
+Made Track: tt14  :7964602964683784206:    1.26    1.25 -0.14  2.89
+Made SmearedTrack: ts13  :7955595897107120141:    1.27    1.26 -0.14  2.89
+Made Cluster: et17  :3352867843726114833:    0.18 -0.15  2.26 sub(et17, )
+Made SmearedCluster: es14  :3341670923508908046:   -0.77 -0.15  2.26 sub(es14, )
+Rejected SmearedCluster: es14  :3341670923508908046:   -0.77 -0.15  2.26 sub(es14, )
+Made Cluster: ht13  :5658756855531307021:    1.09 -0.17  1.84 sub(ht13, )
+Made SmearedCluster: hs6   :5647513932722601990:   -0.58 -0.17  1.84 sub(hs6, )
+Rejected SmearedCluster: hs6   :5647513932722601990:   -0.58 -0.17  1.84 sub(hs6, )
+Simulating Particle :ps26  :10261437589294678042: pdgid =    22, status =   1, q =  0, e =   1.2, theta =  0.02, phi =  2.93, mass =  0.00
+Simulating Photon
+Made Cluster: et18  :3352915760908337170:    1.20  0.03  2.93 sub(et18, )
+Made SmearedCluster: es14  :3343905656609439758:    1.03  0.03  2.93 sub(es14, )
+Simulating Particle :ps27  :10261436722038439963: pdgid =    22, status =   1, q =  0, e =   1.1, theta = -0.71, phi =  3.07, mass =  0.00
+Simulating Photon
+Made Cluster: et19  :3352914893652099091:    1.15 -0.71  3.07 sub(et19, )
+Made SmearedCluster: es15  :3343907077077598223:    1.11 -0.71  3.07 sub(es15, )
+Simulating Particle :ps28  :10261436413492854812: pdgid =    22, status =   1, q =  0, e =   1.1, theta = -0.79, phi = -0.23, mass =  0.00
+Simulating Photon
+Made Cluster: et20  :3352914585106513940:    1.13 -0.79 -0.23 sub(et20, )
+Made SmearedCluster: es16  :3343910687104565264:    1.32 -0.79 -0.23 sub(es16, )
+Simulating Particle :ps29  :10261436236665192477: pdgid =    22, status =   1, q =  0, e =   1.1, theta =  0.12, phi =  2.81, mass =  0.00
+Simulating Photon
+Made Cluster: et21  :3352914408278851605:    1.12  0.12  2.81 sub(et21, )
+Made SmearedCluster: es17  :3343909313902018577:    1.24  0.12  2.81 sub(es17, )
+Simulating Particle :ps30  :10261436130182299678: pdgid =   211, status =   1, q =  1, e =   1.1, theta = -0.61, phi = -0.92, mass =  0.14
+Simulating Hadron
+Made Track: tt15  :7964600165531123727:    1.10    0.90 -0.61 -0.92
+Made SmearedTrack: ts14  :7955593299593527310:    1.12    0.92 -0.61 -0.92
+Made Cluster: et22  :3352880722755977238:    0.30 -0.69 -1.88 sub(et22, )
+Made SmearedCluster: es18  :3341670923508908050:   -2.39 -0.69 -1.88 sub(es18, )
+Rejected SmearedCluster: es18  :3341670923508908050:   -2.39 -0.69 -1.88 sub(es18, )
+Made Cluster: ht14  :5658748697951862798:    0.81 -1.15  3.04 sub(ht14, )
+Made SmearedCluster: hs6   :5649800675316465670:    7.95 -1.15  3.04 sub(hs6, )
+Rejected SmearedCluster: hs6   :5649800675316465670:    7.95 -1.15  3.04 sub(hs6, )
+Simulating Particle :ps31  :10261434548866777119: pdgid =    22, status =   1, q =  0, e =   1.0, theta = -0.58, phi = -3.07, mass =  0.00
+Simulating Photon
+Made Cluster: et23  :3352912720480436247:    1.02 -0.58 -3.07 sub(et23, )
+Made SmearedCluster: es18  :3343909085675257874:    1.22 -0.58 -3.07 sub(es18, )
+Simulating Particle :ps32  :10261433842193661984: pdgid =    22, status =   1, q =  0, e =   1.0, theta = -0.42, phi = -0.07, mass =  0.00
+Simulating Photon
+Made Cluster: et24  :3352912013807321112:    0.99 -0.42 -0.07 sub(et24, )
+Made SmearedCluster: es19  :3343899283800719379:    0.83 -0.42 -0.07 sub(es19, )
+Simulating Particle :ps33  :10261433813569634337: pdgid =    22, status =   1, q =  0, e =   1.0, theta = -0.68, phi = -0.34, mass =  0.00
+Simulating Photon
+Made Cluster: et25  :3352911985183293465:    0.99 -0.68 -0.34 sub(et25, )
+Made SmearedCluster: es20  :3343900921363955732:    0.88 -0.68 -0.34 sub(es20, )
+Simulating Particle :ps34  :10261431755399495714: pdgid =    22, status =   1, q =  0, e =   0.9, theta =  0.37, phi =  2.90, mass =  0.00
+Simulating Photon
+Made Cluster: et26  :3352909927013154842:    0.93  0.37  2.90 sub(et26, )
+Made SmearedCluster: es21  :3343906879829966869:    1.10  0.37  2.90 sub(es21, )
+Simulating Particle :ps35  :10261429365449424931: pdgid =    22, status =   1, q =  0, e =   0.9, theta = -0.71, phi = -0.33, mass =  0.00
+Simulating Photon
+Made Cluster: et27  :3352907537063084059:    0.86 -0.71 -0.33 sub(et27, )
+Made SmearedCluster: es22  :3343905061018271766:    1.00 -0.71 -0.33 sub(es22, )
+Simulating Particle :ps36  :10261429338654113828: pdgid =    22, status =   1, q =  0, e =   0.9, theta = -0.57, phi = -0.24, mass =  0.00
+Simulating Photon
+Made Cluster: et28  :3352907510267772956:    0.86 -0.57 -0.24 sub(et28, )
+Made SmearedCluster: es23  :3343908121163595799:    1.17 -0.57 -0.24 sub(es23, )
+Simulating Particle :ps37  :10261428084626423845: pdgid =  -211, status =   1, q = -1, e =   0.8, theta = -1.08, phi =  0.81, mass =  0.14
+Simulating Hadron
+Made Track: tt16  :7964591857481023504:    0.82    0.38 -1.08  0.81
+Made SmearedTrack: ts15  :7955584450480308239:    0.81    0.38 -1.08  0.81
+Rejected SmearedTrack: ts15  :7955584450480308239:    0.81    0.38 -1.08  0.81
+Made Cluster: et29  :3352877570040266781:    0.26 -1.25  2.39 sub(et29, )
+Made SmearedCluster: es24  :3343947685557174296:    5.68 -1.25  2.39 sub(es24, )
+Made Cluster: ht15  :5658740257351270415:    0.57 -1.35  2.87 sub(ht15, )
+Made SmearedCluster: hs6   :5649766864270655494:    2.13 -1.35  2.87 sub(hs6, )
+Simulating Particle :ps38  :10261425284882366502: pdgid =   211, status =   1, q =  1, e =   0.7, theta =  0.04, phi =  2.86, mass =  0.14
+Simulating Hadron
+Made Track: tt17  :7964589012587380753:    0.73    0.73  0.04  2.86
+Made SmearedTrack: ts15  :7955581662799069199:    0.73    0.73  0.04  2.86
+Made Cluster: et30  :3352877458585026590:    0.25  1.16  0.46 sub(et30, )
+Made SmearedCluster: es25  :3343884553430237209:    0.46  1.16  0.46 sub(es25, )
+Rejected SmearedCluster: es25  :3343884553430237209:    0.46  1.16  0.46 sub(es25, )
+Made Cluster: ht16  :5658737279248629776:    0.49  1.41  0.06 sub(ht16, )
+Made SmearedCluster: hs7   :5647513932722601991:   -1.72  1.41  0.06 sub(hs7, )
+Rejected SmearedCluster: hs7   :5647513932722601991:   -1.72  1.41  0.06 sub(hs7, )
+Simulating Particle :ps39  :10261423917751074855: pdgid =  -211, status =   1, q = -1, e =   0.7, theta = -0.41, phi = -2.99, mass =  0.14
+Simulating Hadron
+Made Track: tt18  :7964587619623370770:    0.70    0.64 -0.41 -2.99
+Made SmearedTrack: ts16  :7955580462718517264:    0.70    0.64 -0.41 -2.99
+Made Cluster: et31  :3352877164990038047:    0.25 -1.14 -2.04 sub(et31, )
+Made SmearedCluster: es25  :3343963319053582361:   10.46 -1.14 -2.04 sub(es25, )
+Made Cluster: ht17  :5658734838581035025:    0.46 -1.23 -0.81 sub(ht17, )
+Made SmearedCluster: hs7   :5649719492803035143:    0.34 -1.23 -0.81 sub(hs7, )
+Rejected SmearedCluster: hs7   :5649719492803035143:    0.34 -1.23 -0.81 sub(hs7, )
+Simulating Particle :ps40  :10261421557058371624: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.26, phi =  2.83, mass =  0.00
+Simulating Photon
+Made Cluster: et32  :3352899728672030752:    0.64  0.26  2.83 sub(et32, )
+Made SmearedCluster: es26  :3343872326188924954:    0.28  0.26  2.83 sub(es26, )
+Rejected SmearedCluster: es26  :3343872326188924954:    0.28  0.26  2.83 sub(es26, )
+Simulating Particle :ps41  :10261417804867567657: pdgid =  -211, status =   1, q = -1, e =   0.5, theta = -0.03, phi =  2.84, mass =  0.14
+Simulating Hadron
+Made Track: tt19  :7964581343321391123:    0.52    0.52 -0.03  2.84
+Made SmearedTrack: ts17  :7955574187190386705:    0.52    0.52 -0.03  2.84
+Made Cluster: et33  :3352833459419611169:    0.05 -1.43 -0.61 sub(et33, )
+Made SmearedCluster: es26  :3341670923508908058:   -1.61 -1.43 -0.61 sub(es26, )
+Rejected SmearedCluster: es26  :3341670923508908058:   -1.61 -1.43 -0.61 sub(es26, )
+Made Cluster: ht18  :5658736888704401426:    0.49 -1.35 -1.02 sub(ht18, )
+Made SmearedCluster: hs7   :5647513932722601991:   -3.15 -1.35 -1.02 sub(hs7, )
+Rejected SmearedCluster: hs7   :5647513932722601991:   -3.15 -1.35 -1.02 sub(hs7, )
+Simulating Particle :ps42  :10261416577991704618: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.80, phi =  0.22, mass =  0.00
+Simulating Photon
+Made Cluster: et34  :3352894749605363746:    0.50 -0.80  0.22 sub(et34, )
+Made SmearedCluster: es26  :3343874201556615194:    0.31 -0.80  0.22 sub(es26, )
+Simulating Particle :ps43  :10261416479326994475: pdgid =  -211, status =   1, q = -1, e =   0.5, theta = -0.44, phi = -1.48, mass =  0.14
+Simulating Hadron
+Made Track: tt20  :7964579267182854164:    0.48    0.43 -0.44 -1.48
+Made SmearedTrack: ts18  :7955571937147617298:    0.48    0.43 -0.44 -1.48
+Rejected SmearedTrack: ts18  :7955571937147617298:    0.48    0.43 -0.44 -1.48
+Made Cluster: et35  :3352840007659290659:    0.06 -1.34  1.00 sub(et35, )
+Made SmearedCluster: es27  :3343938335746818075:    3.77 -1.34  1.00 sub(es27, )
+Made Cluster: ht19  :5658733506356838419:    0.44 -1.33 -0.45 sub(ht19, )
+Made SmearedCluster: hs7   :5649769782721904647:    2.46 -1.33 -0.45 sub(hs7, )
+Rejected SmearedCluster: hs7   :5649769782721904647:    2.46 -1.33 -0.45 sub(hs7, )
+Simulating Particle :ps44  :10261415204292132908: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.83, phi = -0.35, mass =  0.00
+Simulating Photon
+Made Cluster: et36  :3352893375905792036:    0.48 -0.83 -0.35 sub(et36, )
+Made SmearedCluster: es28  :3343889887406325788:    0.57 -0.83 -0.35 sub(es28, )
+Simulating Particle :ps45  :10261413296393420845: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.57, phi = -0.22, mass =  0.00
+Simulating Photon
+Made Cluster: et37  :3352891468007079973:    0.45 -0.57 -0.22 sub(et37, )
+Made SmearedCluster: es29  :3343886954648305693:    0.49 -0.57 -0.22 sub(es29, )
+Simulating Particle :ps46  :10261405678669135918: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.79, phi = -0.25, mass =  0.00
+Simulating Photon
+Made Cluster: et38  :3352883850282795046:    0.35 -0.79 -0.25 sub(et38, )
+Made SmearedCluster: es30  :3343864385721335838:    0.21 -0.79 -0.25 sub(es30, )
+Rejected SmearedCluster: es30  :3343864385721335838:    0.21 -0.79 -0.25 sub(es30, )
+Simulating Particle :ps47  :10261402429268426799: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.50, phi = -3.11, mass =  0.00
+Simulating Photon
+Made Cluster: et39  :3352880600882085927:    0.30 -0.50 -3.11 sub(et39, )
+Made SmearedCluster: es30  :3343888883388514334:    0.54 -0.50 -3.11 sub(es30, )
+Simulating Particle :ps48  :10261402378360062000: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.61, phi = -0.49, mass =  0.00
+Simulating Photon
+Made Cluster: et40  :3352880549973721128:    0.30 -0.61 -0.49 sub(et40, )
+Made SmearedCluster: es31  :3343879744834764831:    0.39 -0.61 -0.49 sub(es31, )
+Simulating Particle :ps50  :10261394495188762674: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.89, phi =  0.14, mass =  0.00
+Simulating Photon
+Made Cluster: et41  :3352872666802421801:    0.22 -0.89  0.14 sub(et41, )
+Made SmearedCluster: es32  :3343845833201156128:    0.10 -0.89  0.14 sub(es32, )
+Rejected SmearedCluster: es32  :3343845833201156128:    0.10 -0.89  0.14 sub(es32, )
+Simulating Particle :ps51  :10261389229011501107: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.00, phi =  2.70, mass =  0.00
+Simulating Photon
+Made Cluster: et42  :3352867400625160234:    0.18 -0.00  2.70 sub(et42, )
+Made SmearedCluster: es32  :3343756583061422112:    0.00 -0.00  2.70 sub(es32, )
+Rejected SmearedCluster: es32  :3343756583061422112:    0.00 -0.00  2.70 sub(es32, )
+Simulating Particle :ps52  :10261381954599387188: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.02, phi =  2.59, mass =  0.00
+Simulating Photon
+Made Cluster: et43  :3352860126213046315:    0.13 -0.02  2.59 sub(et43, )
+Made SmearedCluster: es32  :3343855063253647392:    0.14 -0.02  2.59 sub(es32, )
+Rejected SmearedCluster: es32  :3343855063253647392:    0.14 -0.02  2.59 sub(es32, )
+Simulating Particle :ps53  :10261352414030331957: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  0.89, phi =  2.31, mass =  0.00
+Simulating Photon
+Made Cluster: et44  :3352830585643991084:    0.04  0.88  2.31 sub(et44, )
+Made SmearedCluster: es32  :3343811518729814048:    0.03  0.88  2.31 sub(es32, )
+Rejected SmearedCluster: es32  :3343811518729814048:    0.03  0.88  2.31 sub(es32, )
+Simulating Particle :ps54  :10261349092034609206: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.46, phi = -2.49, mass =  0.00
+Simulating Photon
+Made Cluster: et45  :3352827263648268333:    0.04 -0.46 -2.49 sub(et45, )
+Made SmearedCluster: es32  :3341670923508908064:   -0.25 -0.46 -2.49 sub(es32, )
+Rejected SmearedCluster: es32  :3341670923508908064:   -0.25 -0.46 -2.49 sub(es32, )
+Simulating Particle :ps55  :10261254474039296055: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.46, phi = -1.35, mass =  0.00
+Simulating Photon
+Made Cluster: et46  :3352732645652955182:    0.00 -0.46 -1.35 sub(et46, )
+Made SmearedCluster: es32  :3341670923508908064:   -0.08 -0.46 -1.35 sub(es32, )
+Rejected SmearedCluster: es32  :3341670923508908064:   -0.08 -0.46 -1.35 sub(es32, )
+Made MergedCluster: em0   :3289831006028169216:    0.31 -0.80  0.22 sub(es26, )
+Made MergedCluster: em1   :3289836549306318849:    0.39 -0.61 -0.49 sub(es31, )
+Made MergedCluster: em2   :3289873575653146626:    1.66 -0.57 -0.24 sub(es23, es29, )
+Made MergedCluster: em3   :3289845687860068355:    0.54 -0.50 -3.11 sub(es30, )
+Made MergedCluster: em4   :3289846691877879812:    0.57 -0.83 -0.35 sub(es28, )
+Made MergedCluster: em5   :3289856088272273413:    0.83 -0.42 -0.07 sub(es19, )
+Made MergedCluster: em6   :3289890858645585926:    3.29 -0.68 -0.32 sub(es12, es22, es20, )
+Made MergedCluster: em7   :3289862461080993799:    1.03  0.03  2.93 sub(es14, )
+Made MergedCluster: em8   :3289863684301520904:    1.10  0.37  2.90 sub(es21, )
+Made MergedCluster: em9   :3289863881549152265:    1.11 -0.71  3.07 sub(es15, )
+Made MergedCluster: em10  :3289916879602188298:    8.99  0.12  2.44 sub(es5, es7, es11, )
+Made MergedCluster: em11  :3289865890146811915:    1.22 -0.58 -3.07 sub(es18, )
+Made MergedCluster: em12  :3289918007828021260:    9.50  0.16  2.81 sub(es1, es17, )
+Made MergedCluster: em13  :3289867491576119309:    1.32 -0.79 -0.23 sub(es16, )
+Made MergedCluster: em14  :3289884218026360846:    2.53 -0.76 -0.32 sub(es8, )
+Made MergedCluster: em15  :3289884603363360783:    2.58 -0.61 -0.40 sub(es10, )
+Made MergedCluster: em16  :3289886411250991120:    2.78 -0.61  3.12 sub(es9, )
+Made MergedCluster: em17  :3289895140218372113:    3.77 -1.34  1.00 sub(es27, )
+Made MergedCluster: em18  :3289898102841933842:    4.22 -0.65 -0.08 sub(es3, )
+Made MergedCluster: em19  :3289899204920475667:    4.47 -0.80 -1.04 sub(es13, )
+Made MergedCluster: em20  :3289900174953938964:    4.69 -0.71 -0.76 sub(es6, )
+Made MergedCluster: em21  :3289904490028728341:    5.68 -1.25  2.39 sub(es24, )
+Made MergedCluster: em22  :3289910214878298134:    6.98  0.07  2.61 sub(es4, )
+Made MergedCluster: em23  :3289949394582896663:   31.54  0.24  2.75 sub(es0, es2, )
+Made MergedCluster: em24  :3289920123525136408:   10.46 -1.14 -2.04 sub(es25, )
+Made MergedCluster: hm0   :5595762842132283392:   10.33  0.16  2.91 sub(hs0, hs3, hs2, )
+Made MergedCluster: hm1   :5595723668742209537:    2.13 -1.35  2.87 sub(hs6, )
+Made MergedCluster: hm2   :5595743759175254018:    4.83 -0.62 -0.90 sub(hs4, )
+Made MergedCluster: hm3   :5595746516999340035:    5.45 -0.65 -0.02 sub(hs1, )
+Made MergedCluster: hm4   :5595748725348630532:    5.95 -0.94 -1.73 sub(hs5, )
+Made block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289831006028169216)
+
+Made block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.4 (3289836549306318849)
+
+Made block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.5 (3289845687860068355)
+
+Made block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.6 (3289846691877879812)
+
+Made block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.8 (3289856088272273413)
+
+Made block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  1.0 (3289862461080993799)
+
+Made block:E1       :br6   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  1.1 (3289863684301520904)
+
+Made block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  1.1 (3289863881549152265)
+
+Made block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.2 (3289865890146811915)
+
+Made block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  1.3 (3289867491576119309)
+
+Made block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  1.7 (3289873575653146626)
+
+Made block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  2.5 (3289884218026360846)
+
+Made block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  2.6 (3289884603363360783)
+
+Made block:E1       :br13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  2.8 (3289886411250991120)
+
+Made block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  3.3 (3289890858645585926)
+
+Made block:E1       :br15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  3.8 (3289895140218372113)
+
+Made block:E1H1T2   :br16  : ecals = 1 hcals = 1 tracks = 2
+    elements:
+      t0 = ts3       value=  7.6 (7955641978884980739)
+      t1 = ts6       value=  4.2 (7955627143409434630)
+      h2 = hm3       value=  5.5 (5595746516999340035)
+      e3 = em18      value=  4.2 (3289898102841933842)
+    distances:
+              t0      t1      h2      e3
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.1801       .
+      e3  0.0000     ---     ---       .
+
+Made block:E1H1T1   :br17  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts11      value=  1.5 (7955599831840325643)
+      h1 = hm4       value=  6.0 (5595748725348630532)
+      e2 = em19      value=  4.5 (3289899204920475667)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1T1     :br18  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  3.4 (7955620965883314184)
+      e1 = em20      value=  4.7 (3289900174953938964)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  5.7 (3289904490028728341)
+
+Made block:E1       :br20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  7.0 (3289910214878298134)
+
+Made block:E1       :br21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  9.0 (3289916879602188298)
+
+Made block:E1       :br22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  9.5 (3289918007828021260)
+
+Made block:E1T1     :br23  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  0.7 (7955580462718517264)
+      e1 = em24      value= 10.5 (3289920123525136408)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value= 31.5 (3289949394582896663)
+
+Made block:H1       :br25  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm1       value=  2.1 (5595723668742209537)
+
+Made block:H1T1     :br26  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  3.0 (7955617946552762377)
+      h1 = hm2       value=  4.8 (5595743759175254018)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T3     :br27  : ecals = 0 hcals = 1 tracks = 3
+    elements:
+      t0 = ts2       value= 10.1 (7955648440134795266)
+      t1 = ts4       value=  7.0 (7955639308832997380)
+      t2 = ts5       value=  4.4 (7955628252465201157)
+      h3 = hm0       value= 10.3 (5595762842132283392)
+    distances:
+              t0      t1      t2      h3
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      h3  0.0000  0.0000  0.0000       .
+
+Made block:T1       :br28  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts17      value=  0.5 (7955574187190386705)
+
+Made block:T1       :br29  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  0.7 (7955581662799069199)
+
+Made block:T1       :br30  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.1 (7955593299593527310)
+
+Made block:T1       :br31  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.3 (7955595897107120141)
+
+Made block:T1       :br32  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.5 (7955599796339736588)
+
+Made block:T1       :br33  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  1.6 (7955601713296048138)
+
+Made block:T1       :br34  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts7       value=  3.6 (7955622675496304647)
+
+Made block:T1       :br35  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 46.3 (7955686987520802817)
+
+Made block:T1       :br36  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 57.1 (7955692883646873600)
+
+Splitting block:H1T3     :br27  : ecals = 0 hcals = 1 tracks = 3
+    elements:
+      t0 = ts2       value= 10.1 (7955648440134795266)
+      t1 = ts4       value=  7.0 (7955639308832997380)
+      t2 = ts5       value=  4.4 (7955628252465201157)
+      h3 = hm0       value= 10.3 (5595762842132283392)
+    distances:
+              t0      t1      t2      h3
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      h3  0.0000  0.0000  0.0000       .
+
+Made block:H1T3     :bs0   : ecals = 0 hcals = 1 tracks = 3
+    elements:
+      t0 = ts2       value= 10.1 (7955648440134795266)
+      t1 = ts4       value=  7.0 (7955639308832997380)
+      t2 = ts5       value=  4.4 (7955628252465201157)
+      h3 = hm0       value= 10.3 (5595762842132283392)
+    distances:
+              t0      t1      t2      h3
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      h3  0.0000  0.0000  0.0000       .
+
+Splitting block:E1H1T2   :br16  : ecals = 1 hcals = 1 tracks = 2
+    elements:
+      t0 = ts3       value=  7.6 (7955641978884980739)
+      t1 = ts6       value=  4.2 (7955627143409434630)
+      h2 = hm3       value=  5.5 (5595746516999340035)
+      e3 = em18      value=  4.2 (3289898102841933842)
+    distances:
+              t0      t1      h2      e3
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.1801       .
+      e3  0.0000     ---     ---       .
+
+Made block:E1H1T2   :bs1   : ecals = 1 hcals = 1 tracks = 2
+    elements:
+      t0 = ts3       value=  7.6 (7955641978884980739)
+      t1 = ts6       value=  4.2 (7955627143409434630)
+      h2 = hm3       value=  5.5 (5595746516999340035)
+      e3 = em18      value=  4.2 (3289898102841933842)
+    distances:
+              t0      t1      h2      e3
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.1801       .
+      e3  0.0000     ---     ---       .
+
+Splitting block:E1H1T1   :br17  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts11      value=  1.5 (7955599831840325643)
+      h1 = hm4       value=  6.0 (5595748725348630532)
+      e2 = em19      value=  4.5 (3289899204920475667)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts11      value=  1.5 (7955599831840325643)
+      h1 = hm4       value=  6.0 (5595748725348630532)
+      e2 = em19      value=  4.5 (3289899204920475667)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:H1T1     :br26  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  3.0 (7955617946552762377)
+      h1 = hm2       value=  4.8 (5595743759175254018)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs3   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  3.0 (7955617946552762377)
+      h1 = hm2       value=  4.8 (5595743759175254018)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:E1T1     :br23  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  0.7 (7955580462718517264)
+      e1 = em24      value= 10.5 (3289920123525136408)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs4   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  0.7 (7955580462718517264)
+      e1 = em24      value= 10.5 (3289920123525136408)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br18  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  3.4 (7955620965883314184)
+      e1 = em20      value=  4.7 (3289900174953938964)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs5   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  3.4 (7955620965883314184)
+      e1 = em20      value=  4.7 (3289900174953938964)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:T1       :br36  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 57.1 (7955692883646873600)
+
+Made block:T1       :bs6   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 57.1 (7955692883646873600)
+
+Splitting block:T1       :br35  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 46.3 (7955686987520802817)
+
+Made block:T1       :bs7   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 46.3 (7955686987520802817)
+
+Splitting block:T1       :br34  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts7       value=  3.6 (7955622675496304647)
+
+Made block:T1       :bs8   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts7       value=  3.6 (7955622675496304647)
+
+Splitting block:T1       :br33  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  1.6 (7955601713296048138)
+
+Made block:T1       :bs9   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  1.6 (7955601713296048138)
+
+Splitting block:T1       :br32  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.5 (7955599796339736588)
+
+Made block:T1       :bs10  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.5 (7955599796339736588)
+
+Splitting block:T1       :br31  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.3 (7955595897107120141)
+
+Made block:T1       :bs11  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.3 (7955595897107120141)
+
+Splitting block:T1       :br30  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.1 (7955593299593527310)
+
+Made block:T1       :bs12  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.1 (7955593299593527310)
+
+Splitting block:T1       :br29  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  0.7 (7955581662799069199)
+
+Made block:T1       :bs13  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  0.7 (7955581662799069199)
+
+Splitting block:T1       :br28  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts17      value=  0.5 (7955574187190386705)
+
+Made block:T1       :bs14  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts17      value=  0.5 (7955574187190386705)
+
+Splitting block:H1       :br25  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm1       value=  2.1 (5595723668742209537)
+
+Made block:H1       :bs15  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm1       value=  2.1 (5595723668742209537)
+
+Splitting block:E1       :br24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value= 31.5 (3289949394582896663)
+
+Made block:E1       :bs16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value= 31.5 (3289949394582896663)
+
+Splitting block:E1       :br22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  9.5 (3289918007828021260)
+
+Made block:E1       :bs17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  9.5 (3289918007828021260)
+
+Splitting block:E1       :br21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  9.0 (3289916879602188298)
+
+Made block:E1       :bs18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  9.0 (3289916879602188298)
+
+Splitting block:E1       :br20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  7.0 (3289910214878298134)
+
+Made block:E1       :bs19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  7.0 (3289910214878298134)
+
+Splitting block:E1       :br19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  5.7 (3289904490028728341)
+
+Made block:E1       :bs20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  5.7 (3289904490028728341)
+
+Splitting block:E1       :br15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  3.8 (3289895140218372113)
+
+Made block:E1       :bs21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  3.8 (3289895140218372113)
+
+Splitting block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  3.3 (3289890858645585926)
+
+Made block:E1       :bs22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  3.3 (3289890858645585926)
+
+Splitting block:E1       :br13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  2.8 (3289886411250991120)
+
+Made block:E1       :bs23  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  2.8 (3289886411250991120)
+
+Splitting block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  2.6 (3289884603363360783)
+
+Made block:E1       :bs24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  2.6 (3289884603363360783)
+
+Splitting block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  2.5 (3289884218026360846)
+
+Made block:E1       :bs25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  2.5 (3289884218026360846)
+
+Splitting block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  1.7 (3289873575653146626)
+
+Made block:E1       :bs26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  1.7 (3289873575653146626)
+
+Splitting block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  1.3 (3289867491576119309)
+
+Made block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  1.3 (3289867491576119309)
+
+Splitting block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.2 (3289865890146811915)
+
+Made block:E1       :bs28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.2 (3289865890146811915)
+
+Splitting block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  1.1 (3289863881549152265)
+
+Made block:E1       :bs29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  1.1 (3289863881549152265)
+
+Splitting block:E1       :br6   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  1.1 (3289863684301520904)
+
+Made block:E1       :bs30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  1.1 (3289863684301520904)
+
+Splitting block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  1.0 (3289862461080993799)
+
+Made block:E1       :bs31  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  1.0 (3289862461080993799)
+
+Splitting block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.8 (3289856088272273413)
+
+Made block:E1       :bs32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.8 (3289856088272273413)
+
+Splitting block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.6 (3289846691877879812)
+
+Made block:E1       :bs33  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.6 (3289846691877879812)
+
+Splitting block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.5 (3289845687860068355)
+
+Made block:E1       :bs34  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.5 (3289845687860068355)
+
+Splitting block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.4 (3289836549306318849)
+
+Made block:E1       :bs35  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.4 (3289836549306318849)
+
+Splitting block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289831006028169216)
+
+Made block:E1       :bs36  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289831006028169216)
+
+Processing block:E1H1T2   :bs1   : ecals = 1 hcals = 1 tracks = 2
+    elements:
+      t0 = ts3       value=  7.6 (7955641978884980739)
+      t1 = ts6       value=  4.2 (7955627143409434630)
+      h2 = hm3       value=  5.5 (5595746516999340035)
+      e3 = em18      value=  4.2 (3289898102841933842)
+    distances:
+              t0      t1      h2      e3
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.1801       .
+      e3  0.0000     ---     ---       .
+
+Made Particle :pr0   :10252477794466398208: pdgid =  -211, status =   1, q = -1, e =   7.6, theta = -0.65, phi = -0.21, mass =  0.14 from SmearedTrack: ts3   :7955641978884980739:    7.56    6.04 -0.65 -0.21
+Made Particle :pr1   :10252462963520700417: pdgid =  -211, status =   1, q = -1, e =   4.2, theta = -0.70, phi = -0.37, mass =  0.14 from SmearedTrack: ts6   :7955627143409434630:    4.18    3.21 -0.70 -0.37
+Finished block
+Processing block:H1T3     :bs0   : ecals = 0 hcals = 1 tracks = 3
+    elements:
+      t0 = ts2       value= 10.1 (7955648440134795266)
+      t1 = ts4       value=  7.0 (7955639308832997380)
+      t2 = ts5       value=  4.4 (7955628252465201157)
+      h3 = hm0       value= 10.3 (5595762842132283392)
+    distances:
+              t0      t1      t2      h3
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      h3  0.0000  0.0000  0.0000       .
+
+Made Particle :pr2   :10252484252207677442: pdgid =  -211, status =   1, q = -1, e =  10.1, theta =  0.14, phi =  2.80, mass =  0.14 from SmearedTrack: ts2   :7955648440134795266:   10.05    9.95  0.14  2.80
+Made Particle :pr3   :10252475124905148419: pdgid =   211, status =   1, q =  1, e =   7.0, theta =  0.19, phi =  2.90, mass =  0.14 from SmearedTrack: ts4   :7955639308832997380:    6.95    6.83  0.19  2.90
+Made Particle :pr4   :10252464071999750148: pdgid =  -211, status =   1, q = -1, e =   4.4, theta =  0.19, phi =  2.86, mass =  0.14 from SmearedTrack: ts5   :7955628252465201157:    4.44    4.36  0.19  2.86
+Finished block
+Processing block:E1H1T1   :bs2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts11      value=  1.5 (7955599831840325643)
+      h1 = hm4       value=  6.0 (5595748725348630532)
+      e2 = em19      value=  4.5 (3289899204920475667)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr5   :10252435755343282181: pdgid =   211, status =   1, q =  1, e =   1.5, theta = -0.76, phi = -0.30, mass =  0.14 from SmearedTrack: ts11  :7955599831840325643:    1.49    1.09 -0.76 -0.30
+Made Particle :pr6   :10252464171434115078: pdgid =   130, status =   1, q =  0, e =   4.5, theta = -0.94, phi = -1.73, mass =  0.50 from MergedCluster: hm4   :5595748725348630532:    5.95 -0.94 -1.73 sub(hs5, )
+Made Particle :pr7   :10252464228835262471: pdgid =    22, status =   1, q =  0, e =   4.5, theta = -0.94, phi = -1.73, mass =  0.00 from MergedCluster: hm4   :5595748725348630532:    5.95 -0.94 -1.73 sub(hs5, )
+Finished block
+Processing block:E1T1     :bs5   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  3.4 (7955620965883314184)
+      e1 = em20      value=  4.7 (3289900174953938964)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr8   :10252456800899039240: pdgid =   211, status =   1, q =  1, e =   3.4, theta = -0.70, phi = -0.47, mass =  0.14 from SmearedTrack: ts8   :7955620965883314184:    3.39    2.58 -0.70 -0.47
+Finished block
+Processing block:E1T1     :bs4   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  0.7 (7955580462718517264)
+      e1 = em24      value= 10.5 (3289920123525136408)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr9   :10252416756083589129: pdgid =  -211, status =   1, q = -1, e =   0.7, theta = -0.41, phi = -2.99, mass =  0.14 from SmearedTrack: ts16  :7955580462718517264:    0.70    0.64 -0.41 -2.99
+Finished block
+Processing block:H1T1     :bs3   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  3.0 (7955617946552762377)
+      h1 = hm2       value=  4.8 (5595743759175254018)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr10  :10252453784389156874: pdgid =   211, status =   1, q =  1, e =   3.0, theta = -0.60, phi = -0.45, mass =  0.14 from SmearedTrack: ts9   :7955617946552762377:    3.05    2.51 -0.60 -0.45
+Finished block
+Processing block:E1       :bs36  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289831006028169216)
+
+Made Particle :pr11  :10252396029942956043: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.80, phi =  0.22, mass =  0.00 from MergedCluster: em0   :3289831006028169216:    0.31 -0.80  0.22 sub(es26, )
+Finished block
+Processing block:E1       :bs35  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.4 (3289836549306318849)
+
+Made Particle :pr12  :10252401573221105676: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.61, phi = -0.49, mass =  0.00 from MergedCluster: em1   :3289836549306318849:    0.39 -0.61 -0.49 sub(es31, )
+Finished block
+Processing block:E1       :bs34  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.5 (3289845687860068355)
+
+Made Particle :pr13  :10252410711774855181: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.50, phi = -3.11, mass =  0.00 from MergedCluster: em3   :3289845687860068355:    0.54 -0.50 -3.11 sub(es30, )
+Finished block
+Processing block:E1       :bs33  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.6 (3289846691877879812)
+
+Made Particle :pr14  :10252411715792666638: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.83, phi = -0.35, mass =  0.00 from MergedCluster: em4   :3289846691877879812:    0.57 -0.83 -0.35 sub(es28, )
+Finished block
+Processing block:E1       :bs32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.8 (3289856088272273413)
+
+Made Particle :pr15  :10252421112187060239: pdgid =    22, status =   1, q =  0, e =   0.8, theta = -0.42, phi = -0.07, mass =  0.00 from MergedCluster: em5   :3289856088272273413:    0.83 -0.42 -0.07 sub(es19, )
+Finished block
+Processing block:E1       :bs31  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  1.0 (3289862461080993799)
+
+Made Particle :pr16  :10252427484995780624: pdgid =    22, status =   1, q =  0, e =   1.0, theta =  0.03, phi =  2.93, mass =  0.00 from MergedCluster: em7   :3289862461080993799:    1.03  0.03  2.93 sub(es14, )
+Finished block
+Processing block:E1       :bs30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  1.1 (3289863684301520904)
+
+Made Particle :pr17  :10252428708216307729: pdgid =    22, status =   1, q =  0, e =   1.1, theta =  0.37, phi =  2.90, mass =  0.00 from MergedCluster: em8   :3289863684301520904:    1.10  0.37  2.90 sub(es21, )
+Finished block
+Processing block:E1       :bs29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  1.1 (3289863881549152265)
+
+Made Particle :pr18  :10252428905463939090: pdgid =    22, status =   1, q =  0, e =   1.1, theta = -0.71, phi =  3.07, mass =  0.00 from MergedCluster: em9   :3289863881549152265:    1.11 -0.71  3.07 sub(es15, )
+Finished block
+Processing block:E1       :bs28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.2 (3289865890146811915)
+
+Made Particle :pr19  :10252430914061598739: pdgid =    22, status =   1, q =  0, e =   1.2, theta = -0.58, phi = -3.07, mass =  0.00 from MergedCluster: em11  :3289865890146811915:    1.22 -0.58 -3.07 sub(es18, )
+Finished block
+Processing block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  1.3 (3289867491576119309)
+
+Made Particle :pr20  :10252432515490906132: pdgid =    22, status =   1, q =  0, e =   1.3, theta = -0.79, phi = -0.23, mass =  0.00 from MergedCluster: em13  :3289867491576119309:    1.32 -0.79 -0.23 sub(es16, )
+Finished block
+Processing block:E1       :bs26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  1.7 (3289873575653146626)
+
+Made Particle :pr21  :10252438599567933461: pdgid =    22, status =   1, q =  0, e =   1.7, theta = -0.57, phi = -0.24, mass =  0.00 from MergedCluster: em2   :3289873575653146626:    1.66 -0.57 -0.24 sub(es23, es29, )
+Finished block
+Processing block:E1       :bs25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  2.5 (3289884218026360846)
+
+Made Particle :pr22  :10252449241941147670: pdgid =    22, status =   1, q =  0, e =   2.5, theta = -0.76, phi = -0.32, mass =  0.00 from MergedCluster: em14  :3289884218026360846:    2.53 -0.76 -0.32 sub(es8, )
+Finished block
+Processing block:E1       :bs24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  2.6 (3289884603363360783)
+
+Made Particle :pr23  :10252449627278147607: pdgid =    22, status =   1, q =  0, e =   2.6, theta = -0.61, phi = -0.40, mass =  0.00 from MergedCluster: em15  :3289884603363360783:    2.58 -0.61 -0.40 sub(es10, )
+Finished block
+Processing block:E1       :bs23  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  2.8 (3289886411250991120)
+
+Made Particle :pr24  :10252451435165777944: pdgid =    22, status =   1, q =  0, e =   2.8, theta = -0.61, phi =  3.12, mass =  0.00 from MergedCluster: em16  :3289886411250991120:    2.78 -0.61  3.12 sub(es9, )
+Finished block
+Processing block:E1       :bs22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  3.3 (3289890858645585926)
+
+Made Particle :pr25  :10252455882560372761: pdgid =    22, status =   1, q =  0, e =   3.3, theta = -0.68, phi = -0.32, mass =  0.00 from MergedCluster: em6   :3289890858645585926:    3.29 -0.68 -0.32 sub(es12, es22, es20, )
+Finished block
+Processing block:E1       :bs21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  3.8 (3289895140218372113)
+
+Made Particle :pr26  :10252460164133158938: pdgid =    22, status =   1, q =  0, e =   3.8, theta = -1.34, phi =  1.00, mass =  0.00 from MergedCluster: em17  :3289895140218372113:    3.77 -1.34  1.00 sub(es27, )
+Finished block
+Processing block:E1       :bs20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  5.7 (3289904490028728341)
+
+Made Particle :pr27  :10252469513943515163: pdgid =    22, status =   1, q =  0, e =   5.7, theta = -1.25, phi =  2.39, mass =  0.00 from MergedCluster: em21  :3289904490028728341:    5.68 -1.25  2.39 sub(es24, )
+Finished block
+Processing block:E1       :bs19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  7.0 (3289910214878298134)
+
+Made Particle :pr28  :10252475238793084956: pdgid =    22, status =   1, q =  0, e =   7.0, theta =  0.07, phi =  2.61, mass =  0.00 from MergedCluster: em22  :3289910214878298134:    6.98  0.07  2.61 sub(es4, )
+Finished block
+Processing block:E1       :bs18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  9.0 (3289916879602188298)
+
+Made Particle :pr29  :10252481903516975133: pdgid =    22, status =   1, q =  0, e =   9.0, theta =  0.12, phi =  2.44, mass =  0.00 from MergedCluster: em10  :3289916879602188298:    8.99  0.12  2.44 sub(es5, es7, es11, )
+Finished block
+Processing block:E1       :bs17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  9.5 (3289918007828021260)
+
+Made Particle :pr30  :10252483031742808094: pdgid =    22, status =   1, q =  0, e =   9.5, theta =  0.16, phi =  2.81, mass =  0.00 from MergedCluster: em12  :3289918007828021260:    9.50  0.16  2.81 sub(es1, es17, )
+Finished block
+Processing block:E1       :bs16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value= 31.5 (3289949394582896663)
+
+Made Particle :pr31  :10252514418497683487: pdgid =    22, status =   1, q =  0, e =  31.5, theta =  0.24, phi =  2.75, mass =  0.00 from MergedCluster: em23  :3289949394582896663:   31.54  0.24  2.75 sub(es0, es2, )
+Finished block
+Processing block:H1       :bs15  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm1       value=  2.1 (5595723668742209537)
+
+Made Particle :pr32  :10252445683443302432: pdgid =   130, status =   1, q =  0, e =   2.1, theta = -1.35, phi =  2.87, mass =  0.50 from MergedCluster: hm1   :5595723668742209537:    2.13 -1.35  2.87 sub(hs6, )
+Finished block
+Processing block:T1       :bs14  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts17      value=  0.5 (7955574187190386705)
+
+Made Particle :pr33  :10252410642038259745: pdgid =  -211, status =   1, q = -1, e =   0.5, theta = -0.03, phi =  2.84, mass =  0.14 from SmearedTrack: ts17  :7955574187190386705:    0.52    0.52 -0.03  2.84
+Finished block
+Processing block:T1       :bs13  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  0.7 (7955581662799069199)
+
+Made Particle :pr34  :10252417933997244450: pdgid =   211, status =   1, q =  1, e =   0.7, theta =  0.04, phi =  2.86, mass =  0.14 from SmearedTrack: ts15  :7955581662799069199:    0.73    0.73  0.04  2.86
+Finished block
+Processing block:T1       :bs12  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.1 (7955593299593527310)
+
+Made Particle :pr35  :10252429260415303715: pdgid =   211, status =   1, q =  1, e =   1.1, theta = -0.61, phi = -0.92, mass =  0.14 from SmearedTrack: ts14  :7955593299593527310:    1.12    0.92 -0.61 -0.92
+Finished block
+Processing block:T1       :bs11  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.3 (7955595897107120141)
+
+Made Particle :pr36  :10252431840499466276: pdgid =   211, status =   1, q =  1, e =   1.3, theta = -0.14, phi =  2.89, mass =  0.14 from SmearedTrack: ts13  :7955595897107120141:    1.27    1.26 -0.14  2.89
+Finished block
+Processing block:T1       :bs10  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.5 (7955599796339736588)
+
+Made Particle :pr37  :10252435719997882405: pdgid =  -211, status =   1, q = -1, e =   1.5, theta =  0.21, phi =  2.70, mass =  0.14 from SmearedTrack: ts12  :7955599796339736588:    1.49    1.46  0.21  2.70
+Finished block
+Processing block:T1       :bs9   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  1.6 (7955601713296048138)
+
+Made Particle :pr38  :10252437629242966054: pdgid =   211, status =   1, q =  1, e =   1.6, theta = -0.82, phi = -0.36, mass =  0.14 from SmearedTrack: ts10  :7955601713296048138:    1.60    1.10 -0.82 -0.36
+Finished block
+Processing block:T1       :bs8   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts7       value=  3.6 (7955622675496304647)
+
+Made Particle :pr39  :10252458509155172391: pdgid =  -211, status =   1, q = -1, e =   3.6, theta = -0.54, phi = -0.31, mass =  0.14 from SmearedTrack: ts7   :7955622675496304647:    3.58    3.08 -0.54 -0.31
+Finished block
+Processing block:T1       :bs7   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 46.3 (7955686987520802817)
+
+Made Particle :pr40  :10252522797544767528: pdgid =    13, status =   1, q =  1, e =  46.3, theta = -0.26, phi = -1.44, mass =  0.10 from SmearedTrack: ts1   :7955686987520802817:   46.33   44.83 -0.26 -1.44
+Finished block
+Processing block:T1       :bs6   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 57.1 (7955692883646873600)
+
+Made Particle :pr41  :10252528693660352553: pdgid =   -13, status =   1, q = -1, e =  57.1, theta =  0.50, phi =  0.44, mass =  0.10 from SmearedTrack: ts0   :7955692883646873600:   57.05   49.94  0.50  0.44
+Finished block
+Finished reconstruction
+Event: 3
+Made Particle :ps0   :10261534825150152704: pdgid =   -13, status =   1, q =  1, e =  55.1, theta = -1.14, phi =  0.59, mass =  0.11
+Made Particle :ps1   :10261532135405912065: pdgid =    13, status =   1, q = -1, e =  50.2, theta =  0.56, phi =  2.35, mass =  0.11
+Made Particle :ps2   :10261505199491252226: pdgid =  2112, status =   1, q =  0, e =  16.6, theta =  0.01, phi = -1.89, mass =  0.94
+Made Particle :ps3   :10261497639503659011: pdgid =   321, status =   1, q =  1, e =  12.9, theta =  1.05, phi = -0.27, mass =  0.49
+Made Particle :ps4   :10261493935815786500: pdgid =    22, status =   1, q =  0, e =  11.2, theta =  0.03, phi = -1.80, mass =  0.00
+Made Particle :ps5   :10261477512966045701: pdgid =    22, status =   1, q =  0, e =   5.9, theta =  1.18, phi = -0.42, mass =  0.00
+Made Particle :ps6   :10261474253194919942: pdgid =  -211, status =   1, q = -1, e =   5.1, theta = -0.57, phi = -2.08, mass =  0.14
+Made Particle :ps7   :10261472448211845127: pdgid =   211, status =   1, q =  1, e =   4.7, theta = -0.03, phi = -1.80, mass =  0.14
+Made Particle :ps8   :10261471404899696648: pdgid =    22, status =   1, q =  0, e =   4.5, theta =  0.43, phi =  0.87, mass =  0.00
+Made Particle :ps9   :10261471284676263945: pdgid = -2212, status =   1, q = -1, e =   4.4, theta =  0.01, phi = -1.70, mass =  0.94
+Made Particle :ps10  :10261462296578490378: pdgid = -2112, status =   1, q =  0, e =   3.2, theta = -0.61, phi = -2.03, mass =  0.94
+Made Particle :ps11  :10261460115993395211: pdgid =   211, status =   1, q =  1, e =   3.0, theta = -0.03, phi = -1.83, mass =  0.14
+Made Particle :ps12  :10261458876601729036: pdgid =   211, status =   1, q =  1, e =   2.8, theta = -0.50, phi = -2.20, mass =  0.14
+Made Particle :ps13  :10261458670235680781: pdgid =  -211, status =   1, q = -1, e =   2.8, theta =  0.55, phi =  1.31, mass =  0.14
+Made Particle :ps14  :10261457600407142414: pdgid =  -211, status =   1, q = -1, e =   2.7, theta =  0.66, phi =  0.97, mass =  0.14
+Made Particle :ps15  :10261457101580664847: pdgid =  2212, status =   1, q =  1, e =   2.6, theta = -0.61, phi = -1.79, mass =  0.94
+Made Particle :ps16  :10261456505601523728: pdgid =    22, status =   1, q =  0, e =   2.5, theta =  1.14, phi = -0.42, mass =  0.00
+Made Particle :ps17  :10261456415992315921: pdgid =  -321, status =   1, q = -1, e =   2.5, theta = -0.18, phi =  0.50, mass =  0.49
+Made Particle :ps18  :10261455618306998290: pdgid =    22, status =   1, q =  0, e =   2.4, theta =  0.39, phi =  0.88, mass =  0.00
+Made Particle :ps19  :10261453466880704531: pdgid =    22, status =   1, q =  0, e =   2.2, theta =  0.58, phi =  1.04, mass =  0.00
+Made Particle :ps20  :10261452594364809236: pdgid =    22, status =   1, q =  0, e =   2.1, theta = -0.07, phi = -1.76, mass =  0.00
+Made Particle :ps21  :10261452039852654613: pdgid =    22, status =   1, q =  0, e =   2.0, theta =  0.46, phi =  1.13, mass =  0.00
+Made Particle :ps22  :10261447986519212054: pdgid =    22, status =   1, q =  0, e =   1.8, theta =  0.00, phi = -1.74, mass =  0.00
+Made Particle :ps23  :10261446589778231319: pdgid =    22, status =   1, q =  0, e =   1.7, theta =  1.01, phi =  0.49, mass =  0.00
+Made Particle :ps24  :10261445396159004696: pdgid =   211, status =   1, q =  1, e =   1.6, theta =  0.42, phi =  1.15, mass =  0.14
+Made Particle :ps25  :10261443880102658073: pdgid =   211, status =   1, q =  1, e =   1.6, theta =  0.39, phi =  0.55, mass =  0.14
+Made Particle :ps26  :10261442815152095258: pdgid =    22, status =   1, q =  0, e =   1.5, theta =  0.58, phi =  0.95, mass =  0.00
+Made Particle :ps27  :10261441949286268955: pdgid =  2212, status =   1, q =  1, e =   1.4, theta = -0.86, phi =  0.36, mass =  0.94
+Made Particle :ps28  :10261440490255679516: pdgid =    22, status =   1, q =  0, e =   1.4, theta =  0.58, phi =  0.98, mass =  0.00
+Made Particle :ps29  :10261438571401445405: pdgid =  -211, status =   1, q = -1, e =   1.3, theta = -0.77, phi = -1.84, mass =  0.14
+Made Particle :ps30  :10261438064364617758: pdgid =  -211, status =   1, q = -1, e =   1.2, theta = -0.31, phi = -1.89, mass =  0.14
+Made Particle :ps31  :10261438021079400479: pdgid =    22, status =   1, q =  0, e =   1.2, theta =  0.32, phi =  0.99, mass =  0.00
+Made Particle :ps32  :10261437410128691232: pdgid =    22, status =   1, q =  0, e =   1.2, theta = -0.08, phi = -1.70, mass =  0.00
+Made Particle :ps33  :10261436675984982049: pdgid =  -211, status =   1, q = -1, e =   1.1, theta =  0.98, phi = -0.32, mass =  0.14
+Made Particle :ps34  :10261434009338773538: pdgid =   211, status =   1, q =  1, e =   1.0, theta = -0.50, phi =  0.82, mass =  0.14
+Made Particle :ps35  :10261433849466585123: pdgid =    22, status =   1, q =  0, e =   1.0, theta = -0.20, phi = -1.71, mass =  0.00
+Made Particle :ps36  :10261432416960774180: pdgid = -2112, status =   1, q =  0, e =   1.0, theta = -0.07, phi =  0.49, mass =  0.94
+Made Particle :ps37  :10261431290309902373: pdgid =   211, status =   1, q =  1, e =   0.9, theta = -0.81, phi =  0.30, mass =  0.14
+Made Particle :ps38  :10261431209078816806: pdgid =  -211, status =   1, q = -1, e =   0.9, theta =  0.56, phi =  0.90, mass =  0.14
+Made Particle :ps39  :10261430773590523943: pdgid =    22, status =   1, q =  0, e =   0.9, theta =  0.73, phi =  0.73, mass =  0.00
+Made Particle :ps40  :10261430597358452776: pdgid =    22, status =   1, q =  0, e =   0.9, theta = -0.06, phi = -1.70, mass =  0.00
+Made Particle :ps41  :10261428361731506217: pdgid =    22, status =   1, q =  0, e =   0.8, theta = -0.36, phi = -1.68, mass =  0.00
+Made Particle :ps42  :10261427893349384234: pdgid =  -211, status =   1, q = -1, e =   0.8, theta = -0.55, phi = -1.30, mass =  0.14
+Made Particle :ps43  :10261427199301124139: pdgid =  -211, status =   1, q = -1, e =   0.8, theta =  0.02, phi =  0.24, mass =  0.14
+Made Particle :ps44  :10261426224259661868: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.04, phi = -2.00, mass =  0.00
+Made Particle :ps45  :10261425980224569389: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.89, phi =  0.55, mass =  0.00
+Made Particle :ps46  :10261425317268684846: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.46, phi =  1.02, mass =  0.00
+Made Particle :ps47  :10261421403746074671: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.02, phi = -1.64, mass =  0.00
+Made Particle :ps48  :10261421183339593776: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.38, phi = -1.97, mass =  0.00
+Made Particle :ps49  :10261420627552370737: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.05, phi = -1.85, mass =  0.00
+Made Particle :ps50  :10261420163372941362: pdgid =   211, status =   1, q =  1, e =   0.6, theta =  1.12, phi =  2.27, mass =  0.14
+Made Particle :ps51  :10261417479590903859: pdgid =    11, status =   1, q = -1, e =   0.5, theta =  0.11, phi = -1.75, mass =  0.00
+Made Particle :ps52  :10261416102665912372: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.44, phi =  0.88, mass =  0.00
+Made Particle :ps53  :10261413774820900917: pdgid =   211, status =   1, q =  1, e =   0.5, theta =  0.09, phi = -2.44, mass =  0.14
+Made Particle :ps54  :10261412595122569270: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.94, phi =  0.70, mass =  0.00
+Made Particle :ps55  :10261412412057976887: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.20, phi = -1.68, mass =  0.00
+Made Particle :ps56  :10261412093399924792: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -1.15, phi =  2.11, mass =  0.00
+Made Particle :ps57  :10261412031949176889: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.49, phi = -2.23, mass =  0.00
+Made Particle :ps58  :10261407886393475130: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.24, phi = -1.71, mass =  0.00
+Made Particle :ps59  :10261407671221485627: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.33, phi =  1.81, mass =  0.00
+Made Particle :ps60  :10261406753893646396: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.39, phi =  1.13, mass =  0.00
+Made Particle :ps61  :10261406082456879165: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.15, phi = -1.76, mass =  0.00
+Made Particle :ps62  :10261403256922046526: pdgid =  -211, status =   1, q = -1, e =   0.3, theta = -0.64, phi = -3.13, mass =  0.14
+Made Particle :ps63  :10261401576371388479: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.46, phi =  1.18, mass =  0.00
+Made Particle :ps64  :10261400934873563200: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.56, phi =  1.18, mass =  0.00
+Made Particle :ps65  :10261399568677601345: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.18, phi =  0.34, mass =  0.00
+Made Particle :ps66  :10261399504676716610: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.23, phi =  0.88, mass =  0.00
+Made Particle :ps67  :10261399160932532291: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.25, phi = -1.88, mass =  0.00
+Made Particle :ps68  :10261398730760519748: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.51, phi =  0.48, mass =  0.00
+Made Particle :ps69  :10261393830345441349: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.48, phi =  0.54, mass =  0.00
+Made Particle :ps70  :10261393521330094150: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.14, phi = -1.92, mass =  0.00
+Made Particle :ps71  :10261391061127528519: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.20, phi = -1.88, mass =  0.00
+Made Particle :ps72  :10261382995929727048: pdgid =   -11, status =   1, q =  1, e =   0.1, theta =  0.11, phi = -1.74, mass =  0.00
+Made Particle :ps73  :10261380614710100041: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.89, phi = -0.47, mass =  0.00
+Made Particle :ps74  :10261369953762410570: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  1.16, phi =  0.82, mass =  0.00
+Made Particle :ps75  :10261368997593219147: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.68, phi = -1.74, mass =  0.00
+Made Particle :ps76  :10261364288826376268: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -1.02, phi = -1.69, mass =  0.00
+Made Particle :ps77  :10261360117012234317: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.28, phi =  2.41, mass =  0.00
+Simulating Particle :ps0   :10261534825150152704: pdgid =   -13, status =   1, q =  1, e =  55.1, theta = -1.14, phi =  0.59, mass =  0.11
+Simulating Muon
+Made Track: tt0   :7964699015136673792:   55.11   22.92 -1.14  0.59
+Made SmearedTrack: ts0   :7955692685652656128:   56.69   23.58 -1.14  0.59
+Simulating Particle :ps1   :10261532135405912065: pdgid =    13, status =   1, q = -1, e =  50.2, theta =  0.56, phi =  2.35, mass =  0.11
+Simulating Muon
+Made Track: tt1   :7964696325384044545:   50.22   42.52  0.56  2.35
+Made SmearedTrack: ts1   :7955689261034897409:   50.46   42.73  0.56  2.35
+Simulating Particle :ps2   :10261505199491252226: pdgid =  2112, status =   1, q =  0, e =  16.6, theta =  0.01, phi = -1.89, mass =  0.94
+Simulating Hadron
+Made Cluster: et0   :3352922223976382464:    1.56  0.01 -1.89 sub(et0, )
+Made SmearedCluster: es0   :3343904238349582336:    0.97  0.01 -1.89 sub(es0, )
+Made Cluster: ht0   :5658823616567967744:   15.05  0.01 -1.89 sub(ht0, )
+Made SmearedCluster: hs0   :5649823388881911808:   20.44  0.01 -1.89 sub(hs0, )
+Simulating Particle :ps3   :10261497639503659011: pdgid =   321, status =   1, q =  1, e =  12.9, theta =  1.05, phi = -0.27, mass =  0.49
+Simulating Hadron
+Made Track: tt2   :7964661808711598082:   12.86    6.40  1.05 -0.27
+Made SmearedTrack: ts2   :7955654689622589442:   12.89    6.42  1.05 -0.27
+Made Cluster: ht1   :5658818820331012097:   12.87  1.05 -0.40 sub(ht1, )
+Made SmearedCluster: hs1   :5649793720550162433:    6.36  1.05 -0.40 sub(hs1, )
+Rejected SmearedCluster: hs1   :5649793720550162433:    6.36  1.05 -0.40 sub(hs1, )
+Simulating Particle :ps4   :10261493935815786500: pdgid =    22, status =   1, q =  0, e =  11.2, theta =  0.03, phi = -1.80, mass =  0.00
+Simulating Photon
+Made Cluster: et1   :3352972107429445633:   11.18  0.03 -1.80 sub(et1, )
+Made SmearedCluster: es1   :3343964923834138625:   11.19  0.03 -1.80 sub(es1, )
+Simulating Particle :ps5   :10261477512966045701: pdgid =    22, status =   1, q =  0, e =   5.9, theta =  1.18, phi = -0.42, mass =  0.00
+Simulating Photon
+Made Cluster: et2   :3352955684579704834:    5.86  1.18 -0.42 sub(et2, )
+Made SmearedCluster: es2   :3343950328658657282:    6.28  1.18 -0.42 sub(es2, )
+Simulating Particle :ps6   :10261474253194919942: pdgid =  -211, status =   1, q = -1, e =   5.1, theta = -0.57, phi = -2.08, mass =  0.14
+Simulating Hadron
+Made Track: tt3   :7964638434862039043:    5.11    4.30 -0.57 -2.08
+Made SmearedTrack: ts3   :7955631826639257603:    5.25    4.41 -0.57 -2.08
+Made Cluster: et3   :3352909874571771907:    0.93 -0.57 -1.91 sub(et3, )
+Made SmearedCluster: es3   :3343921610324180995:    1.94 -0.57 -1.91 sub(es3, )
+Made Cluster: ht2   :5658791342954774530:    4.19 -0.58 -1.83 sub(ht2, )
+Made SmearedCluster: hs1   :5649787864228036609:    5.03 -0.58 -1.83 sub(hs1, )
+Simulating Particle :ps7   :10261472448211845127: pdgid =   211, status =   1, q =  1, e =   4.7, theta = -0.03, phi = -1.80, mass =  0.14
+Simulating Hadron
+Made Track: tt4   :7964636629149155332:    4.70    4.70 -0.03 -1.80
+Made SmearedTrack: ts4   :7955629281290223620:    4.67    4.67 -0.03 -1.80
+Made Cluster: et4   :3352939041000521732:    3.04 -0.03 -1.95 sub(et4, )
+Made SmearedCluster: es4   :3343915734928457732:    1.60 -0.03 -1.95 sub(es4, )
+Made Cluster: ht3   :5658767115195252739:    1.67 -0.03 -2.03 sub(ht3, )
+Made SmearedCluster: hs2   :5647513932722601986:   -0.21 -0.03 -2.03 sub(hs2, )
+Rejected SmearedCluster: hs2   :5647513932722601986:   -0.21 -0.03 -2.03 sub(hs2, )
+Simulating Particle :ps8   :10261471404899696648: pdgid =    22, status =   1, q =  0, e =   4.5, theta =  0.43, phi =  0.87, mass =  0.00
+Simulating Photon
+Made Cluster: et5   :3352949576513355781:    4.47  0.43  0.87 sub(et5, )
+Made SmearedCluster: es5   :3343941969670832133:    4.38  0.43  0.87 sub(es5, )
+Simulating Particle :ps9   :10261471284676263945: pdgid = -2212, status =   1, q = -1, e =   4.4, theta =  0.01, phi = -1.70, mass =  0.94
+Simulating Hadron
+Made Track: tt5   :7964635033868697605:    4.34    4.34  0.01 -1.70
+Made SmearedTrack: ts5   :7955627954101288965:    4.37    4.37  0.01 -1.70
+Made Cluster: et6   :3352914953095872518:    1.15  0.01 -1.53 sub(et6, )
+Made SmearedCluster: es6   :3341670923508908038:   -1.58  0.01 -1.53 sub(es6, )
+Rejected SmearedCluster: es6   :3341670923508908038:   -1.58  0.01 -1.53 sub(es6, )
+Made Cluster: ht4   :5658784299583799300:    3.29  0.01 -1.45 sub(ht4, )
+Made SmearedCluster: hs2   :5649791888589324290:    5.95  0.01 -1.45 sub(hs2, )
+Simulating Particle :ps10  :10261462296578490378: pdgid = -2112, status =   1, q =  0, e =   3.2, theta = -0.61, phi = -2.03, mass =  0.94
+Simulating Hadron
+Made Cluster: ht5   :5658783477405843461:    3.20 -0.61 -2.03 sub(ht5, )
+Made SmearedCluster: hs3   :5649782206470553603:    3.87 -0.61 -2.03 sub(hs3, )
+Simulating Particle :ps11  :10261460115993395211: pdgid =   211, status =   1, q =  1, e =   3.0, theta = -0.03, phi = -1.83, mass =  0.14
+Simulating Hadron
+Made Track: tt6   :7964624276986789894:    2.95    2.95 -0.03 -1.83
+Made SmearedTrack: ts6   :7955617404489302022:    2.98    2.98 -0.03 -1.83
+Made Cluster: et7   :3352923787917000711:    1.65 -0.03 -2.07 sub(et7, )
+Made SmearedCluster: es6   :3341670923508908038:   -1.73 -0.03 -2.07 sub(es6, )
+Rejected SmearedCluster: es6   :3341670923508908038:   -1.73 -0.03 -2.07 sub(es6, )
+Made Cluster: ht6   :5658760612138713094:    1.30 -0.03 -2.19 sub(ht6, )
+Made SmearedCluster: hs4   :5647513932722601988:   -5.37 -0.03 -2.19 sub(hs4, )
+Rejected SmearedCluster: hs4   :5647513932722601988:   -5.37 -0.03 -2.19 sub(hs4, )
+Simulating Particle :ps12  :10261458876601729036: pdgid =   211, status =   1, q =  1, e =   2.8, theta = -0.50, phi = -2.20, mass =  0.14
+Simulating Hadron
+Made Track: tt7   :7964623036135505927:    2.81    2.47 -0.50 -2.20
+Made SmearedTrack: ts7   :7955615727807889415:    2.79    2.46 -0.50 -2.20
+Made Cluster: et8   :3352928689573593096:    1.93 -0.50 -2.50 sub(et8, )
+Made SmearedCluster: es6   :3341670923508908038:   -0.01 -0.50 -2.50 sub(es6, )
+Rejected SmearedCluster: es6   :3341670923508908038:   -0.01 -0.50 -2.50 sub(es6, )
+Made Cluster: ht7   :5658751123792592903:    0.88 -0.51 -2.65 sub(ht7, )
+Made SmearedCluster: hs4   :5647513932722601988:   -1.19 -0.51 -2.65 sub(hs4, )
+Rejected SmearedCluster: hs4   :5647513932722601988:   -1.19 -0.51 -2.65 sub(hs4, )
+Simulating Particle :ps13  :10261458670235680781: pdgid =  -211, status =   1, q = -1, e =   2.8, theta =  0.55, phi =  1.31, mass =  0.14
+Simulating Hadron
+Made Track: tt8   :7964622829513605128:    2.78    2.37  0.55  1.31
+Made SmearedTrack: ts8   :7955615485385506824:    2.77    2.36  0.55  1.31
+Made Cluster: et9   :3352882208636403721:    0.32  0.56  1.59 sub(et9, )
+Made SmearedCluster: es6   :3341670923508908038:   -3.63  0.56  1.59 sub(es6, )
+Rejected SmearedCluster: es6   :3341670923508908038:   -3.63  0.56  1.59 sub(es6, )
+Made Cluster: ht8   :5658777019213676552:    2.46  0.57  1.75 sub(ht8, )
+Made SmearedCluster: hs4   :5649761251153149956:    1.75  0.57  1.75 sub(hs4, )
+Rejected SmearedCluster: hs4   :5649761251153149956:    1.75  0.57  1.75 sub(hs4, )
+Simulating Particle :ps14  :10261457600407142414: pdgid =  -211, status =   1, q = -1, e =   2.7, theta =  0.66, phi =  0.97, mass =  0.14
+Simulating Hadron
+Made Track: tt9   :7964621758279974921:    2.66    2.10  0.66  0.97
+Made SmearedTrack: ts9   :7955614317166985225:    2.63    2.07  0.66  0.97
+Made Cluster: et10  :3352914311275085834:    1.11  0.67  1.33 sub(et10, )
+Made SmearedCluster: es6   :3343925628526133254:    2.33  0.67  1.33 sub(es6, )
+Made Cluster: ht9   :5658765057608122377:    1.55  0.69  1.52 sub(ht9, )
+Made SmearedCluster: hs4   :5649771057662394372:    2.61  0.69  1.52 sub(hs4, )
+Rejected SmearedCluster: hs4   :5649771057662394372:    2.61  0.69  1.52 sub(hs4, )
+Simulating Particle :ps15  :10261457101580664847: pdgid =  2212, status =   1, q =  1, e =   2.6, theta = -0.61, phi = -1.79, mass =  0.94
+Simulating Hadron
+Made Track: tt10  :7964619755789221898:    2.43    1.99 -0.61 -1.79
+Made SmearedTrack: ts10  :7955612171482693642:    2.39    1.96 -0.61 -1.79
+Made Cluster: et11  :3352915273540698123:    1.17 -0.62 -2.17 sub(et11, )
+Made SmearedCluster: es7   :3343911980546129927:    1.39 -0.62 -2.17 sub(es7, )
+Made Cluster: ht10  :5658763097689554954:    1.44 -0.64 -2.36 sub(ht10, )
+Made SmearedCluster: hs4   :5649719376104914948:    0.34 -0.64 -2.36 sub(hs4, )
+Rejected SmearedCluster: hs4   :5649719376104914948:    0.34 -0.64 -2.36 sub(hs4, )
+Simulating Particle :ps16  :10261456505601523728: pdgid =    22, status =   1, q =  0, e =   2.5, theta =  1.14, phi = -0.42, mass =  0.00
+Simulating Photon
+Made Cluster: et12  :3352934677215182860:    2.54  1.14 -0.42 sub(et12, )
+Made SmearedCluster: es8   :3343930094545534984:    2.84  1.14 -0.42 sub(es8, )
+Simulating Particle :ps17  :10261456415992315921: pdgid =  -321, status =   1, q = -1, e =   2.5, theta = -0.18, phi =  0.50, mass =  0.49
+Simulating Hadron
+Made Track: tt11  :7964620178308726795:    2.48    2.44 -0.18  0.50
+Made SmearedTrack: ts11  :7955612944430006283:    2.48    2.44 -0.18  0.50
+Made Cluster: ht11  :5658777596819669003:    2.53 -0.18  0.96 sub(ht11, )
+Made SmearedCluster: hs4   :5647513932722601988:   -1.98 -0.18  0.96 sub(hs4, )
+Rejected SmearedCluster: hs4   :5647513932722601988:   -1.98 -0.18  0.96 sub(hs4, )
+Simulating Particle :ps18  :10261455618306998290: pdgid =    22, status =   1, q =  0, e =   2.4, theta =  0.39, phi =  0.88, mass =  0.00
+Simulating Photon
+Made Cluster: et13  :3352933789920657421:    2.44  0.39  0.88 sub(et13, )
+Made SmearedCluster: es9   :3343925596871720969:    2.33  0.39  0.88 sub(es9, )
+Simulating Particle :ps19  :10261453466880704531: pdgid =    22, status =   1, q =  0, e =   2.2, theta =  0.58, phi =  1.04, mass =  0.00
+Simulating Photon
+Made Cluster: et14  :3352931638494363662:    2.20  0.58  1.04 sub(et14, )
+Made SmearedCluster: es10  :3343923053861011466:    2.04  0.58  1.04 sub(es10, )
+Simulating Particle :ps20  :10261452594364809236: pdgid =    22, status =   1, q =  0, e =   2.1, theta = -0.07, phi = -1.76, mass =  0.00
+Simulating Photon
+Made Cluster: et15  :3352930765978468367:    2.10 -0.07 -1.76 sub(et15, )
+Made SmearedCluster: es11  :3343924881484939275:    2.25 -0.07 -1.76 sub(es11, )
+Simulating Particle :ps21  :10261452039852654613: pdgid =    22, status =   1, q =  0, e =   2.0, theta =  0.46, phi =  1.13, mass =  0.00
+Simulating Photon
+Made Cluster: et16  :3352930211466313744:    2.03  0.46  1.13 sub(et16, )
+Made SmearedCluster: es12  :3343923664874635276:    2.11  0.46  1.13 sub(es12, )
+Simulating Particle :ps22  :10261447986519212054: pdgid =    22, status =   1, q =  0, e =   1.8, theta =  0.00, phi = -1.74, mass =  0.00
+Simulating Photon
+Made Cluster: et17  :3352926158132871185:    1.79  0.00 -1.74 sub(et17, )
+Made SmearedCluster: es13  :3343918901286141965:    1.78  0.00 -1.74 sub(es13, )
+Simulating Particle :ps23  :10261446589778231319: pdgid =    22, status =   1, q =  0, e =   1.7, theta =  1.01, phi =  0.49, mass =  0.00
+Simulating Photon
+Made Cluster: et18  :3352924761391890450:    1.71  1.01  0.49 sub(et18, )
+Made SmearedCluster: es14  :3343920233095102478:    1.86  1.01  0.49 sub(es14, )
+Simulating Particle :ps24  :10261445396159004696: pdgid =   211, status =   1, q =  1, e =   1.6, theta =  0.42, phi =  1.15, mass =  0.14
+Simulating Hadron
+Made Track: tt12  :7964609481451503628:    1.63    1.49  0.42  1.15
+Made SmearedTrack: ts12  :7955602314832642060:    1.63    1.49  0.42  1.15
+Made Cluster: et19  :3352892553746710547:    0.47  0.44  0.69 sub(et19, )
+Made SmearedCluster: es15  :3341670923508908047:   -3.21  0.44  0.69 sub(es15, )
+Rejected SmearedCluster: es15  :3341670923508908047:   -3.21  0.44  0.69 sub(es15, )
+Made Cluster: ht12  :5658758327006396428:    1.17  0.46  0.39 sub(ht12, )
+Made SmearedCluster: hs4   :5649750169174933508:    1.12  0.46  0.39 sub(hs4, )
+Rejected SmearedCluster: hs4   :5649750169174933508:    1.12  0.46  0.39 sub(hs4, )
+Simulating Particle :ps25  :10261443880102658073: pdgid =   211, status =   1, q =  1, e =   1.6, theta =  0.39, phi =  0.55, mass =  0.14
+Simulating Hadron
+Made Track: tt13  :7964607959558782989:    1.55    1.43  0.39  0.55
+Made SmearedTrack: ts13  :7955601242799996941:    1.57    1.45  0.39  0.55
+Made Cluster: et20  :3352913292740788244:    1.05  0.41  0.00 sub(et20, )
+Made SmearedCluster: es15  :3343937312957399055:    3.66  0.41  0.00 sub(es15, )
+Made Cluster: ht13  :5658737598951063565:    0.50  0.44 -0.31 sub(ht13, )
+Made SmearedCluster: hs4   :5649761864729493508:    1.78  0.44 -0.31 sub(hs4, )
+Simulating Particle :ps26  :10261442815152095258: pdgid =    22, status =   1, q =  0, e =   1.5, theta =  0.58, phi =  0.95, mass =  0.00
+Simulating Photon
+Made Cluster: et21  :3352920986765754389:    1.49  0.58  0.95 sub(et21, )
+Made SmearedCluster: es16  :3343911564462784528:    1.37  0.58  0.95 sub(es16, )
+Simulating Particle :ps27  :10261441949286268955: pdgid =  2212, status =   1, q =  1, e =   1.4, theta = -0.86, phi =  0.36, mass =  0.94
+Simulating Hadron
+Made Track: tt14  :7964600039420985358:    1.10    0.71 -0.86  0.36
+Made SmearedTrack: ts14  :7955592607250251790:    1.08    0.71 -0.86  0.36
+Made Cluster: et22  :3352903907658432534:    0.76 -1.02 -1.01 sub(et22, )
+Made SmearedCluster: es17  :3341670923508908049:   -0.32 -1.02 -1.01 sub(es17, )
+Rejected SmearedCluster: es17  :3341670923508908049:   -0.32 -1.02 -1.01 sub(es17, )
+Made Cluster: ht14  :5658744158983028750:    0.68 -1.13 -1.42 sub(ht14, )
+Made SmearedCluster: hs5   :5649768219676770309:    2.28 -1.13 -1.42 sub(hs5, )
+Rejected SmearedCluster: hs5   :5649768219676770309:    2.28 -1.13 -1.42 sub(hs5, )
+Simulating Particle :ps28  :10261440490255679516: pdgid =    22, status =   1, q =  0, e =   1.4, theta =  0.58, phi =  0.98, mass =  0.00
+Simulating Photon
+Made Cluster: et23  :3352918661869338647:    1.36  0.58  0.98 sub(et23, )
+Made SmearedCluster: es17  :3343910705802772497:    1.32  0.58  0.98 sub(es17, )
+Simulating Particle :ps29  :10261438571401445405: pdgid =  -211, status =   1, q = -1, e =   1.3, theta = -0.77, phi = -1.84, mass =  0.14
+Simulating Hadron
+Made Track: tt15  :7964602624026607631:    1.24    0.89 -0.77 -1.84
+Made SmearedTrack: ts15  :7955595593835872271:    1.25    0.90 -0.77 -1.84
+Made Cluster: et24  :3352879896463409176:    0.29 -0.85 -0.87 sub(et24, )
+Made SmearedCluster: es18  :3343939271475068946:    3.88 -0.85 -0.87 sub(es18, )
+Made Cluster: ht15  :5658753993535389711:    0.96 -1.03 -0.13 sub(ht15, )
+Made SmearedCluster: hs5   :5647513932722601989:   -0.93 -1.03 -0.13 sub(hs5, )
+Rejected SmearedCluster: hs5   :5647513932722601989:   -0.93 -1.03 -0.13 sub(hs5, )
+Simulating Particle :ps30  :10261438064364617758: pdgid =  -211, status =   1, q = -1, e =   1.2, theta = -0.31, phi = -1.89, mass =  0.14
+Simulating Hadron
+Made Track: tt16  :7964602113728708624:    1.21    1.16 -0.31 -1.89
+Made SmearedTrack: ts16  :7955594663425998864:    1.20    1.14 -0.31 -1.89
+Made Cluster: et25  :3352886283671175193:    0.38 -0.34 -1.20 sub(et25, )
+Made SmearedCluster: es19  :3341670923508908051:   -0.54 -0.34 -1.20 sub(es19, )
+Rejected SmearedCluster: es19  :3341670923508908051:   -0.54 -0.34 -1.20 sub(es19, )
+Made Cluster: ht16  :5658749785862045712:    0.84 -0.40 -0.68 sub(ht16, )
+Made SmearedCluster: hs5   :5647513932722601989:   -4.49 -0.40 -0.68 sub(hs5, )
+Rejected SmearedCluster: hs5   :5647513932722601989:   -4.49 -0.40 -0.68 sub(hs5, )
+Simulating Particle :ps31  :10261438021079400479: pdgid =    22, status =   1, q =  0, e =   1.2, theta =  0.32, phi =  0.99, mass =  0.00
+Simulating Photon
+Made Cluster: et26  :3352916192693059610:    1.22  0.32  0.99 sub(et26, )
+Made SmearedCluster: es19  :3343907528378417171:    1.14  0.32  0.99 sub(es19, )
+Simulating Particle :ps32  :10261437410128691232: pdgid =    22, status =   1, q =  0, e =   1.2, theta = -0.08, phi = -1.70, mass =  0.00
+Simulating Photon
+Made Cluster: et27  :3352915581742350363:    1.18 -0.08 -1.70 sub(et27, )
+Made SmearedCluster: es20  :3343905757933338644:    1.04 -0.08 -1.70 sub(es20, )
+Simulating Particle :ps33  :10261436675984982049: pdgid =  -211, status =   1, q = -1, e =   1.1, theta =  0.98, phi = -0.32, mass =  0.14
+Simulating Hadron
+Made Track: tt17  :7964600715565858833:    1.13    0.63  0.98 -0.32
+Made SmearedTrack: ts17  :7955593490801360913:    1.13    0.63  0.98 -0.32
+Made Cluster: ht17  :5658757856812335121:    1.14  1.17  1.25 sub(ht17, )
+Made SmearedCluster: hs5   :5649736206659878917:    0.66  1.17  1.25 sub(hs5, )
+Rejected SmearedCluster: hs5   :5649736206659878917:    0.66  1.17  1.25 sub(hs5, )
+Simulating Particle :ps34  :10261434009338773538: pdgid =   211, status =   1, q =  1, e =   1.0, theta = -0.50, phi =  0.82, mass =  0.14
+Simulating Hadron
+Made Track: tt18  :7964597853517512722:    0.99    0.86 -0.50  0.82
+Made SmearedTrack: ts18  :7955591101203611666:    1.00    0.88 -0.50  0.82
+Made Cluster: et28  :3352899783376240668:    0.64 -0.58 -0.21 sub(et28, )
+Made SmearedCluster: es21  :3343950303671091221:    6.27 -0.58 -0.21 sub(es21, )
+Made Cluster: ht18  :5658727358197137426:    0.35 -1.56 -2.31 sub(ht18, )
+Made SmearedCluster: hs5   :5649789448666218501:    5.39 -1.56 -2.31 sub(hs5, )
+Rejected SmearedCluster: hs5   :5649789448666218501:    5.39 -1.56 -2.31 sub(hs5, )
+Simulating Particle :ps35  :10261433849466585123: pdgid =    22, status =   1, q =  0, e =   1.0, theta = -0.20, phi = -1.71, mass =  0.00
+Simulating Photon
+Made Cluster: et29  :3352912021080244253:    0.99 -0.20 -1.71 sub(et29, )
+Made SmearedCluster: es22  :3343909223070171158:    1.23 -0.20 -1.71 sub(es22, )
+Simulating Particle :ps36  :10261432416960774180: pdgid = -2112, status =   1, q =  0, e =   1.0, theta = -0.07, phi =  0.49, mass =  0.94
+Simulating Hadron
+Made Cluster: ht19  :5658753597788127251:    0.95 -0.07  0.49 sub(ht19, )
+Made SmearedCluster: hs5   :5647513932722601989:   -0.03 -0.07  0.49 sub(hs5, )
+Rejected SmearedCluster: hs5   :5647513932722601989:   -0.03 -0.07  0.49 sub(hs5, )
+Simulating Particle :ps37  :10261431290309902373: pdgid =   211, status =   1, q =  1, e =   0.9, theta = -0.81, phi =  0.30, mass =  0.14
+Simulating Hadron
+Made Track: tt19  :7964595105061404691:    0.91    0.63 -0.81  0.30
+Made SmearedTrack: ts19  :7955587896057004051:    0.91    0.63 -0.81  0.30
+Made Cluster: ht20  :5658752471137255444:    0.92 -1.25 -1.95 sub(ht20, )
+Made SmearedCluster: hs5   :5649807625984933893:   11.05 -1.25 -1.95 sub(hs5, )
+Rejected SmearedCluster: hs5   :5649807625984933893:   11.05 -1.25 -1.95 sub(hs5, )
+Simulating Particle :ps38  :10261431209078816806: pdgid =  -211, status =   1, q = -1, e =   0.9, theta =  0.56, phi =  0.90, mass =  0.14
+Simulating Hadron
+Made Track: tt20  :7964595022874017812:    0.91    0.77  0.56  0.90
+Made SmearedTrack: ts20  :7955587291221590036:    0.89    0.76  0.56  0.90
+Made Cluster: et30  :3352898289910415390:    0.60  0.70  2.20 sub(et30, )
+Made SmearedCluster: es23  :3343925753141002263:    2.34  0.70  2.20 sub(es23, )
+Made Cluster: ht21  :5658724744610971669:    0.32  1.54 -2.30 sub(ht21, )
+Made SmearedCluster: hs5   :5649801493430140933:    8.26  1.54 -2.30 sub(hs5, )
+Simulating Particle :ps39  :10261430773590523943: pdgid =    22, status =   1, q =  0, e =   0.9, theta =  0.73, phi =  0.73, mass =  0.00
+Simulating Photon
+Made Cluster: et31  :3352908945204183071:    0.90  0.73  0.73 sub(et31, )
+Made SmearedCluster: es24  :3343892311428825112:    0.64  0.73  0.73 sub(es24, )
+Simulating Particle :ps40  :10261430597358452776: pdgid =    22, status =   1, q =  0, e =   0.9, theta = -0.06, phi = -1.70, mass =  0.00
+Simulating Photon
+Made Cluster: et32  :3352908768972111904:    0.90 -0.06 -1.70 sub(et32, )
+Made SmearedCluster: es25  :3343901356288114713:    0.89 -0.06 -1.70 sub(es25, )
+Simulating Particle :ps41  :10261428361731506217: pdgid =    22, status =   1, q =  0, e =   0.8, theta = -0.36, phi = -1.68, mass =  0.00
+Simulating Photon
+Made Cluster: et33  :3352906533345165345:    0.84 -0.35 -1.68 sub(et33, )
+Made SmearedCluster: es26  :3343903196549480474:    0.95 -0.35 -1.68 sub(es26, )
+Simulating Particle :ps42  :10261427893349384234: pdgid =  -211, status =   1, q = -1, e =   0.8, theta = -0.55, phi = -1.30, mass =  0.14
+Simulating Hadron
+Made Track: tt21  :7964591663402188821:    0.81    0.69 -0.55 -1.30
+Made SmearedTrack: ts21  :7955584889615548437:    0.82    0.70 -0.55 -1.30
+Made Cluster: et34  :3352884339045040162:    0.35 -1.32  1.40 sub(et34, )
+Made SmearedCluster: es27  :3341670923508908059:   -4.59 -1.32  1.40 sub(es27, )
+Rejected SmearedCluster: es27  :3341670923508908059:   -4.59 -1.32  1.40 sub(es27, )
+Made Cluster: ht22  :5658735615722651670:    0.47 -1.41 -0.94 sub(ht22, )
+Made SmearedCluster: hs6   :5647513932722601990:   -5.13 -1.41 -0.94 sub(hs6, )
+Rejected SmearedCluster: hs6   :5647513932722601990:   -5.13 -1.41 -0.94 sub(hs6, )
+Simulating Particle :ps43  :10261427199301124139: pdgid =  -211, status =   1, q = -1, e =   0.8, theta =  0.02, phi =  0.24, mass =  0.14
+Simulating Hadron
+Made Track: tt22  :7964590958868168726:    0.79    0.79  0.02  0.24
+Made SmearedTrack: ts22  :7955583250433310742:    0.78    0.78  0.02  0.24
+Rejected SmearedTrack: ts22  :7955583250433310742:    0.78    0.78  0.02  0.24
+Made Cluster: et35  :3352892061790502947:    0.46  0.02  1.45 sub(et35, )
+Made SmearedCluster: es27  :3341670923508908059:   -0.13  0.02  1.45 sub(es27, )
+Rejected SmearedCluster: es27  :3341670923508908059:   -0.13  0.02  1.45 sub(es27, )
+Made Cluster: ht23  :5658726504878571543:    0.34  1.10  2.11 sub(ht23, )
+Made SmearedCluster: hs6   :5647513932722601990:   -0.54  1.10  2.11 sub(hs6, )
+Rejected SmearedCluster: hs6   :5647513932722601990:   -0.54  1.10  2.11 sub(hs6, )
+Simulating Particle :ps44  :10261426224259661868: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.04, phi = -2.00, mass =  0.00
+Simulating Photon
+Made Cluster: et36  :3352904395873320996:    0.77  0.04 -2.00 sub(et36, )
+Made SmearedCluster: es27  :3343896176805019675:    0.75  0.04 -2.00 sub(es27, )
+Simulating Particle :ps45  :10261425980224569389: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.89, phi =  0.55, mass =  0.00
+Simulating Photon
+Made Cluster: et37  :3352904151838228517:    0.77  0.89  0.55 sub(et37, )
+Made SmearedCluster: es28  :3343895713632223260:    0.73  0.89  0.55 sub(es28, )
+Simulating Particle :ps46  :10261425317268684846: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.46, phi =  1.02, mass =  0.00
+Simulating Photon
+Made Cluster: et38  :3352903488882343974:    0.75  0.46  1.02 sub(et38, )
+Made SmearedCluster: es29  :3343896497725898781:    0.75  0.46  1.02 sub(es29, )
+Simulating Particle :ps47  :10261421403746074671: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.02, phi = -1.64, mass =  0.00
+Simulating Photon
+Made Cluster: et39  :3352899575359733799:    0.64  0.02 -1.64 sub(et39, )
+Made SmearedCluster: es30  :3343885989891276830:    0.48  0.02 -1.64 sub(es30, )
+Simulating Particle :ps48  :10261421183339593776: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.38, phi = -1.97, mass =  0.00
+Simulating Photon
+Made Cluster: et40  :3352899354953252904:    0.63 -0.38 -1.97 sub(et40, )
+Made SmearedCluster: es31  :3343889464066834463:    0.55 -0.38 -1.97 sub(es31, )
+Simulating Particle :ps49  :10261420627552370737: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.05, phi = -1.85, mass =  0.00
+Simulating Photon
+Made Cluster: et41  :3352898799166029865:    0.62  0.05 -1.85 sub(et41, )
+Made SmearedCluster: es32  :3343890487101620256:    0.58  0.05 -1.85 sub(es32, )
+Simulating Particle :ps50  :10261420163372941362: pdgid =   211, status =   1, q =  1, e =   0.6, theta =  1.12, phi =  2.27, mass =  0.14
+Simulating Hadron
+Made Track: tt23  :7964583776518930455:    0.59    0.25  1.12  2.27
+Made SmearedTrack: ts22  :7955576326526599190:    0.58    0.25  1.12  2.27
+Rejected SmearedTrack: ts22  :7955576326526599190:    0.58    0.25  1.12  2.27
+Made Cluster: ht24  :5658741344200294424:    0.60  1.51 -0.53 sub(ht24, )
+Made SmearedCluster: hs6   :5649763390776672262:    1.87  1.51 -0.53 sub(hs6, )
+Rejected SmearedCluster: hs6   :5649763390776672262:    1.87  1.51 -0.53 sub(hs6, )
+Simulating Particle :ps51  :10261417479590903859: pdgid =    11, status =   1, q = -1, e =   0.5, theta =  0.11, phi = -1.75, mass =  0.00
+Simulating Electron
+Made Track: tt24  :7964581669623562264:    0.53    0.52  0.11 -1.75
+Made SmearedTrack: ts22  :7955573404833153046:    0.50    0.49  0.11 -1.75
+Rejected SmearedTrack: ts22  :7955573404833153046:    0.50    0.49  0.11 -1.75
+Simulating Particle :ps52  :10261416102665912372: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.44, phi =  0.88, mass =  0.00
+Simulating Photon
+Made Cluster: et42  :3352894274279571498:    0.49  0.44  0.88 sub(et42, )
+Made SmearedCluster: es33  :3343889158769737761:    0.55  0.44  0.88 sub(es33, )
+Simulating Particle :ps53  :10261413774820900917: pdgid =   211, status =   1, q =  1, e =   0.5, theta =  0.09, phi = -2.44, mass =  0.14
+Simulating Hadron
+Made Track: tt25  :7964576440064671769:    0.44    0.44  0.09 -2.44
+Made SmearedTrack: ts22  :7955568712526856214:    0.43    0.43  0.09 -2.44
+Rejected SmearedTrack: ts22  :7955568712526856214:    0.43    0.43  0.09 -2.44
+Made Cluster: et43  :3352813774892433451:    0.02  1.33  1.39 sub(et43, )
+Made SmearedCluster: es34  :3343960427896766498:    9.15  1.33  1.39 sub(es34, )
+Made Cluster: ht25  :5658733418783965209:    0.44  1.29  2.54 sub(ht25, )
+Made SmearedCluster: hs6   :5647513932722601990:   -6.86  1.29  2.54 sub(hs6, )
+Rejected SmearedCluster: hs6   :5647513932722601990:   -6.86  1.29  2.54 sub(hs6, )
+Simulating Particle :ps54  :10261412595122569270: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.94, phi =  0.70, mass =  0.00
+Simulating Photon
+Made Cluster: et44  :3352890766736228396:    0.44  0.94  0.70 sub(et44, )
+Made SmearedCluster: es35  :3343872903975272483:    0.29  0.94  0.70 sub(es35, )
+Rejected SmearedCluster: es35  :3343872903975272483:    0.29  0.94  0.70 sub(es35, )
+Simulating Particle :ps55  :10261412412057976887: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.20, phi = -1.68, mass =  0.00
+Simulating Photon
+Made Cluster: et45  :3352890583671636013:    0.44 -0.20 -1.68 sub(et45, )
+Made SmearedCluster: es35  :3343887670066544675:    0.50 -0.20 -1.68 sub(es35, )
+Simulating Particle :ps56  :10261412093399924792: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -1.15, phi =  2.11, mass =  0.00
+Simulating Photon
+Made Cluster: et46  :3352890265013583918:    0.44 -1.15  2.11 sub(et46, )
+Made SmearedCluster: es36  :3341670923508908068:   -0.55 -1.15  2.11 sub(es36, )
+Rejected SmearedCluster: es36  :3341670923508908068:   -0.55 -1.15  2.11 sub(es36, )
+Simulating Particle :ps57  :10261412031949176889: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.49, phi = -2.23, mass =  0.00
+Simulating Photon
+Made Cluster: et47  :3352890203562836015:    0.44 -0.49 -2.23 sub(et47, )
+Made SmearedCluster: es36  :3343888584361902116:    0.53 -0.49 -2.23 sub(es36, )
+Simulating Particle :ps58  :10261407886393475130: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.24, phi = -1.71, mass =  0.00
+Simulating Photon
+Made Cluster: et48  :3352886058007134256:    0.38 -0.24 -1.71 sub(et48, )
+Made SmearedCluster: es37  :3343848049662230565:    0.11 -0.24 -1.71 sub(es37, )
+Rejected SmearedCluster: es37  :3343848049662230565:    0.11 -0.24 -1.71 sub(es37, )
+Simulating Particle :ps59  :10261407671221485627: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.33, phi =  1.81, mass =  0.00
+Simulating Photon
+Made Cluster: et49  :3352885842835144753:    0.37  0.33  1.81 sub(et49, )
+Made SmearedCluster: es37  :3343882149290836005:    0.42  0.33  1.81 sub(es37, )
+Simulating Particle :ps60  :10261406753893646396: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.39, phi =  1.13, mass =  0.00
+Simulating Photon
+Made Cluster: et50  :3352884925507305522:    0.36  0.39  1.13 sub(et50, )
+Made SmearedCluster: es38  :3343857690989297702:    0.16  0.39  1.13 sub(es38, )
+Rejected SmearedCluster: es38  :3343857690989297702:    0.16  0.39  1.13 sub(es38, )
+Simulating Particle :ps61  :10261406082456879165: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.15, phi = -1.76, mass =  0.00
+Simulating Photon
+Made Cluster: et51  :3352884254070538291:    0.35  0.15 -1.76 sub(et51, )
+Made SmearedCluster: es38  :3343885988383424550:    0.48  0.15 -1.76 sub(es38, )
+Simulating Particle :ps62  :10261403256922046526: pdgid =  -211, status =   1, q = -1, e =   0.3, theta = -0.64, phi = -3.13, mass =  0.14
+Simulating Hadron
+Made Track: tt26  :7964565118191140890:    0.28    0.22 -0.64 -3.13
+Made SmearedTrack: ts22  :7955557772733448214:    0.28    0.22 -0.64 -3.13
+Rejected SmearedTrack: ts22  :7955557772733448214:    0.28    0.22 -0.64 -3.13
+Made Cluster: et52  :3352854842243547188:    0.11 -1.46 -2.50 sub(et52, )
+Made SmearedCluster: es39  :3343894870998646823:    0.71 -1.46 -2.50 sub(es39, )
+Rejected SmearedCluster: es39  :3343894870998646823:    0.71 -1.46 -2.50 sub(es39, )
+Made Cluster: ht26  :5658713483875713050:    0.20 -1.51 -0.43 sub(ht26, )
+Made SmearedCluster: hs6   :5649803603884376070:    9.22 -1.51 -0.43 sub(hs6, )
+Simulating Particle :ps63  :10261401576371388479: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.46, phi =  1.18, mass =  0.00
+Simulating Photon
+Made Cluster: et53  :3352879747985047605:    0.29  0.46  1.18 sub(et53, )
+Made SmearedCluster: es39  :3343854682398261287:    0.14  0.46  1.18 sub(es39, )
+Rejected SmearedCluster: es39  :3343854682398261287:    0.14  0.46  1.18 sub(es39, )
+Simulating Particle :ps64  :10261400934873563200: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.56, phi =  1.18, mass =  0.00
+Simulating Photon
+Made Cluster: et54  :3352879106487222326:    0.28  0.56  1.18 sub(et54, )
+Made SmearedCluster: es39  :3343881323367366695:    0.41  0.56  1.18 sub(es39, )
+Simulating Particle :ps65  :10261399568677601345: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.18, phi =  0.34, mass =  0.00
+Simulating Photon
+Made Cluster: et55  :3352877740291260471:    0.26 -0.18  0.34 sub(et55, )
+Made SmearedCluster: es40  :3343866385540317224:    0.22 -0.18  0.34 sub(es40, )
+Rejected SmearedCluster: es40  :3343866385540317224:    0.22 -0.18  0.34 sub(es40, )
+Simulating Particle :ps66  :10261399504676716610: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.23, phi =  0.88, mass =  0.00
+Simulating Photon
+Made Cluster: et56  :3352877676290375736:    0.26 -0.23  0.88 sub(et56, )
+Made SmearedCluster: es40  :3343853112010997800:    0.13 -0.23  0.88 sub(es40, )
+Rejected SmearedCluster: es40  :3343853112010997800:    0.13 -0.23  0.88 sub(es40, )
+Simulating Particle :ps67  :10261399160932532291: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.25, phi = -1.88, mass =  0.00
+Simulating Photon
+Made Cluster: et57  :3352877332546191417:    0.25 -0.25 -1.88 sub(et57, )
+Made SmearedCluster: es40  :3343890240717717544:    0.58 -0.25 -1.88 sub(es40, )
+Simulating Particle :ps68  :10261398730760519748: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.51, phi =  0.48, mass =  0.00
+Simulating Photon
+Made Cluster: et58  :3352876902374178874:    0.25  0.51  0.48 sub(et58, )
+Made SmearedCluster: es41  :3343872714862493737:    0.29  0.51  0.48 sub(es41, )
+Rejected SmearedCluster: es41  :3343872714862493737:    0.29  0.51  0.48 sub(es41, )
+Simulating Particle :ps69  :10261393830345441349: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.48, phi =  0.54, mass =  0.00
+Simulating Photon
+Made Cluster: et59  :3352872001959100475:    0.21  0.48  0.54 sub(et59, )
+Made SmearedCluster: es41  :3343865229164412969:    0.22  0.48  0.54 sub(es41, )
+Rejected SmearedCluster: es41  :3343865229164412969:    0.22  0.48  0.54 sub(es41, )
+Simulating Particle :ps70  :10261393521330094150: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.14, phi = -1.92, mass =  0.00
+Simulating Photon
+Made Cluster: et60  :3352871692943753276:    0.21 -0.14 -1.92 sub(et60, )
+Made SmearedCluster: es41  :3343883212607717417:    0.44 -0.14 -1.92 sub(es41, )
+Simulating Particle :ps71  :10261391061127528519: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.20, phi = -1.88, mass =  0.00
+Simulating Photon
+Made Cluster: et61  :3352869232741187645:    0.19 -0.20 -1.88 sub(et61, )
+Made SmearedCluster: es42  :3343814840423546922:    0.03 -0.20 -1.88 sub(es42, )
+Rejected SmearedCluster: es42  :3343814840423546922:    0.03 -0.20 -1.88 sub(es42, )
+Simulating Particle :ps72  :10261382995929727048: pdgid =   -11, status =   1, q =  1, e =   0.1, theta =  0.11, phi = -1.74, mass =  0.00
+Simulating Electron
+Made Track: tt27  :7964547185836556315:    0.14    0.14  0.11 -1.74
+Made SmearedTrack: ts22  :7955542610620186646:    0.16    0.15  0.11 -1.74
+Rejected SmearedTrack: ts22  :7955542610620186646:    0.16    0.15  0.11 -1.74
+Simulating Particle :ps73  :10261380614710100041: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.89, phi = -0.47, mass =  0.00
+Simulating Photon
+Made Cluster: et62  :3352858786323759166:    0.12  0.89 -0.47 sub(et62, )
+Made SmearedCluster: es42  :3343839808897155114:    0.08  0.89 -0.47 sub(es42, )
+Rejected SmearedCluster: es42  :3343839808897155114:    0.08  0.89 -0.47 sub(es42, )
+Simulating Particle :ps74  :10261369953762410570: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  1.16, phi =  0.82, mass =  0.00
+Simulating Photon
+Made Cluster: et63  :3352848125376069695:    0.08  1.15  0.82 sub(et63, )
+Made SmearedCluster: es42  :3343896916004962346:    0.77  1.15  0.82 sub(es42, )
+Rejected SmearedCluster: es42  :3343896916004962346:    0.77  1.15  0.82 sub(es42, )
+Simulating Particle :ps75  :10261368997593219147: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.68, phi = -1.74, mass =  0.00
+Simulating Photon
+Made Cluster: et64  :3352847169206878272:    0.08 -0.68 -1.74 sub(et64, )
+Made SmearedCluster: es42  :3343859350209822762:    0.17 -0.68 -1.74 sub(es42, )
+Rejected SmearedCluster: es42  :3343859350209822762:    0.17 -0.68 -1.74 sub(es42, )
+Simulating Particle :ps76  :10261364288826376268: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -1.02, phi = -1.69, mass =  0.00
+Simulating Photon
+Made Cluster: et65  :3352842460440035393:    0.06 -1.02 -1.69 sub(et65, )
+Made SmearedCluster: es42  :3343865896694186026:    0.22 -1.02 -1.69 sub(es42, )
+Rejected SmearedCluster: es42  :3343865896694186026:    0.22 -1.02 -1.69 sub(es42, )
+Simulating Particle :ps77  :10261360117012234317: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.28, phi =  2.41, mass =  0.00
+Simulating Photon
+Made Cluster: et66  :3352838288625893442:    0.06 -0.28  2.41 sub(et66, )
+Made SmearedCluster: es42  :3341670923508908074:   -0.06 -0.28  2.41 sub(es42, )
+Rejected SmearedCluster: es42  :3341670923508908074:   -0.06 -0.28  2.41 sub(es42, )
+Made MergedCluster: em0   :3289838127838920704:    0.41  0.56  1.18 sub(es39, )
+Made MergedCluster: em1   :3289838953762390017:    0.42  0.33  1.81 sub(es37, )
+Made MergedCluster: em2   :3289840017079271426:    0.44 -0.14 -1.92 sub(es41, )
+Made MergedCluster: em3   :3289842792854978563:    0.48  0.15 -1.76 sub(es38, )
+Made MergedCluster: em4   :3289842794362830852:    0.48  0.02 -1.64 sub(es30, )
+Made MergedCluster: em5   :3289874889193816069:    1.74 -0.20 -1.70 sub(es22, es35, )
+Made MergedCluster: em6   :3289845388833456134:    0.53 -0.49 -2.23 sub(es36, )
+Made MergedCluster: em7   :3289911408510107655:    7.25  0.42  0.87 sub(es5, es9, es33, )
+Made MergedCluster: em8   :3289846268538388488:    0.55 -0.38 -1.97 sub(es31, )
+Made MergedCluster: em9   :3289847045189271561:    0.58 -0.25 -1.88 sub(es40, )
+Made MergedCluster: em10  :3289930319175614474:   15.10  0.02 -1.84 sub(es1, es4, es0, es27, es32, )
+Made MergedCluster: em11  :3289849115900379147:    0.64  0.73  0.73 sub(es24, )
+Made MergedCluster: em12  :3289852518103777292:    0.73  0.89  0.55 sub(es28, )
+Made MergedCluster: em13  :3289853302197452813:    0.75  0.46  1.02 sub(es29, )
+Made MergedCluster: em14  :3289897883905556494:    4.17 -0.07 -1.73 sub(es11, es20, es25, )
+Made MergedCluster: em15  :3289860001021034511:    0.95 -0.35 -1.68 sub(es26, )
+Made MergedCluster: em16  :3289864332849971216:    1.14  0.32  0.99 sub(es19, )
+Made MergedCluster: em17  :3289885531791425553:    2.68  0.58  0.96 sub(es16, es17, )
+Made MergedCluster: em18  :3289868785017683986:    1.39 -0.62 -2.17 sub(es7, )
+Made MergedCluster: em19  :3289875705757696019:    1.78  0.00 -1.74 sub(es13, )
+Made MergedCluster: em20  :3289877037566656532:    1.86  1.01  0.49 sub(es14, )
+Made MergedCluster: em21  :3289878414795735061:    1.94 -0.57 -1.91 sub(es3, )
+Made MergedCluster: em22  :3289879858332565526:    2.04  0.58  1.04 sub(es10, )
+Made MergedCluster: em23  :3289880469346189335:    2.11  0.46  1.13 sub(es12, )
+Made MergedCluster: em24  :3289882432997687320:    2.33  0.67  1.33 sub(es6, )
+Made MergedCluster: em25  :3289882557612556313:    2.34  0.70  2.20 sub(es23, )
+Made MergedCluster: em26  :3289917163499946010:    9.11  1.17 -0.42 sub(es2, es8, )
+Made MergedCluster: em27  :3289894117428953115:    3.66  0.41  0.00 sub(es15, )
+Made MergedCluster: em28  :3289896075946623004:    3.88 -0.85 -0.87 sub(es18, )
+Made MergedCluster: em29  :3289907108142645277:    6.27 -0.58 -0.21 sub(es21, )
+Made MergedCluster: em30  :3289917232368320542:    9.15  1.33  1.39 sub(es34, )
+Made MergedCluster: hm0   :5595718669201047552:    1.78  0.44 -0.31 sub(hs4, )
+Made MergedCluster: hm1   :5595739010942107649:    3.87 -0.61 -2.03 sub(hs3, )
+Made MergedCluster: hm2   :5595744668699590658:    5.03 -0.58 -1.83 sub(hs1, )
+Made MergedCluster: hm3   :5595748693060878339:    5.95  0.01 -1.45 sub(hs2, )
+Made MergedCluster: hm4   :5595758297901694980:    8.26  1.54 -2.30 sub(hs5, )
+Made MergedCluster: hm5   :5595760408355930117:    9.22 -1.51 -0.43 sub(hs6, )
+Made MergedCluster: hm6   :5595780193353465862:   20.44  0.01 -1.89 sub(hs0, )
+Made block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.4 (3289838127838920704)
+
+Made block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.4 (3289838953762390017)
+
+Made block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.4 (3289840017079271426)
+
+Made block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.5 (3289842792854978563)
+
+Made block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.5 (3289842794362830852)
+
+Made block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.5 (3289845388833456134)
+
+Made block:E1       :br6   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.6 (3289846268538388488)
+
+Made block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  0.6 (3289847045189271561)
+
+Made block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  0.6 (3289849115900379147)
+
+Made block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  0.7 (3289852518103777292)
+
+Made block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  0.8 (3289853302197452813)
+
+Made block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  0.9 (3289860001021034511)
+
+Made block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  1.1 (3289864332849971216)
+
+Made block:E1T1     :br13  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  2.4 (7955612171482693642)
+      e1 = em18      value=  1.4 (3289868785017683986)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  1.7 (3289874889193816069)
+
+Made block:E1       :br15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  1.8 (3289875705757696019)
+
+Made block:E1       :br16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em20      value=  1.9 (3289877037566656532)
+
+Made block:E1H1T1   :br17  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  5.2 (7955631826639257603)
+      h1 = hm2       value=  5.0 (5595744668699590658)
+      e2 = em21      value=  1.9 (3289878414795735061)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1       :br18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  2.0 (3289879858332565526)
+
+Made block:E1       :br19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  2.1 (3289880469346189335)
+
+Made block:E1T1     :br20  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  2.6 (7955614317166985225)
+      e1 = em24      value=  2.3 (3289882432997687320)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1H1T1   :br21  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts20      value=  0.9 (7955587291221590036)
+      h1 = hm4       value=  8.3 (5595758297901694980)
+      e2 = em25      value=  2.3 (3289882557612556313)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1       :br22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  2.7 (3289885531791425553)
+
+Made block:E1H1T1   :br23  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  1.6 (7955601242799996941)
+      h1 = hm0       value=  1.8 (5595718669201047552)
+      e2 = em27      value=  3.7 (3289894117428953115)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1T1     :br24  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  1.3 (7955595593835872271)
+      e1 = em28      value=  3.9 (3289896075946623004)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  4.2 (3289897883905556494)
+
+Made block:E1H1T1   :br26  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts18      value=  1.0 (7955591101203611666)
+      h1 = hm5       value=  9.2 (5595760408355930117)
+      e2 = em29      value=  6.3 (3289907108142645277)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.1752       .
+      e2  0.0000     ---       .
+
+Made block:E1       :br27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  7.2 (3289911408510107655)
+
+Made block:E1       :br28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em26      value=  9.1 (3289917163499946010)
+
+Made block:E1       :br29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em30      value=  9.1 (3289917232368320542)
+
+Made block:E1T1     :br30  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts4       value=  4.7 (7955629281290223620)
+      e1 = em10      value= 15.1 (3289930319175614474)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:H1       :br31  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm1       value=  3.9 (5595739010942107649)
+
+Made block:H1T1     :br32  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  4.4 (7955627954101288965)
+      h1 = hm3       value=  5.9 (5595748693060878339)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1       :br33  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm6       value= 20.4 (5595780193353465862)
+
+Made block:T1       :br34  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts21      value=  0.8 (7955584889615548437)
+
+Made block:T1       :br35  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts19      value=  0.9 (7955587896057004051)
+
+Made block:T1       :br36  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.1 (7955592607250251790)
+
+Made block:T1       :br37  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts17      value=  1.1 (7955593490801360913)
+
+Made block:T1       :br38  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  1.2 (7955594663425998864)
+
+Made block:T1       :br39  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.6 (7955602314832642060)
+
+Made block:T1       :br40  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  2.5 (7955612944430006283)
+
+Made block:T1       :br41  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  2.8 (7955615485385506824)
+
+Made block:T1       :br42  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts7       value=  2.8 (7955615727807889415)
+
+Made block:T1       :br43  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts6       value=  3.0 (7955617404489302022)
+
+Made block:T1       :br44  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts2       value= 12.9 (7955654689622589442)
+
+Made block:T1       :br45  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 50.5 (7955689261034897409)
+
+Made block:T1       :br46  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 56.7 (7955692685652656128)
+
+Splitting block:E1H1T1   :br26  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts18      value=  1.0 (7955591101203611666)
+      h1 = hm5       value=  9.2 (5595760408355930117)
+      e2 = em29      value=  6.3 (3289907108142645277)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.1752       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs0   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts18      value=  1.0 (7955591101203611666)
+      h1 = hm5       value=  9.2 (5595760408355930117)
+      e2 = em29      value=  6.3 (3289907108142645277)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.1752       .
+      e2  0.0000     ---       .
+
+Splitting block:E1H1T1   :br23  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  1.6 (7955601242799996941)
+      h1 = hm0       value=  1.8 (5595718669201047552)
+      e2 = em27      value=  3.7 (3289894117428953115)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs1   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  1.6 (7955601242799996941)
+      h1 = hm0       value=  1.8 (5595718669201047552)
+      e2 = em27      value=  3.7 (3289894117428953115)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:E1H1T1   :br21  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts20      value=  0.9 (7955587291221590036)
+      h1 = hm4       value=  8.3 (5595758297901694980)
+      e2 = em25      value=  2.3 (3289882557612556313)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts20      value=  0.9 (7955587291221590036)
+      h1 = hm4       value=  8.3 (5595758297901694980)
+      e2 = em25      value=  2.3 (3289882557612556313)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:E1H1T1   :br17  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  5.2 (7955631826639257603)
+      h1 = hm2       value=  5.0 (5595744668699590658)
+      e2 = em21      value=  1.9 (3289878414795735061)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs3   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  5.2 (7955631826639257603)
+      h1 = hm2       value=  5.0 (5595744668699590658)
+      e2 = em21      value=  1.9 (3289878414795735061)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:H1T1     :br32  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  4.4 (7955627954101288965)
+      h1 = hm3       value=  5.9 (5595748693060878339)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs4   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  4.4 (7955627954101288965)
+      h1 = hm3       value=  5.9 (5595748693060878339)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:E1T1     :br30  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts4       value=  4.7 (7955629281290223620)
+      e1 = em10      value= 15.1 (3289930319175614474)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs5   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts4       value=  4.7 (7955629281290223620)
+      e1 = em10      value= 15.1 (3289930319175614474)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br24  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  1.3 (7955595593835872271)
+      e1 = em28      value=  3.9 (3289896075946623004)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs6   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  1.3 (7955595593835872271)
+      e1 = em28      value=  3.9 (3289896075946623004)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br20  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  2.6 (7955614317166985225)
+      e1 = em24      value=  2.3 (3289882432997687320)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs7   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  2.6 (7955614317166985225)
+      e1 = em24      value=  2.3 (3289882432997687320)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br13  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  2.4 (7955612171482693642)
+      e1 = em18      value=  1.4 (3289868785017683986)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs8   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  2.4 (7955612171482693642)
+      e1 = em18      value=  1.4 (3289868785017683986)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:T1       :br46  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 56.7 (7955692685652656128)
+
+Made block:T1       :bs9   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 56.7 (7955692685652656128)
+
+Splitting block:T1       :br45  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 50.5 (7955689261034897409)
+
+Made block:T1       :bs10  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 50.5 (7955689261034897409)
+
+Splitting block:T1       :br44  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts2       value= 12.9 (7955654689622589442)
+
+Made block:T1       :bs11  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts2       value= 12.9 (7955654689622589442)
+
+Splitting block:T1       :br43  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts6       value=  3.0 (7955617404489302022)
+
+Made block:T1       :bs12  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts6       value=  3.0 (7955617404489302022)
+
+Splitting block:T1       :br42  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts7       value=  2.8 (7955615727807889415)
+
+Made block:T1       :bs13  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts7       value=  2.8 (7955615727807889415)
+
+Splitting block:T1       :br41  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  2.8 (7955615485385506824)
+
+Made block:T1       :bs14  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  2.8 (7955615485385506824)
+
+Splitting block:T1       :br40  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  2.5 (7955612944430006283)
+
+Made block:T1       :bs15  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  2.5 (7955612944430006283)
+
+Splitting block:T1       :br39  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.6 (7955602314832642060)
+
+Made block:T1       :bs16  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.6 (7955602314832642060)
+
+Splitting block:T1       :br38  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  1.2 (7955594663425998864)
+
+Made block:T1       :bs17  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  1.2 (7955594663425998864)
+
+Splitting block:T1       :br37  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts17      value=  1.1 (7955593490801360913)
+
+Made block:T1       :bs18  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts17      value=  1.1 (7955593490801360913)
+
+Splitting block:T1       :br36  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.1 (7955592607250251790)
+
+Made block:T1       :bs19  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.1 (7955592607250251790)
+
+Splitting block:T1       :br35  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts19      value=  0.9 (7955587896057004051)
+
+Made block:T1       :bs20  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts19      value=  0.9 (7955587896057004051)
+
+Splitting block:T1       :br34  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts21      value=  0.8 (7955584889615548437)
+
+Made block:T1       :bs21  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts21      value=  0.8 (7955584889615548437)
+
+Splitting block:H1       :br33  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm6       value= 20.4 (5595780193353465862)
+
+Made block:H1       :bs22  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm6       value= 20.4 (5595780193353465862)
+
+Splitting block:H1       :br31  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm1       value=  3.9 (5595739010942107649)
+
+Made block:H1       :bs23  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm1       value=  3.9 (5595739010942107649)
+
+Splitting block:E1       :br29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em30      value=  9.1 (3289917232368320542)
+
+Made block:E1       :bs24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em30      value=  9.1 (3289917232368320542)
+
+Splitting block:E1       :br28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em26      value=  9.1 (3289917163499946010)
+
+Made block:E1       :bs25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em26      value=  9.1 (3289917163499946010)
+
+Splitting block:E1       :br27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  7.2 (3289911408510107655)
+
+Made block:E1       :bs26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  7.2 (3289911408510107655)
+
+Splitting block:E1       :br25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  4.2 (3289897883905556494)
+
+Made block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  4.2 (3289897883905556494)
+
+Splitting block:E1       :br22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  2.7 (3289885531791425553)
+
+Made block:E1       :bs28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  2.7 (3289885531791425553)
+
+Splitting block:E1       :br19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  2.1 (3289880469346189335)
+
+Made block:E1       :bs29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  2.1 (3289880469346189335)
+
+Splitting block:E1       :br18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  2.0 (3289879858332565526)
+
+Made block:E1       :bs30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  2.0 (3289879858332565526)
+
+Splitting block:E1       :br16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em20      value=  1.9 (3289877037566656532)
+
+Made block:E1       :bs31  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em20      value=  1.9 (3289877037566656532)
+
+Splitting block:E1       :br15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  1.8 (3289875705757696019)
+
+Made block:E1       :bs32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  1.8 (3289875705757696019)
+
+Splitting block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  1.7 (3289874889193816069)
+
+Made block:E1       :bs33  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  1.7 (3289874889193816069)
+
+Splitting block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  1.1 (3289864332849971216)
+
+Made block:E1       :bs34  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  1.1 (3289864332849971216)
+
+Splitting block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  0.9 (3289860001021034511)
+
+Made block:E1       :bs35  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  0.9 (3289860001021034511)
+
+Splitting block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  0.8 (3289853302197452813)
+
+Made block:E1       :bs36  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  0.8 (3289853302197452813)
+
+Splitting block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  0.7 (3289852518103777292)
+
+Made block:E1       :bs37  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  0.7 (3289852518103777292)
+
+Splitting block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  0.6 (3289849115900379147)
+
+Made block:E1       :bs38  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  0.6 (3289849115900379147)
+
+Splitting block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  0.6 (3289847045189271561)
+
+Made block:E1       :bs39  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  0.6 (3289847045189271561)
+
+Splitting block:E1       :br6   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.6 (3289846268538388488)
+
+Made block:E1       :bs40  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.6 (3289846268538388488)
+
+Splitting block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.5 (3289845388833456134)
+
+Made block:E1       :bs41  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.5 (3289845388833456134)
+
+Splitting block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.5 (3289842794362830852)
+
+Made block:E1       :bs42  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.5 (3289842794362830852)
+
+Splitting block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.5 (3289842792854978563)
+
+Made block:E1       :bs43  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.5 (3289842792854978563)
+
+Splitting block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.4 (3289840017079271426)
+
+Made block:E1       :bs44  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.4 (3289840017079271426)
+
+Splitting block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.4 (3289838953762390017)
+
+Made block:E1       :bs45  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.4 (3289838953762390017)
+
+Splitting block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.4 (3289838127838920704)
+
+Made block:E1       :bs46  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.4 (3289838127838920704)
+
+Processing block:E1H1T1   :bs3   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value=  5.2 (7955631826639257603)
+      h1 = hm2       value=  5.0 (5595744668699590658)
+      e2 = em21      value=  1.9 (3289878414795735061)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr0   :10252467644693217280: pdgid =  -211, status =   1, q = -1, e =   5.3, theta = -0.57, phi = -2.08, mass =  0.14 from SmearedTrack: ts3   :7955631826639257603:    5.25    4.41 -0.57 -2.08
+Finished block
+Processing block:E1H1T1   :bs2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts20      value=  0.9 (7955587291221590036)
+      h1 = hm4       value=  8.3 (5595758297901694980)
+      e2 = em25      value=  2.3 (3289882557612556313)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr1   :10252423480645517313: pdgid =  -211, status =   1, q = -1, e =   0.9, theta =  0.56, phi =  0.90, mass =  0.14 from SmearedTrack: ts20  :7955587291221590036:    0.89    0.76  0.56  0.90
+Finished block
+Processing block:E1H1T1   :bs1   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  1.6 (7955601242799996941)
+      h1 = hm0       value=  1.8 (5595718669201047552)
+      e2 = em27      value=  3.7 (3289894117428953115)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr2   :10252437160539979778: pdgid =   211, status =   1, q =  1, e =   1.6, theta =  0.39, phi =  0.55, mass =  0.14 from SmearedTrack: ts13  :7955601242799996941:    1.57    1.45  0.39  0.55
+Finished block
+Processing block:E1H1T1   :bs0   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts18      value=  1.0 (7955591101203611666)
+      h1 = hm5       value=  9.2 (5595760408355930117)
+      e2 = em29      value=  6.3 (3289907108142645277)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.1752       .
+      e2  0.0000     ---       .
+
+Made Particle :pr3   :10252427104708722691: pdgid =   211, status =   1, q =  1, e =   1.0, theta = -0.50, phi =  0.82, mass =  0.14 from SmearedTrack: ts18  :7955591101203611666:    1.00    0.88 -0.50  0.82
+Made Particle :pr4   :10252480227055763460: pdgid =   130, status =   1, q =  0, e =   8.2, theta = -1.51, phi = -0.43, mass =  0.50 from MergedCluster: hm5   :5595760408355930117:    9.22 -1.51 -0.43 sub(hs6, )
+Made Particle :pr5   :10252472132057432069: pdgid =    22, status =   1, q =  0, e =   6.3, theta = -1.51, phi = -0.43, mass =  0.00 from MergedCluster: hm5   :5595760408355930117:    9.22 -1.51 -0.43 sub(hs6, )
+Finished block
+Processing block:E1T1     :bs8   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  2.4 (7955612171482693642)
+      e1 = em18      value=  1.4 (3289868785017683986)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr6   :10252448016967401478: pdgid =   211, status =   1, q =  1, e =   2.4, theta = -0.61, phi = -1.79, mass =  0.14 from SmearedTrack: ts10  :7955612171482693642:    2.39    1.96 -0.61 -1.79
+Finished block
+Processing block:E1T1     :bs7   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  2.6 (7955614317166985225)
+      e1 = em24      value=  2.3 (3289882432997687320)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr7   :10252450159367553031: pdgid =  -211, status =   1, q = -1, e =   2.6, theta =  0.66, phi =  0.97, mass =  0.14 from SmearedTrack: ts9   :7955614317166985225:    2.63    2.07  0.66  0.97
+Finished block
+Processing block:E1T1     :bs6   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  1.3 (7955595593835872271)
+      e1 = em28      value=  3.9 (3289896075946623004)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr8   :10252431539054837768: pdgid =  -211, status =   1, q = -1, e =   1.3, theta = -0.77, phi = -1.84, mass =  0.14 from SmearedTrack: ts15  :7955595593835872271:    1.25    0.90 -0.77 -1.84
+Finished block
+Processing block:E1T1     :bs5   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts4       value=  4.7 (7955629281290223620)
+      e1 = em10      value= 15.1 (3289930319175614474)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr9   :10252465100344524809: pdgid =   211, status =   1, q =  1, e =   4.7, theta = -0.03, phi = -1.80, mass =  0.14 from SmearedTrack: ts4   :7955629281290223620:    4.67    4.67 -0.03 -1.80
+Finished block
+Processing block:H1T1     :bs4   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  4.4 (7955627954101288965)
+      h1 = hm3       value=  5.9 (5595748693060878339)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr10  :10252463773784735754: pdgid =  -211, status =   1, q = -1, e =   4.4, theta =  0.01, phi = -1.70, mass =  0.14 from SmearedTrack: ts5   :7955627954101288965:    4.37    4.37  0.01 -1.70
+Finished block
+Processing block:E1       :bs46  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.4 (3289838127838920704)
+
+Made Particle :pr11  :10252403151753707531: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.56, phi =  1.18, mass =  0.00 from MergedCluster: em0   :3289838127838920704:    0.41  0.56  1.18 sub(es39, )
+Finished block
+Processing block:E1       :bs45  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.4 (3289838953762390017)
+
+Made Particle :pr12  :10252403977677176844: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.33, phi =  1.81, mass =  0.00 from MergedCluster: em1   :3289838953762390017:    0.42  0.33  1.81 sub(es37, )
+Finished block
+Processing block:E1       :bs44  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.4 (3289840017079271426)
+
+Made Particle :pr13  :10252405040994058253: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.14, phi = -1.92, mass =  0.00 from MergedCluster: em2   :3289840017079271426:    0.44 -0.14 -1.92 sub(es41, )
+Finished block
+Processing block:E1       :bs43  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.5 (3289842792854978563)
+
+Made Particle :pr14  :10252407816769765390: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.15, phi = -1.76, mass =  0.00 from MergedCluster: em3   :3289842792854978563:    0.48  0.15 -1.76 sub(es38, )
+Finished block
+Processing block:E1       :bs42  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.5 (3289842794362830852)
+
+Made Particle :pr15  :10252407818277617679: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.02, phi = -1.64, mass =  0.00 from MergedCluster: em4   :3289842794362830852:    0.48  0.02 -1.64 sub(es30, )
+Finished block
+Processing block:E1       :bs41  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.5 (3289845388833456134)
+
+Made Particle :pr16  :10252410412748242960: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.49, phi = -2.23, mass =  0.00 from MergedCluster: em6   :3289845388833456134:    0.53 -0.49 -2.23 sub(es36, )
+Finished block
+Processing block:E1       :bs40  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.6 (3289846268538388488)
+
+Made Particle :pr17  :10252411292453175313: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.38, phi = -1.97, mass =  0.00 from MergedCluster: em8   :3289846268538388488:    0.55 -0.38 -1.97 sub(es31, )
+Finished block
+Processing block:E1       :bs39  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  0.6 (3289847045189271561)
+
+Made Particle :pr18  :10252412069104058386: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.25, phi = -1.88, mass =  0.00 from MergedCluster: em9   :3289847045189271561:    0.58 -0.25 -1.88 sub(es40, )
+Finished block
+Processing block:E1       :bs38  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  0.6 (3289849115900379147)
+
+Made Particle :pr19  :10252414139815165971: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.73, phi =  0.73, mass =  0.00 from MergedCluster: em11  :3289849115900379147:    0.64  0.73  0.73 sub(es24, )
+Finished block
+Processing block:E1       :bs37  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  0.7 (3289852518103777292)
+
+Made Particle :pr20  :10252417542018564116: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.89, phi =  0.55, mass =  0.00 from MergedCluster: em12  :3289852518103777292:    0.73  0.89  0.55 sub(es28, )
+Finished block
+Processing block:E1       :bs36  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  0.8 (3289853302197452813)
+
+Made Particle :pr21  :10252418326112239637: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.46, phi =  1.02, mass =  0.00 from MergedCluster: em13  :3289853302197452813:    0.75  0.46  1.02 sub(es29, )
+Finished block
+Processing block:E1       :bs35  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  0.9 (3289860001021034511)
+
+Made Particle :pr22  :10252425024935821334: pdgid =    22, status =   1, q =  0, e =   0.9, theta = -0.35, phi = -1.68, mass =  0.00 from MergedCluster: em15  :3289860001021034511:    0.95 -0.35 -1.68 sub(es26, )
+Finished block
+Processing block:E1       :bs34  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  1.1 (3289864332849971216)
+
+Made Particle :pr23  :10252429356764758039: pdgid =    22, status =   1, q =  0, e =   1.1, theta =  0.32, phi =  0.99, mass =  0.00 from MergedCluster: em16  :3289864332849971216:    1.14  0.32  0.99 sub(es19, )
+Finished block
+Processing block:E1       :bs33  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  1.7 (3289874889193816069)
+
+Made Particle :pr24  :10252439913108602904: pdgid =    22, status =   1, q =  0, e =   1.7, theta = -0.20, phi = -1.70, mass =  0.00 from MergedCluster: em5   :3289874889193816069:    1.74 -0.20 -1.70 sub(es22, es35, )
+Finished block
+Processing block:E1       :bs32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  1.8 (3289875705757696019)
+
+Made Particle :pr25  :10252440729672482841: pdgid =    22, status =   1, q =  0, e =   1.8, theta =  0.00, phi = -1.74, mass =  0.00 from MergedCluster: em19  :3289875705757696019:    1.78  0.00 -1.74 sub(es13, )
+Finished block
+Processing block:E1       :bs31  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em20      value=  1.9 (3289877037566656532)
+
+Made Particle :pr26  :10252442061481443354: pdgid =    22, status =   1, q =  0, e =   1.9, theta =  1.01, phi =  0.49, mass =  0.00 from MergedCluster: em20  :3289877037566656532:    1.86  1.01  0.49 sub(es14, )
+Finished block
+Processing block:E1       :bs30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  2.0 (3289879858332565526)
+
+Made Particle :pr27  :10252444882247352347: pdgid =    22, status =   1, q =  0, e =   2.0, theta =  0.58, phi =  1.04, mass =  0.00 from MergedCluster: em22  :3289879858332565526:    2.04  0.58  1.04 sub(es10, )
+Finished block
+Processing block:E1       :bs29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  2.1 (3289880469346189335)
+
+Made Particle :pr28  :10252445493260976156: pdgid =    22, status =   1, q =  0, e =   2.1, theta =  0.46, phi =  1.13, mass =  0.00 from MergedCluster: em23  :3289880469346189335:    2.11  0.46  1.13 sub(es12, )
+Finished block
+Processing block:E1       :bs28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  2.7 (3289885531791425553)
+
+Made Particle :pr29  :10252450555706212381: pdgid =    22, status =   1, q =  0, e =   2.7, theta =  0.58, phi =  0.96, mass =  0.00 from MergedCluster: em17  :3289885531791425553:    2.68  0.58  0.96 sub(es16, es17, )
+Finished block
+Processing block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  4.2 (3289897883905556494)
+
+Made Particle :pr30  :10252462907820343326: pdgid =    22, status =   1, q =  0, e =   4.2, theta = -0.07, phi = -1.73, mass =  0.00 from MergedCluster: em14  :3289897883905556494:    4.17 -0.07 -1.73 sub(es11, es20, es25, )
+Finished block
+Processing block:E1       :bs26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  7.2 (3289911408510107655)
+
+Made Particle :pr31  :10252476432424894495: pdgid =    22, status =   1, q =  0, e =   7.2, theta =  0.42, phi =  0.87, mass =  0.00 from MergedCluster: em7   :3289911408510107655:    7.25  0.42  0.87 sub(es5, es9, es33, )
+Finished block
+Processing block:E1       :bs25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em26      value=  9.1 (3289917163499946010)
+
+Made Particle :pr32  :10252482187414732832: pdgid =    22, status =   1, q =  0, e =   9.1, theta =  1.17, phi = -0.42, mass =  0.00 from MergedCluster: em26  :3289917163499946010:    9.11  1.17 -0.42 sub(es2, es8, )
+Finished block
+Processing block:E1       :bs24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em30      value=  9.1 (3289917232368320542)
+
+Made Particle :pr33  :10252482256283107361: pdgid =    22, status =   1, q =  0, e =   9.1, theta =  1.33, phi =  1.39, mass =  0.00 from MergedCluster: em30  :3289917232368320542:    9.15  1.33  1.39 sub(es34, )
+Finished block
+Processing block:H1       :bs23  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm1       value=  3.9 (5595739010942107649)
+
+Made Particle :pr34  :10252461025643200546: pdgid =   130, status =   1, q =  0, e =   3.9, theta = -0.61, phi = -2.03, mass =  0.50 from MergedCluster: hm1   :5595739010942107649:    3.87 -0.61 -2.03 sub(hs3, )
+Finished block
+Processing block:H1       :bs22  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm6       value= 20.4 (5595780193353465862)
+
+Made Particle :pr35  :10252502208054558755: pdgid =   130, status =   1, q =  0, e =  20.4, theta =  0.01, phi = -1.89, mass =  0.50 from MergedCluster: hm6   :5595780193353465862:   20.44  0.01 -1.89 sub(hs0, )
+Finished block
+Processing block:T1       :bs21  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts21      value=  0.8 (7955584889615548437)
+
+Made Particle :pr36  :10252421110121365540: pdgid =  -211, status =   1, q = -1, e =   0.8, theta = -0.55, phi = -1.30, mass =  0.14 from SmearedTrack: ts21  :7955584889615548437:    0.82    0.70 -0.55 -1.30
+Finished block
+Processing block:T1       :bs20  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts19      value=  0.9 (7955587896057004051)
+
+Made Particle :pr37  :10252424078375780389: pdgid =   211, status =   1, q =  1, e =   0.9, theta = -0.81, phi =  0.30, mass =  0.14 from SmearedTrack: ts19  :7955587896057004051:    0.91    0.63 -0.81  0.30
+Finished block
+Processing block:T1       :bs19  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.1 (7955592607250251790)
+
+Made Particle :pr38  :10252428573512040486: pdgid =   211, status =   1, q =  1, e =   1.1, theta = -0.86, phi =  0.36, mass =  0.14 from SmearedTrack: ts14  :7955592607250251790:    1.08    0.71 -0.86  0.36
+Finished block
+Processing block:T1       :bs18  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts17      value=  1.1 (7955593490801360913)
+
+Made Particle :pr39  :10252429450188685351: pdgid =  -211, status =   1, q = -1, e =   1.1, theta =  0.98, phi = -0.32, mass =  0.14 from SmearedTrack: ts17  :7955593490801360913:    1.13    0.63  0.98 -0.32
+Finished block
+Processing block:T1       :bs17  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  1.2 (7955594663425998864)
+
+Made Particle :pr40  :10252430614567321640: pdgid =  -211, status =   1, q = -1, e =   1.2, theta = -0.31, phi = -1.89, mass =  0.14 from SmearedTrack: ts16  :7955594663425998864:    1.20    1.14 -0.31 -1.89
+Finished block
+Processing block:T1       :bs16  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.6 (7955602314832642060)
+
+Made Particle :pr41  :10252438228571258921: pdgid =   211, status =   1, q =  1, e =   1.6, theta =  0.42, phi =  1.15, mass =  0.14 from SmearedTrack: ts12  :7955602314832642060:    1.63    1.49  0.42  1.15
+Finished block
+Processing block:T1       :bs15  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  2.5 (7955612944430006283)
+
+Made Particle :pr42  :10252448788656422954: pdgid =  -211, status =   1, q = -1, e =   2.5, theta = -0.18, phi =  0.50, mass =  0.14 from SmearedTrack: ts11  :7955612944430006283:    2.48    2.44 -0.18  0.50
+Finished block
+Processing block:T1       :bs14  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  2.8 (7955615485385506824)
+
+Made Particle :pr43  :10252451326038376491: pdgid =  -211, status =   1, q = -1, e =   2.8, theta =  0.55, phi =  1.31, mass =  0.14 from SmearedTrack: ts8   :7955615485385506824:    2.77    2.36  0.55  1.31
+Finished block
+Processing block:T1       :bs13  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts7       value=  2.8 (7955615727807889415)
+
+Made Particle :pr44  :10252451568158769196: pdgid =   211, status =   1, q =  1, e =   2.8, theta = -0.50, phi = -2.20, mass =  0.14 from SmearedTrack: ts7   :7955615727807889415:    2.79    2.46 -0.50 -2.20
+Finished block
+Processing block:T1       :bs12  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts6       value=  3.0 (7955617404489302022)
+
+Made Particle :pr45  :10252453242902413357: pdgid =   211, status =   1, q =  1, e =   3.0, theta = -0.03, phi = -1.83, mass =  0.14 from SmearedTrack: ts6   :7955617404489302022:    2.98    2.98 -0.03 -1.83
+Finished block
+Processing block:T1       :bs11  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts2       value= 12.9 (7955654689622589442)
+
+Made Particle :pr46  :10252490501227806766: pdgid =   211, status =   1, q =  1, e =  12.9, theta =  1.05, phi = -0.27, mass =  0.14 from SmearedTrack: ts2   :7955654689622589442:   12.89    6.42  1.05 -0.27
+Finished block
+Processing block:T1       :bs10  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 50.5 (7955689261034897409)
+
+Made Particle :pr47  :10252525071052570671: pdgid =   -13, status =   1, q = -1, e =  50.5, theta =  0.56, phi =  2.35, mass =  0.11 from SmearedTrack: ts1   :7955689261034897409:   50.46   42.73  0.56  2.35
+Finished block
+Processing block:T1       :bs9   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 56.7 (7955692685652656128)
+
+Made Particle :pr48  :10252528495666135088: pdgid =    13, status =   1, q =  1, e =  56.7, theta = -1.14, phi =  0.59, mass =  0.10 from SmearedTrack: ts0   :7955692685652656128:   56.69   23.58 -1.14  0.59
+Finished block
+Finished reconstruction
+Event: 4
+Made Particle :ps0   :10261532433513971712: pdgid =    13, status =   1, q = -1, e =  50.8, theta = -1.36, phi =  0.53, mass =  0.11
+Made Particle :ps1   :10261529486740684801: pdgid =   -13, status =   1, q =  1, e =  45.4, theta =  0.70, phi = -1.07, mass =  0.11
+Made Particle :ps2   :10261491712857735170: pdgid =    22, status =   1, q =  0, e =  10.2, theta = -1.57, phi = -1.05, mass =  0.00
+Made Particle :ps3   :10261482322549276675: pdgid =  -211, status =   1, q = -1, e =   7.0, theta =  0.29, phi = -2.36, mass =  0.14
+Made Particle :ps4   :10261478667913789444: pdgid =   130, status =   1, q =  0, e =   6.1, theta =  0.69, phi =  1.33, mass =  0.50
+Made Particle :ps5   :10261478054396166149: pdgid = -2112, status =   1, q =  0, e =   6.0, theta =  0.18, phi =  1.54, mass =  0.94
+Made Particle :ps6   :10261474455303749638: pdgid =  2212, status =   1, q =  1, e =   5.2, theta =  0.17, phi = -2.40, mass =  0.94
+Made Particle :ps7   :10261473583326822407: pdgid =   211, status =   1, q =  1, e =   5.0, theta = -0.07, phi = -2.65, mass =  0.14
+Made Particle :ps8   :10261469588944322568: pdgid =  -211, status =   1, q = -1, e =   4.1, theta =  0.36, phi =  1.12, mass =  0.14
+Made Particle :ps9   :10261468910414987273: pdgid =  2212, status =   1, q =  1, e =   4.0, theta =  0.20, phi =  1.27, mass =  0.94
+Made Particle :ps10  :10261467715317268490: pdgid =   130, status =   1, q =  0, e =   3.8, theta = -0.01, phi = -2.63, mass =  0.50
+Made Particle :ps11  :10261467195584282635: pdgid = -2212, status =   1, q = -1, e =   3.8, theta =  0.21, phi = -2.60, mass =  0.94
+Made Particle :ps12  :10261466455046357004: pdgid =  -321, status =   1, q = -1, e =   3.7, theta =  0.09, phi =  0.98, mass =  0.49
+Made Particle :ps13  :10261465789678747661: pdgid =   211, status =   1, q =  1, e =   3.6, theta =  0.05, phi = -2.79, mass =  0.14
+Made Particle :ps14  :10261465273674498062: pdgid =   211, status =   1, q =  1, e =   3.5, theta =  0.18, phi =  1.33, mass =  0.14
+Made Particle :ps15  :10261462872496275471: pdgid =    22, status =   1, q =  0, e =   3.3, theta =  0.04, phi =  1.10, mass =  0.00
+Made Particle :ps16  :10261462730940612624: pdgid =  -321, status =   1, q = -1, e =   3.2, theta =  0.17, phi =  1.08, mass =  0.49
+Made Particle :ps17  :10261462058555932689: pdgid =   211, status =   1, q =  1, e =   3.2, theta =  0.18, phi = -2.55, mass =  0.14
+Made Particle :ps18  :10261460680179712018: pdgid =    22, status =   1, q =  0, e =   3.0, theta =  0.24, phi =  1.28, mass =  0.00
+Made Particle :ps19  :10261460455895597075: pdgid =  -211, status =   1, q = -1, e =   3.0, theta =  0.36, phi =  1.28, mass =  0.14
+Made Particle :ps20  :10261457432794365972: pdgid =   211, status =   1, q =  1, e =   2.6, theta =  0.79, phi = -2.35, mass =  0.14
+Made Particle :ps21  :10261456140890013717: pdgid =  -321, status =   1, q = -1, e =   2.5, theta =  0.23, phi =  1.04, mass =  0.49
+Made Particle :ps22  :10261454141647749142: pdgid =   130, status =   1, q =  0, e =   2.3, theta =  1.20, phi =  0.23, mass =  0.50
+Made Particle :ps23  :10261454125499678743: pdgid =    22, status =   1, q =  0, e =   2.3, theta =  0.21, phi =  0.97, mass =  0.00
+Made Particle :ps24  :10261453244318351384: pdgid =   211, status =   1, q =  1, e =   2.2, theta =  0.26, phi =  1.14, mass =  0.14
+Made Particle :ps25  :10261451841055227929: pdgid =    22, status =   1, q =  0, e =   2.0, theta =  0.35, phi = -2.39, mass =  0.00
+Made Particle :ps26  :10261450777530728474: pdgid =  -211, status =   1, q = -1, e =   1.9, theta =  0.80, phi =  1.93, mass =  0.14
+Made Particle :ps27  :10261450735510093851: pdgid =   211, status =   1, q =  1, e =   1.9, theta =  0.36, phi = -2.02, mass =  0.14
+Made Particle :ps28  :10261450350672216092: pdgid =    22, status =   1, q =  0, e =   1.9, theta = -0.13, phi = -2.74, mass =  0.00
+Made Particle :ps29  :10261448640794984477: pdgid =   321, status =   1, q =  1, e =   1.8, theta = -0.06, phi =  0.82, mass =  0.49
+Made Particle :ps30  :10261447687901544478: pdgid =  -211, status =   1, q = -1, e =   1.8, theta =  0.40, phi =  1.48, mass =  0.14
+Made Particle :ps31  :10261445944419549215: pdgid =   211, status =   1, q =  1, e =   1.7, theta =  0.21, phi = -2.20, mass =  0.14
+Made Particle :ps32  :10261445607323336736: pdgid =  -211, status =   1, q = -1, e =   1.7, theta =  0.46, phi =  1.42, mass =  0.14
+Made Particle :ps33  :10261444176688185377: pdgid =  -211, status =   1, q = -1, e =   1.6, theta =  0.21, phi = -2.21, mass =  0.14
+Made Particle :ps34  :10261442273923301410: pdgid =    22, status =   1, q =  0, e =   1.5, theta =  0.10, phi = -2.76, mass =  0.00
+Made Particle :ps35  :10261441811927007267: pdgid =   211, status =   1, q =  1, e =   1.4, theta =  0.12, phi =  1.49, mass =  0.14
+Made Particle :ps36  :10261441528297685028: pdgid =   321, status =   1, q =  1, e =   1.4, theta =  0.13, phi =  1.50, mass =  0.49
+Made Particle :ps37  :10261438662717734949: pdgid =    22, status =   1, q =  0, e =   1.3, theta =  0.50, phi = -2.56, mass =  0.00
+Made Particle :ps38  :10261438189751238694: pdgid =    22, status =   1, q =  0, e =   1.2, theta =  0.29, phi = -2.42, mass =  0.00
+Made Particle :ps39  :10261438053662851111: pdgid =    22, status =   1, q =  0, e =   1.2, theta =  0.25, phi = -2.43, mass =  0.00
+Made Particle :ps40  :10261437990593101864: pdgid =   321, status =   1, q =  1, e =   1.2, theta =  0.49, phi =  1.21, mass =  0.49
+Made Particle :ps41  :10261437524874362921: pdgid =   211, status =   1, q =  1, e =   1.2, theta =  0.13, phi =  1.58, mass =  0.14
+Made Particle :ps42  :10261437145824624682: pdgid =  -211, status =   1, q = -1, e =   1.2, theta =  0.02, phi =  1.51, mass =  0.14
+Made Particle :ps43  :10261436736085164075: pdgid =  -211, status =   1, q = -1, e =   1.1, theta =  0.24, phi = -2.29, mass =  0.14
+Made Particle :ps44  :10261436180971126828: pdgid =   -11, status =   1, q =  1, e =   1.1, theta = -0.49, phi =  1.21, mass =  0.00
+Made Particle :ps45  :10261434332436496429: pdgid =  -321, status =   1, q = -1, e =   1.0, theta =  1.04, phi = -2.73, mass =  0.49
+Made Particle :ps46  :10261432927439028270: pdgid =    22, status =   1, q =  0, e =   1.0, theta = -0.22, phi = -2.52, mass =  0.00
+Made Particle :ps47  :10261431673327452207: pdgid =    22, status =   1, q =  0, e =   0.9, theta =  0.59, phi = -2.70, mass =  0.00
+Made Particle :ps48  :10261430531044409392: pdgid =   211, status =   1, q =  1, e =   0.9, theta =  0.81, phi =  1.94, mass =  0.14
+Made Particle :ps49  :10261430052147167281: pdgid =    22, status =   1, q =  0, e =   0.9, theta = -0.02, phi = -2.79, mass =  0.00
+Made Particle :ps50  :10261429979409547314: pdgid =    22, status =   1, q =  0, e =   0.9, theta =  0.06, phi = -2.58, mass =  0.00
+Made Particle :ps51  :10261426554150060083: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.29, phi =  3.01, mass =  0.00
+Made Particle :ps52  :10261423639159111732: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.12, phi = -2.49, mass =  0.00
+Made Particle :ps53  :10261423226116636725: pdgid =    22, status =   1, q =  0, e =   0.7, theta = -0.20, phi = -2.69, mass =  0.00
+Made Particle :ps54  :10261422851913416758: pdgid =  -211, status =   1, q = -1, e =   0.7, theta = -0.10, phi = -2.76, mass =  0.14
+Made Particle :ps55  :10261421777378869303: pdgid =  -211, status =   1, q = -1, e =   0.6, theta = -0.49, phi =  0.88, mass =  0.14
+Made Particle :ps56  :10261421625471664184: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.23, phi = -2.37, mass =  0.00
+Made Particle :ps57  :10261421082451902521: pdgid =   211, status =   1, q =  1, e =   0.6, theta =  0.05, phi =  0.98, mass =  0.14
+Made Particle :ps58  :10261419761665572922: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  1.13, phi = -2.84, mass =  0.00
+Made Particle :ps59  :10261416690503909435: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.04, phi = -2.64, mass =  0.00
+Made Particle :ps60  :10261415532160876604: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.54, phi = -2.19, mass =  0.00
+Made Particle :ps61  :10261415429612240957: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.15, phi = -2.41, mass =  0.00
+Made Particle :ps62  :10261414110660919358: pdgid =   211, status =   1, q =  1, e =   0.5, theta =  0.31, phi =  0.72, mass =  0.14
+Made Particle :ps63  :10261413498028294207: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.25, phi = -2.68, mass =  0.00
+Made Particle :ps64  :10261412190248501312: pdgid =  -211, status =   1, q = -1, e =   0.4, theta =  0.78, phi = -1.99, mass =  0.14
+Made Particle :ps65  :10261411295540543553: pdgid =  -211, status =   1, q = -1, e =   0.4, theta = -0.21, phi =  0.76, mass =  0.14
+Made Particle :ps66  :10261410230157967426: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.07, phi = -2.70, mass =  0.00
+Made Particle :ps67  :10261407898575831107: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.00, phi =  1.21, mass =  0.00
+Made Particle :ps68  :10261407375778906180: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.42, phi = -2.35, mass =  0.00
+Made Particle :ps69  :10261407349388345413: pdgid =   211, status =   1, q =  1, e =   0.4, theta =  0.81, phi =  1.37, mass =  0.14
+Made Particle :ps70  :10261406918174048326: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.56, phi = -2.43, mass =  0.00
+Made Particle :ps71  :10261404348539994183: pdgid =  -211, status =   1, q = -1, e =   0.3, theta =  0.12, phi =  1.49, mass =  0.14
+Made Particle :ps72  :10261402016314032200: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.07, phi = -2.50, mass =  0.00
+Made Particle :ps73  :10261399777056915529: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.03, phi =  0.94, mass =  0.00
+Made Particle :ps74  :10261392126950506570: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.14, phi = -2.80, mass =  0.00
+Made Particle :ps75  :10261389396947238987: pdgid =  -211, status =   1, q = -1, e =   0.2, theta =  1.33, phi =  0.63, mass =  0.14
+Made Particle :ps76  :10261389196126060620: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.10, phi = -2.71, mass =  0.00
+Made Particle :ps77  :10261388763911422029: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.18, phi =  0.79, mass =  0.00
+Made Particle :ps78  :10261387637226995790: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.32, phi =  1.46, mass =  0.00
+Made Particle :ps79  :10261376739961733199: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.74, phi =  3.14, mass =  0.00
+Made Particle :ps80  :10261372478504829008: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.62, phi = -2.96, mass =  0.00
+Made Particle :ps81  :10261362973318578257: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.28, phi = -1.91, mass =  0.00
+Made Particle :ps82  :10261341939353780306: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  0.39, phi =  2.11, mass =  0.00
+Made Particle :ps83  :10261308924512698451: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -1.19, phi =  0.11, mass =  0.00
+Made Particle :ps84  :10261280415083921492: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  0.70, phi = -1.07, mass =  0.00
+Simulating Particle :ps0   :10261532433513971712: pdgid =    13, status =   1, q = -1, e =  50.8, theta = -1.36, phi =  0.53, mass =  0.11
+Simulating Muon
+Made Track: tt0   :7964696623496298496:   50.76   10.80 -1.36  0.53
+Made SmearedTrack: ts0   :7955688219771666432:   48.57   10.33 -1.36  0.53
+Simulating Particle :ps1   :10261529486740684801: pdgid =   -13, status =   1, q =  1, e =  45.4, theta =  0.70, phi = -1.07, mass =  0.11
+Simulating Muon
+Made Track: tt1   :7964693676714622977:   45.40   34.77  0.70 -1.07
+Made SmearedTrack: ts1   :7955686412678856705:   45.28   34.68  0.70 -1.07
+Simulating Particle :ps2   :10261491712857735170: pdgid =    22, status =   1, q =  0, e =  10.2, theta = -1.57, phi = -1.05, mass =  0.00
+Simulating Photon
+Made Cluster: et0   :3352969884471394304:   10.17 -1.57 -1.05 sub(et0, )
+Made SmearedCluster: es0   :3343962974460051456:   10.30 -1.57 -1.05 sub(es0, )
+Rejected SmearedCluster: es0   :3343962974460051456:   10.30 -1.57 -1.05 sub(es0, )
+Simulating Particle :ps3   :10261482322549276675: pdgid =  -211, status =   1, q = -1, e =   7.0, theta =  0.29, phi = -2.36, mass =  0.14
+Simulating Hadron
+Made Track: tt2   :7964646506428891138:    6.95    6.65  0.29 -2.36
+Made SmearedTrack: ts2   :7955639476106035202:    6.99    6.69  0.29 -2.36
+Made Cluster: ht0   :5658803503376629760:    6.95  0.29 -2.20 sub(ht0, )
+Made SmearedCluster: hs0   :5649798988057018368:    7.56  0.29 -2.20 sub(hs0, )
+Simulating Particle :ps4   :10261478667913789444: pdgid =   130, status =   1, q =  0, e =   6.1, theta =  0.69, phi =  1.33, mass =  0.50
+Simulating Hadron
+Made Cluster: et1   :3352948199665958913:    4.16  0.69  1.33 sub(et1, )
+Made SmearedCluster: es0   :3343939335970881536:    3.89  0.69  1.33 sub(es0, )
+Made Cluster: ht1   :5658772306866995201:    1.96  0.69  1.33 sub(ht1, )
+Made SmearedCluster: hs1   :5649792978644893697:    6.20  0.69  1.33 sub(hs1, )
+Simulating Particle :ps5   :10261478054396166149: pdgid = -2112, status =   1, q =  0, e =   6.0, theta =  0.18, phi =  1.54, mass =  0.94
+Simulating Hadron
+Made Cluster: ht2   :5658799235223519234:    5.98  0.18  1.54 sub(ht2, )
+Made SmearedCluster: hs2   :5649791383324590082:    5.83  0.18  1.54 sub(hs2, )
+Simulating Particle :ps6   :10261474455303749638: pdgid =  2212, status =   1, q =  1, e =   5.2, theta =  0.17, phi = -2.40, mass =  0.94
+Simulating Hadron
+Made Track: tt3   :7964638267192639491:    5.08    5.00  0.17 -2.40
+Made SmearedTrack: ts3   :7955630704790863875:    4.99    4.92  0.17 -2.40
+Rejected SmearedTrack: ts3   :7955630704790863875:    4.99    4.92  0.17 -2.40
+Made Cluster: et2   :3352942913161003010:    3.48  0.17 -2.55 sub(et2, )
+Made SmearedCluster: es1   :3343893782197174273:    0.68  0.17 -2.55 sub(es1, )
+Made Cluster: ht3   :5658767399244005379:    1.69  0.17 -2.62 sub(ht3, )
+Made SmearedCluster: hs3   :5647513932722601987:   -2.32  0.17 -2.62 sub(hs3, )
+Rejected SmearedCluster: hs3   :5647513932722601987:   -2.32  0.17 -2.62 sub(hs3, )
+Simulating Particle :ps7   :10261473583326822407: pdgid =   211, status =   1, q =  1, e =   5.0, theta = -0.07, phi = -2.65, mass =  0.14
+Simulating Hadron
+Made Track: tt4   :7964637764735991812:    4.96    4.95 -0.07 -2.65
+Made SmearedTrack: ts3   :7955630666142449667:    4.99    4.97 -0.07 -2.65
+Rejected SmearedTrack: ts3   :7955630666142449667:    4.99    4.97 -0.07 -2.65
+Made Cluster: et3   :3352925256791621635:    1.73 -0.07 -2.80 sub(et3, )
+Made SmearedCluster: es2   :3343901509728337922:    0.90 -0.07 -2.80 sub(es2, )
+Made Cluster: ht4   :5658783745035993092:    3.23 -0.07 -2.87 sub(ht4, )
+Made SmearedCluster: hs3   :5649787681383645187:    4.99 -0.07 -2.87 sub(hs3, )
+Simulating Particle :ps8   :10261469588944322568: pdgid =  -211, status =   1, q = -1, e =   4.1, theta =  0.36, phi =  1.12, mass =  0.14
+Simulating Hadron
+Made Track: tt5   :7964633768422014981:    4.05    3.79  0.36  1.12
+Made SmearedTrack: ts3   :7955626791247282179:    4.10    3.84  0.36  1.12
+Made Cluster: et4   :3352932982745726980:    2.35  0.36  1.32 sub(et4, )
+Made SmearedCluster: es3   :3343927579875737603:    2.55  0.36  1.32 sub(es3, )
+Made Cluster: ht5   :5658767794634752005:    1.71  0.37  1.41 sub(ht5, )
+Made SmearedCluster: hs4   :5647513932722601988:   -3.15  0.37  1.41 sub(hs4, )
+Rejected SmearedCluster: hs4   :5647513932722601988:   -3.15  0.37  1.41 sub(hs4, )
+Simulating Particle :ps9   :10261468910414987273: pdgid =  2212, status =   1, q =  1, e =   4.0, theta =  0.20, phi =  1.27, mass =  0.94
+Simulating Hadron
+Made Track: tt6   :7964632106225631238:    3.84    3.76  0.20  1.27
+Made SmearedTrack: ts4   :7955624626195791876:    3.81    3.73  0.20  1.27
+Made Cluster: ht6   :5658790091242340358:    3.95  0.21  0.98 sub(ht6, )
+Made SmearedCluster: hs4   :5649740280585256964:    0.78  0.21  0.98 sub(hs4, )
+Rejected SmearedCluster: hs4   :5649740280585256964:    0.78  0.21  0.98 sub(hs4, )
+Simulating Particle :ps10  :10261467715317268490: pdgid =   130, status =   1, q =  0, e =   3.8, theta = -0.01, phi = -2.63, mass =  0.50
+Simulating Hadron
+Made Cluster: ht7   :5658788896144621575:    3.81 -0.01 -2.63 sub(ht7, )
+Made SmearedCluster: hs4   :5647513932722601988:   -0.16 -0.01 -2.63 sub(hs4, )
+Rejected SmearedCluster: hs4   :5647513932722601988:   -0.16 -0.01 -2.63 sub(hs4, )
+Simulating Particle :ps11  :10261467195584282635: pdgid = -2212, status =   1, q = -1, e =   3.8, theta =  0.21, phi = -2.60, mass =  0.94
+Simulating Hadron
+Made Track: tt7   :7964630338141945863:    3.64    3.55  0.21 -2.60
+Made SmearedTrack: ts5   :7955623322958430213:    3.66    3.57  0.21 -2.60
+Made Cluster: ht8   :5658788376411635720:    3.76  0.22 -2.29 sub(ht8, )
+Made SmearedCluster: hs4   :5649788408973754372:    5.16  0.22 -2.29 sub(hs4, )
+Simulating Particle :ps12  :10261466455046357004: pdgid =  -321, status =   1, q = -1, e =   3.7, theta =  0.09, phi =  0.98, mass =  0.49
+Simulating Hadron
+Made Track: tt8   :7964630351819571208:    3.64    3.62  0.09  0.98
+Made SmearedTrack: ts6   :7955623307133321222:    3.66    3.64  0.09  0.98
+Made Cluster: ht9   :5658787635873710089:    3.67  0.10  1.28 sub(ht9, )
+Made SmearedCluster: hs5   :5649786287849209861:    4.67  0.10  1.28 sub(hs5, )
+Simulating Particle :ps13  :10261465789678747661: pdgid =   211, status =   1, q =  1, e =   3.6, theta =  0.05, phi = -2.79, mass =  0.14
+Simulating Hadron
+Made Track: tt9   :7964629955887759369:    3.59    3.59  0.05 -2.79
+Made SmearedTrack: ts7   :7955622741629992967:    3.59    3.59  0.05 -2.79
+Made Cluster: ht10  :5658786970506100746:    3.60  0.05 -3.09 sub(ht10, )
+Made SmearedCluster: hs6   :5649795366105645062:    6.74  0.05 -3.09 sub(hs6, )
+Simulating Particle :ps14  :10261465273674498062: pdgid =   211, status =   1, q =  1, e =   3.5, theta =  0.18, phi =  1.33, mass =  0.14
+Simulating Hadron
+Made Track: tt10  :7964629439485050890:    3.53    3.48  0.18  1.33
+Made SmearedTrack: ts8   :7955622255088631816:    3.54    3.48  0.18  1.33
+Made Cluster: ht11  :5658786454501851147:    3.54  0.18  1.02 sub(ht11, )
+Made SmearedCluster: hs7   :5647513932722601991:   -0.95  0.18  1.02 sub(hs7, )
+Rejected SmearedCluster: hs7   :5647513932722601991:   -0.95  0.18  1.02 sub(hs7, )
+Simulating Particle :ps15  :10261462872496275471: pdgid =    22, status =   1, q =  0, e =   3.3, theta =  0.04, phi =  1.10, mass =  0.00
+Simulating Photon
+Made Cluster: et5   :3352941044109934597:    3.26  0.04  1.10 sub(et5, )
+Made SmearedCluster: es4   :3343935442281037828:    3.45  0.04  1.10 sub(es4, )
+Simulating Particle :ps16  :10261462730940612624: pdgid =  -321, status =   1, q = -1, e =   3.2, theta =  0.17, phi =  1.08, mass =  0.49
+Simulating Hadron
+Made Track: tt11  :7964626589067509771:    3.21    3.16  0.17  1.08
+Made SmearedTrack: ts9   :7955619349308375049:    3.21    3.16  0.17  1.08
+Made Cluster: ht12  :5658783911767965708:    3.25  0.18  1.43 sub(ht12, )
+Made SmearedCluster: hs7   :5647513932722601991:   -3.94  0.18  1.43 sub(hs7, )
+Rejected SmearedCluster: hs7   :5647513932722601991:   -3.94  0.18  1.43 sub(hs7, )
+Simulating Particle :ps17  :10261462058555932689: pdgid =   211, status =   1, q =  1, e =   3.2, theta =  0.18, phi = -2.55, mass =  0.14
+Simulating Hadron
+Made Track: tt12  :7964626221573079052:    3.17    3.12  0.18 -2.55
+Made SmearedTrack: ts10  :7955619310861287434:    3.20    3.15  0.18 -2.55
+Made Cluster: et6   :3352909565711613958:    0.92  0.18 -2.79 sub(et6, )
+Made SmearedCluster: es5   :3341670923508908037:   -0.37  0.18 -2.79 sub(es5, )
+Rejected SmearedCluster: es5   :3341670923508908037:   -0.37  0.18 -2.79 sub(es5, )
+Made Cluster: ht13  :5658775134459133965:    2.25  0.18 -2.90 sub(ht13, )
+Made SmearedCluster: hs7   :5647513932722601991:   -0.96  0.18 -2.90 sub(hs7, )
+Rejected SmearedCluster: hs7   :5647513932722601991:   -0.96  0.18 -2.90 sub(hs7, )
+Simulating Particle :ps18  :10261460680179712018: pdgid =    22, status =   1, q =  0, e =   3.0, theta =  0.24, phi =  1.28, mass =  0.00
+Simulating Photon
+Made Cluster: et7   :3352938851793371143:    3.02  0.24  1.28 sub(et7, )
+Made SmearedCluster: es5   :3343933087856721925:    3.18  0.24  1.28 sub(es5, )
+Simulating Particle :ps19  :10261460455895597075: pdgid =  -211, status =   1, q = -1, e =   3.0, theta =  0.36, phi =  1.28, mass =  0.14
+Simulating Hadron
+Made Track: tt13  :7964624617264381965:    2.99    2.80  0.36  1.28
+Made SmearedTrack: ts11  :7955617510588416011:    3.00    2.81  0.36  1.28
+Made Cluster: ht14  :5658781636722950158:    2.99  0.37  1.68 sub(ht14, )
+Made SmearedCluster: hs7   :5647513932722601991:   -0.96  0.37  1.68 sub(hs7, )
+Rejected SmearedCluster: hs7   :5647513932722601991:   -0.96  0.37  1.68 sub(hs7, )
+Simulating Particle :ps20  :10261457432794365972: pdgid =   211, status =   1, q =  1, e =   2.6, theta =  0.79, phi = -2.35, mass =  0.14
+Simulating Hadron
+Made Track: tt14  :7964621590432317454:    2.64    1.87  0.79 -2.35
+Made SmearedTrack: ts12  :7955614560184958988:    2.66    1.88  0.79 -2.35
+Made Cluster: et8   :3352885876951613448:    0.37  0.80 -2.76 sub(et8, )
+Made SmearedCluster: es6   :3343889994497392646:    0.57  0.80 -2.76 sub(es6, )
+Made Cluster: ht15  :5658775323232174095:    2.27  0.82 -2.97 sub(ht15, )
+Made SmearedCluster: hs7   :5649755856126869511:    1.44  0.82 -2.97 sub(hs7, )
+Rejected SmearedCluster: hs7   :5649755856126869511:    1.44  0.82 -2.97 sub(hs7, )
+Simulating Particle :ps21  :10261456140890013717: pdgid =  -321, status =   1, q = -1, e =   2.5, theta =  0.23, phi =  1.04, mass =  0.49
+Simulating Hadron
+Made Track: tt15  :7964619897747537935:    2.45    2.38  0.23  1.04
+Made SmearedTrack: ts13  :7955612851761053709:    2.47    2.40  0.23  1.04
+Made Cluster: et9   :3352896129279721481:    0.54  0.24  1.36 sub(et9, )
+Made SmearedCluster: es7   :3341670923508908039:   -1.55  0.24  1.36 sub(es7, )
+Rejected SmearedCluster: es7   :3341670923508908039:   -1.55  0.24  1.36 sub(es7, )
+Made Cluster: ht16  :5658772220011347984:    1.96  0.24  1.51 sub(ht16, )
+Made SmearedCluster: hs7   :5649788535958405127:    5.18  0.24  1.51 sub(hs7, )
+Simulating Particle :ps22  :10261454141647749142: pdgid =   130, status =   1, q =  0, e =   2.3, theta =  1.20, phi =  0.23, mass =  0.50
+Simulating Hadron
+Made Cluster: ht17  :5658775322475102225:    2.27  1.20  0.23 sub(ht17, )
+Made SmearedCluster: hs8   :5647513932722601992:   -4.57  1.20  0.23 sub(hs8, )
+Rejected SmearedCluster: hs8   :5647513932722601992:   -4.57  1.20  0.23 sub(hs8, )
+Simulating Particle :ps23  :10261454125499678743: pdgid =    22, status =   1, q =  0, e =   2.3, theta =  0.21, phi =  0.97, mass =  0.00
+Simulating Photon
+Made Cluster: et10  :3352932297113337866:    2.27  0.21  0.97 sub(et10, )
+Made SmearedCluster: es7   :3343924783220785159:    2.23  0.21  0.97 sub(es7, )
+Simulating Particle :ps24  :10261453244318351384: pdgid =   211, status =   1, q =  1, e =   2.2, theta =  0.26, phi =  1.14, mass =  0.14
+Simulating Hadron
+Made Track: tt16  :7964617394834374672:    2.17    2.09  0.26  1.14
+Made SmearedTrack: ts14  :7955610148859281422:    2.16    2.09  0.26  1.14
+Made Cluster: et11  :3352919830400335883:    1.43  0.27  0.78 sub(et11, )
+Made SmearedCluster: es8   :3341670923508908040:   -1.34  0.27  0.78 sub(es8, )
+Rejected SmearedCluster: es8   :3341670923508908040:   -1.34  0.27  0.78 sub(es8, )
+Made Cluster: ht18  :5658746313007693842:    0.74  0.27  0.60 sub(ht18, )
+Made SmearedCluster: hs8   :5649779286589046792:    3.54  0.27  0.60 sub(hs8, )
+Simulating Particle :ps25  :10261451841055227929: pdgid =    22, status =   1, q =  0, e =   2.0, theta =  0.35, phi = -2.39, mass =  0.00
+Simulating Photon
+Made Cluster: et12  :3352930012668887052:    2.01  0.35 -2.39 sub(et12, )
+Made SmearedCluster: es8   :3343920109692387336:    1.85  0.35 -2.39 sub(es8, )
+Simulating Particle :ps26  :10261450777530728474: pdgid =  -211, status =   1, q = -1, e =   1.9, theta =  0.80, phi =  1.93, mass =  0.14
+Simulating Hadron
+Made Track: tt17  :7964614879346688017:    1.94    1.35  0.80  1.93
+Made SmearedTrack: ts15  :7955608085926510607:    1.96    1.37  0.80  1.93
+Rejected SmearedTrack: ts15  :7955608085926510607:    1.96    1.37  0.80  1.93
+Made Cluster: et13  :3352887312450060301:    0.39  0.83  2.51 sub(et13, )
+Made SmearedCluster: es9   :3343890444464422921:    0.58  0.83  2.51 sub(es9, )
+Made Cluster: ht19  :5658765018703855635:    1.55  0.88  2.86 sub(ht19, )
+Made SmearedCluster: hs9   :5647513932722601993:   -1.13  0.88  2.86 sub(hs9, )
+Rejected SmearedCluster: hs9   :5647513932722601993:   -1.13  0.88  2.86 sub(hs9, )
+Simulating Particle :ps27  :10261450735510093851: pdgid =   211, status =   1, q =  1, e =   1.9, theta =  0.36, phi = -2.02, mass =  0.14
+Simulating Hadron
+Made Track: tt18  :7964614837219098642:    1.94    1.81  0.36 -2.02
+Made SmearedTrack: ts15  :7955607520939081743:    1.93    1.81  0.36 -2.02
+Made Cluster: et14  :3352838893494861838:    0.06  0.37 -2.43 sub(et14, )
+Made SmearedCluster: es10  :3343937881749061642:    3.72  0.37 -2.43 sub(es10, )
+Made Cluster: ht20  :5658770912705511444:    1.89  0.38 -2.65 sub(ht20, )
+Made SmearedCluster: hs9   :5647513932722601993:   -0.25  0.38 -2.65 sub(hs9, )
+Rejected SmearedCluster: hs9   :5647513932722601993:   -0.25  0.38 -2.65 sub(hs9, )
+Simulating Particle :ps28  :10261450350672216092: pdgid =    22, status =   1, q =  0, e =   1.9, theta = -0.13, phi = -2.74, mass =  0.00
+Simulating Photon
+Made Cluster: et15  :3352928522285875215:    1.92 -0.12 -2.74 sub(et15, )
+Made SmearedCluster: es11  :3343920277401632779:    1.86 -0.12 -2.74 sub(es11, )
+Simulating Particle :ps29  :10261448640794984477: pdgid =   321, status =   1, q =  1, e =   1.8, theta = -0.06, phi =  0.82, mass =  0.49
+Simulating Hadron
+Made Track: tt19  :7964611632624042003:    1.76    1.75 -0.06  0.82
+Made SmearedTrack: ts16  :7955603972853596176:    1.73    1.73 -0.06  0.82
+Made Cluster: ht21  :5658769821622337557:    1.82 -0.06  0.15 sub(ht21, )
+Made SmearedCluster: hs9   :5649774165788459017:    2.96 -0.06  0.15 sub(hs9, )
+Simulating Particle :ps30  :10261447687901544478: pdgid =  -211, status =   1, q = -1, e =   1.8, theta =  0.40, phi =  1.48, mass =  0.14
+Simulating Hadron
+Made Track: tt20  :7964611780934631444:    1.76    1.62  0.40  1.48
+Made SmearedTrack: ts17  :7955604660675411985:    1.77    1.63  0.40  1.48
+Made Cluster: ht22  :5658768868728897558:    1.77  0.43  2.20 sub(ht22, )
+Made SmearedCluster: hs10  :5647513932722601994:   -3.96  0.43  2.20 sub(hs10, )
+Rejected SmearedCluster: hs10  :5647513932722601994:   -3.96  0.43  2.20 sub(hs10, )
+Simulating Particle :ps31  :10261445944419549215: pdgid =   211, status =   1, q =  1, e =   1.7, theta =  0.21, phi = -2.20, mass =  0.14
+Simulating Hadron
+Made Track: tt21  :7964610031674982421:    1.66    1.63  0.21 -2.20
+Made SmearedTrack: ts18  :7955603337330556946:    1.69    1.65  0.21 -2.20
+Made Cluster: ht23  :5658767125246902295:    1.67  0.23 -2.93 sub(ht23, )
+Made SmearedCluster: hs10  :5649776074498768906:    3.18  0.23 -2.93 sub(hs10, )
+Simulating Particle :ps32  :10261445607323336736: pdgid =  -211, status =   1, q = -1, e =   1.7, theta =  0.46, phi =  1.42, mass =  0.14
+Simulating Hadron
+Made Track: tt22  :7964609693381296150:    1.64    1.47  0.46  1.42
+Made SmearedTrack: ts19  :7955602701220315155:    1.66    1.49  0.46  1.42
+Made Cluster: et16  :3352881365879095312:    0.31  0.48  1.94 sub(et16, )
+Made SmearedCluster: es12  :3343900712617639948:    0.87  0.48  1.94 sub(es12, )
+Made Cluster: ht24  :5658761335140253720:    1.34  0.51  2.24 sub(ht24, )
+Made SmearedCluster: hs11  :5649757369469501451:    1.52  0.51  2.24 sub(hs11, )
+Simulating Particle :ps33  :10261444176688185377: pdgid =  -211, status =   1, q = -1, e =   1.6, theta =  0.21, phi = -2.21, mass =  0.14
+Simulating Hadron
+Made Track: tt23  :7964608257335492631:    1.56    1.53  0.21 -2.21
+Made SmearedTrack: ts20  :7955600931817521172:    1.56    1.52  0.21 -2.21
+Made Cluster: et17  :3352863193683722257:    0.15  0.22 -1.72 sub(et17, )
+Made SmearedCluster: es13  :3341670923508908045:   -0.62  0.22 -1.72 sub(es13, )
+Rejected SmearedCluster: es13  :3341670923508908045:   -0.62  0.22 -1.72 sub(es13, )
+Made Cluster: ht25  :5658762703510962201:    1.42  0.23 -1.44 sub(ht25, )
+Made SmearedCluster: hs12  :5647513932722601996:   -4.28  0.23 -1.44 sub(hs12, )
+Rejected SmearedCluster: hs12  :5647513932722601996:   -4.28  0.23 -1.44 sub(hs12, )
+Simulating Particle :ps34  :10261442273923301410: pdgid =    22, status =   1, q =  0, e =   1.5, theta =  0.10, phi = -2.76, mass =  0.00
+Simulating Photon
+Made Cluster: et18  :3352920445536960530:    1.46  0.10 -2.76 sub(et18, )
+Made SmearedCluster: es13  :3343910131749355533:    1.28  0.10 -2.76 sub(es13, )
+Simulating Particle :ps35  :10261441811927007267: pdgid =   211, status =   1, q =  1, e =   1.4, theta =  0.12, phi =  1.49, mass =  0.14
+Simulating Hadron
+Made Track: tt24  :7964605882283589656:    1.43    1.42  0.12  1.49
+Made SmearedTrack: ts21  :7955598890082762773:    1.44    1.43  0.12  1.49
+Made Cluster: et19  :3352908946969985043:    0.90  0.12  0.94 sub(et19, )
+Made SmearedCluster: es14  :3343910968659804174:    1.33  0.12  0.94 sub(es14, )
+Made Cluster: ht26  :5658738844952952858:    0.53  0.13  0.62 sub(ht26, )
+Made SmearedCluster: hs12  :5647513932722601996:   -2.01  0.13  0.62 sub(hs12, )
+Rejected SmearedCluster: hs12  :5647513932722601996:   -2.01  0.13  0.62 sub(hs12, )
+Simulating Particle :ps36  :10261441528297685028: pdgid =   321, status =   1, q =  1, e =   1.4, theta =  0.13, phi =  1.50, mass =  0.49
+Simulating Hadron
+Made Track: tt25  :7964604158749704217:    1.33    1.32  0.13  1.50
+Made SmearedTrack: ts22  :7955597169390518294:    1.34    1.33  0.13  1.50
+Made Cluster: et20  :3352896209363664916:    0.54  0.14  0.91 sub(et20, )
+Made SmearedCluster: es15  :3343917405444243471:    1.70  0.14  0.91 sub(es15, )
+Made Cluster: ht27  :5658751015300628507:    0.88  0.15  0.54 sub(ht27, )
+Made SmearedCluster: hs12  :5649769211375910924:    2.40  0.15  0.54 sub(hs12, )
+Rejected SmearedCluster: hs12  :5649769211375910924:    2.40  0.15  0.54 sub(hs12, )
+Simulating Particle :ps37  :10261438662717734949: pdgid =    22, status =   1, q =  0, e =   1.3, theta =  0.50, phi = -2.56, mass =  0.00
+Simulating Photon
+Made Cluster: et21  :3352916834331394069:    1.26  0.50 -2.56 sub(et21, )
+Made SmearedCluster: es16  :3343906425519734800:    1.07  0.50 -2.56 sub(es16, )
+Simulating Particle :ps38  :10261438189751238694: pdgid =    22, status =   1, q =  0, e =   1.2, theta =  0.29, phi = -2.42, mass =  0.00
+Simulating Photon
+Made Cluster: et22  :3352916361364897814:    1.23  0.29 -2.42 sub(et22, )
+Made SmearedCluster: es17  :3343905841722949649:    1.04  0.29 -2.42 sub(es17, )
+Simulating Particle :ps39  :10261438053662851111: pdgid =    22, status =   1, q =  0, e =   1.2, theta =  0.25, phi = -2.43, mass =  0.00
+Simulating Photon
+Made Cluster: et23  :3352916225276510231:    1.22  0.25 -2.43 sub(et23, )
+Made SmearedCluster: es18  :3343909418893836306:    1.24  0.25 -2.43 sub(es18, )
+Simulating Particle :ps40  :10261437990593101864: pdgid =   321, status =   1, q =  1, e =   1.2, theta =  0.49, phi =  1.21, mass =  0.49
+Simulating Hadron
+Made Track: tt26  :7964600341324890138:    1.11    0.98  0.49  1.21
+Made SmearedTrack: ts23  :7955592660811513879:    1.09    0.96  0.49  1.21
+Made Cluster: et24  :3352896400357589016:    0.55  0.54  0.35 sub(et24, )
+Made SmearedCluster: es19  :3343854805343797267:    0.14  0.54  0.35 sub(es19, )
+Rejected SmearedCluster: es19  :3343854805343797267:    0.14  0.54  0.35 sub(es19, )
+Made Cluster: ht28  :5658743748897538076:    0.67  1.38 -1.64 sub(ht28, )
+Made SmearedCluster: hs12  :5647513932722601996:   -6.25  1.38 -1.64 sub(hs12, )
+Rejected SmearedCluster: hs12  :5647513932722601996:   -6.25  1.38 -1.64 sub(hs12, )
+Simulating Particle :ps41  :10261437524874362921: pdgid =   211, status =   1, q =  1, e =   1.2, theta =  0.13, phi =  1.58, mass =  0.14
+Simulating Hadron
+Made Track: tt27  :7964601570591506459:    1.18    1.17  0.13  1.58
+Made SmearedTrack: ts24  :7955594067197296664:    1.17    1.16  0.13  1.58
+Made Cluster: et25  :3352888199406944281:    0.41  0.14  0.90 sub(et25, )
+Made SmearedCluster: es19  :3341670923508908051:   -0.83  0.14  0.90 sub(es19, )
+Rejected SmearedCluster: es19  :3341670923508908051:   -0.83  0.14  0.90 sub(es19, )
+Made Cluster: ht29  :5658747749011554333:    0.78  0.16  0.41 sub(ht29, )
+Made SmearedCluster: hs12  :5647513932722601996:   -3.79  0.16  0.41 sub(hs12, )
+Rejected SmearedCluster: hs12  :5647513932722601996:   -3.79  0.16  0.41 sub(hs12, )
+Simulating Particle :ps42  :10261437145824624682: pdgid =  -211, status =   1, q = -1, e =   1.2, theta =  0.02, phi =  1.51, mass =  0.14
+Simulating Hadron
+Made Track: tt28  :7964601188865802268:    1.16    1.16  0.02  1.51
+Made SmearedTrack: ts25  :7955594176142245913:    1.17    1.17  0.02  1.51
+Made Cluster: ht30  :5658758326651977758:    1.17  0.02  2.71 sub(ht30, )
+Made SmearedCluster: hs12  :5649753875574423564:    1.33  0.02  2.71 sub(hs12, )
+Rejected SmearedCluster: hs12  :5649753875574423564:    1.33  0.02  2.71 sub(hs12, )
+Simulating Particle :ps43  :10261436736085164075: pdgid =  -211, status =   1, q = -1, e =   1.1, theta =  0.24, phi = -2.29, mass =  0.14
+Simulating Hadron
+Made Track: tt29  :7964600776116928541:    1.14    1.11  0.24 -2.29
+Made SmearedTrack: ts26  :7955593548896665626:    1.14    1.10  0.24 -2.29
+Made Cluster: et26  :3352807302647250970:    0.02  0.26 -1.56 sub(et26, )
+Made SmearedCluster: es19  :3343928352628015123:    2.64  0.26 -1.56 sub(es19, )
+Made Cluster: ht31  :5658757633826357279:    1.13  0.33 -0.93 sub(ht31, )
+Made SmearedCluster: hs12  :5647513932722601996:   -1.62  0.33 -0.93 sub(hs12, )
+Rejected SmearedCluster: hs12  :5647513932722601996:   -1.62  0.33 -0.93 sub(hs12, )
+Simulating Particle :ps44  :10261436180971126828: pdgid =   -11, status =   1, q =  1, e =   1.1, theta = -0.49, phi =  1.21, mass =  0.00
+Simulating Electron
+Made Track: tt30  :7964600371010076702:    1.11    0.98 -0.49  1.21
+Made SmearedTrack: ts27  :7955596479211503643:    1.30    1.15 -0.49  1.21
+Rejected SmearedTrack: ts27  :7955596479211503643:    1.30    1.15 -0.49  1.21
+Simulating Particle :ps45  :10261434332436496429: pdgid =  -321, status =   1, q = -1, e =   1.0, theta =  1.04, phi = -2.73, mass =  0.49
+Simulating Hadron
+Made Track: tt31  :7964594161066180639:    0.88    0.45  1.04 -2.73
+Made SmearedTrack: ts27  :7955587181632815131:    0.89    0.45  1.04 -2.73
+Rejected SmearedTrack: ts27  :7955587181632815131:    0.89    0.45  1.04 -2.73
+Made Cluster: ht32  :5658755513263849504:    1.01  1.30 -0.78 sub(ht32, )
+Made SmearedCluster: hs12  :5649791817418276876:    5.93  1.30 -0.78 sub(hs12, )
+Rejected SmearedCluster: hs12  :5649791817418276876:    5.93  1.30 -0.78 sub(hs12, )
+Simulating Particle :ps46  :10261432927439028270: pdgid =    22, status =   1, q =  0, e =   1.0, theta = -0.22, phi = -2.52, mass =  0.00
+Simulating Photon
+Made Cluster: et27  :3352911099052687387:    0.97 -0.22 -2.53 sub(et27, )
+Made SmearedCluster: es20  :3343910579269009428:    1.31 -0.22 -2.53 sub(es20, )
+Simulating Particle :ps47  :10261431673327452207: pdgid =    22, status =   1, q =  0, e =   0.9, theta =  0.59, phi = -2.70, mass =  0.00
+Simulating Photon
+Made Cluster: et28  :3352909844941111324:    0.93  0.59 -2.70 sub(et28, )
+Made SmearedCluster: es21  :3343899839902515221:    0.85  0.59 -2.70 sub(es21, )
+Simulating Particle :ps48  :10261430531044409392: pdgid =   211, status =   1, q =  1, e =   0.9, theta =  0.81, phi =  1.94, mass =  0.14
+Simulating Hadron
+Made Track: tt32  :7964594336656523296:    0.89    0.61  0.81  1.94
+Made SmearedTrack: ts27  :7955586714743865371:    0.87    0.60  0.81  1.94
+Made Cluster: ht33  :5658751711871762465:    0.90  1.27 -0.36 sub(ht33, )
+Made SmearedCluster: hs12  :5649756642902802444:    1.48  1.27 -0.36 sub(hs12, )
+Simulating Particle :ps49  :10261430052147167281: pdgid =    22, status =   1, q =  0, e =   0.9, theta = -0.02, phi = -2.79, mass =  0.00
+Simulating Photon
+Made Cluster: et29  :3352908223760826397:    0.88 -0.02 -2.79 sub(et29, )
+Made SmearedCluster: es22  :3343902831793930262:    0.93 -0.02 -2.79 sub(es22, )
+Simulating Particle :ps50  :10261429979409547314: pdgid =    22, status =   1, q =  0, e =   0.9, theta =  0.06, phi = -2.58, mass =  0.00
+Simulating Photon
+Made Cluster: et30  :3352908151023206430:    0.88  0.06 -2.58 sub(et30, )
+Made SmearedCluster: es23  :3343899450935345175:    0.84  0.06 -2.58 sub(es23, )
+Simulating Particle :ps51  :10261426554150060083: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.29, phi =  3.01, mass =  0.00
+Simulating Photon
+Made Cluster: et31  :3352904725763719199:    0.78  0.29  3.01 sub(et31, )
+Made SmearedCluster: es24  :3343896176287023128:    0.75  0.29  3.01 sub(es24, )
+Simulating Particle :ps52  :10261423639159111732: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.12, phi = -2.49, mass =  0.00
+Simulating Photon
+Made Cluster: et32  :3352901810772770848:    0.70  0.12 -2.49 sub(et32, )
+Made SmearedCluster: es25  :3343890012562259993:    0.57  0.12 -2.49 sub(es25, )
+Simulating Particle :ps53  :10261423226116636725: pdgid =    22, status =   1, q =  0, e =   0.7, theta = -0.20, phi = -2.69, mass =  0.00
+Simulating Photon
+Made Cluster: et33  :3352901397730295841:    0.69 -0.20 -2.69 sub(et33, )
+Made SmearedCluster: es26  :3343899026522112026:    0.83 -0.20 -2.69 sub(es26, )
+Simulating Particle :ps54  :10261422851913416758: pdgid =  -211, status =   1, q = -1, e =   0.7, theta = -0.10, phi = -2.76, mass =  0.14
+Simulating Hadron
+Made Track: tt33  :7964586531528638497:    0.66    0.66 -0.10 -2.76
+Made SmearedTrack: ts28  :7955579427321020444:    0.67    0.66 -0.10 -2.76
+Made Cluster: et34  :3352891667236519970:    0.46 -1.05 -1.24 sub(et34, )
+Made SmearedCluster: es27  :3341670923508908059:   -3.18 -1.05 -1.24 sub(es27, )
+Rejected SmearedCluster: es27  :3341670923508908059:   -3.18 -1.05 -1.24 sub(es27, )
+Made Cluster: ht34  :5658716254083481634:    0.22 -1.39 -2.36 sub(ht34, )
+Made SmearedCluster: hs13  :5647513932722601997:  -10.60 -1.39 -2.36 sub(hs13, )
+Rejected SmearedCluster: hs13  :5647513932722601997:  -10.60 -1.39 -2.36 sub(hs13, )
+Simulating Particle :ps55  :10261421777378869303: pdgid =  -211, status =   1, q = -1, e =   0.6, theta = -0.49, phi =  0.88, mass =  0.14
+Simulating Hadron
+Made Track: tt34  :7964585432379818018:    0.63    0.56 -0.49  0.88
+Made SmearedTrack: ts29  :7955578357576368157:    0.64    0.56 -0.49  0.88
+Made Cluster: et35  :3352811277603831843:    0.02 -1.27  1.56 sub(et35, )
+Made SmearedCluster: es27  :3343932958028333083:    3.16 -1.27  1.56 sub(es27, )
+Made Cluster: ht35  :5658742267815395363:    0.63 -1.22  2.71 sub(ht35, )
+Made SmearedCluster: hs13  :5649789150956617741:    5.32 -1.22  2.71 sub(hs13, )
+Rejected SmearedCluster: hs13  :5649789150956617741:    5.32 -1.22  2.71 sub(hs13, )
+Simulating Particle :ps56  :10261421625471664184: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.23, phi = -2.37, mass =  0.00
+Simulating Photon
+Made Cluster: et36  :3352899797085323300:    0.64  0.23 -2.37 sub(et36, )
+Made SmearedCluster: es28  :3343895371597217820:    0.72  0.23 -2.37 sub(es28, )
+Simulating Particle :ps57  :10261421082451902521: pdgid =   211, status =   1, q =  1, e =   0.6, theta =  0.05, phi =  0.98, mass =  0.14
+Simulating Hadron
+Made Track: tt35  :7964584720210067491:    0.61    0.61  0.05  0.98
+Made SmearedTrack: ts30  :7955577513200058398:    0.61    0.61  0.05  0.98
+Made Cluster: et37  :3352859778863857701:    0.13  1.38  0.61 sub(et37, )
+Made SmearedCluster: es29  :3343913253412536349:    1.46  1.38  0.61 sub(es29, )
+Made Cluster: ht36  :5658737808976642084:    0.50  1.18 -0.44 sub(ht36, )
+Made SmearedCluster: hs13  :5647513932722601997:   -3.04  1.18 -0.44 sub(hs13, )
+Rejected SmearedCluster: hs13  :5647513932722601997:   -3.04  1.18 -0.44 sub(hs13, )
+Simulating Particle :ps58  :10261419761665572922: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  1.13, phi = -2.84, mass =  0.00
+Simulating Photon
+Made Cluster: et38  :3352897933279232038:    0.59  1.13 -2.84 sub(et38, )
+Made SmearedCluster: es30  :3343876899741892638:    0.35  1.13 -2.84 sub(es30, )
+Rejected SmearedCluster: es30  :3343876899741892638:    0.35  1.13 -2.84 sub(es30, )
+Simulating Particle :ps59  :10261416690503909435: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.04, phi = -2.64, mass =  0.00
+Simulating Photon
+Made Cluster: et39  :3352894862117568551:    0.50  0.04 -2.64 sub(et39, )
+Made SmearedCluster: es30  :3343888136320057374:    0.52  0.04 -2.64 sub(es30, )
+Simulating Particle :ps60  :10261415532160876604: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.54, phi = -2.19, mass =  0.00
+Simulating Photon
+Made Cluster: et40  :3352893703774535720:    0.49  0.54 -2.19 sub(et40, )
+Made SmearedCluster: es31  :3343884662194831391:    0.46  0.54 -2.19 sub(es31, )
+Simulating Particle :ps61  :10261415429612240957: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.15, phi = -2.41, mass =  0.00
+Simulating Photon
+Made Cluster: et41  :3352893601225900073:    0.48  0.15 -2.41 sub(et41, )
+Made SmearedCluster: es32  :3343889479975829536:    0.56  0.15 -2.41 sub(es32, )
+Simulating Particle :ps62  :10261414110660919358: pdgid =   211, status =   1, q =  1, e =   0.5, theta =  0.31, phi =  0.72, mass =  0.14
+Simulating Hadron
+Made Track: tt36  :7964576792312807460:    0.44    0.42  0.31  0.72
+Made SmearedTrack: ts31  :7955570193860657183:    0.45    0.43  0.31  0.72
+Rejected SmearedTrack: ts31  :7955570193860657183:    0.45    0.43  0.31  0.72
+Made Cluster: et42  :3352875497028583466:    0.24  1.28 -1.48 sub(et42, )
+Made SmearedCluster: es33  :3341670923508908065:   -7.13  1.28 -1.48 sub(es33, )
+Rejected SmearedCluster: es33  :3341670923508908065:   -7.13  1.28 -1.48 sub(es33, )
+Made Cluster: ht37  :5658716892362178597:    0.23  1.29 -0.89 sub(ht37, )
+Made SmearedCluster: hs13  :5649781518107672589:    3.79  1.29 -0.89 sub(hs13, )
+Simulating Particle :ps63  :10261413498028294207: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.25, phi = -2.68, mass =  0.00
+Simulating Photon
+Made Cluster: et43  :3352891669641953323:    0.46  0.25 -2.68 sub(et43, )
+Made SmearedCluster: es33  :3343859140641423393:    0.17  0.25 -2.68 sub(es33, )
+Rejected SmearedCluster: es33  :3343859140641423393:    0.17  0.25 -2.68 sub(es33, )
+Simulating Particle :ps64  :10261412190248501312: pdgid =  -211, status =   1, q = -1, e =   0.4, theta =  0.78, phi = -1.99, mass =  0.14
+Simulating Hadron
+Made Track: tt37  :7964574772868677669:    0.41    0.30  0.78 -1.99
+Made SmearedTrack: ts31  :7955567813389713439:    0.42    0.30  0.78 -1.99
+Rejected SmearedTrack: ts31  :7955567813389713439:    0.42    0.30  0.78 -1.99
+Made Cluster: ht38  :5658733371075854374:    0.44  1.39 -0.05 sub(ht38, )
+Made SmearedCluster: hs14  :5647513932722601998:   -5.62  1.39 -0.05 sub(hs14, )
+Rejected SmearedCluster: hs14  :5647513932722601998:   -5.62  1.39 -0.05 sub(hs14, )
+Simulating Particle :ps65  :10261411295540543553: pdgid =  -211, status =   1, q = -1, e =   0.4, theta = -0.21, phi =  0.76, mass =  0.14
+Simulating Hadron
+Made Track: tt38  :7964573827304783910:    0.40    0.39 -0.21  0.76
+Made SmearedTrack: ts31  :7955566515930005535:    0.40    0.39 -0.21  0.76
+Rejected SmearedTrack: ts31  :7955566515930005535:    0.40    0.39 -0.21  0.76
+Made Cluster: ht39  :5658732476367896615:    0.43 -1.34  2.78 sub(ht39, )
+Made SmearedCluster: hs14  :5647513932722601998:   -7.51 -1.34  2.78 sub(hs14, )
+Rejected SmearedCluster: hs14  :5647513932722601998:   -7.51 -1.34  2.78 sub(hs14, )
+Simulating Particle :ps66  :10261410230157967426: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.07, phi = -2.70, mass =  0.00
+Simulating Photon
+Made Cluster: et44  :3352888401771626540:    0.41  0.07 -2.70 sub(et44, )
+Made SmearedCluster: es33  :3343890109826072609:    0.57  0.07 -2.70 sub(es33, )
+Simulating Particle :ps67  :10261407898575831107: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.00, phi =  1.21, mass =  0.00
+Simulating Photon
+Made Cluster: et45  :3352886070189490221:    0.38  0.00  1.21 sub(et45, )
+Made SmearedCluster: es34  :3343855232950992930:    0.15  0.00  1.21 sub(es34, )
+Rejected SmearedCluster: es34  :3343855232950992930:    0.15  0.00  1.21 sub(es34, )
+Simulating Particle :ps68  :10261407375778906180: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.42, phi = -2.35, mass =  0.00
+Simulating Photon
+Made Cluster: et46  :3352885547392565294:    0.37  0.42 -2.35 sub(et46, )
+Made SmearedCluster: es34  :3343891433785393186:    0.61  0.42 -2.35 sub(es34, )
+Simulating Particle :ps69  :10261407349388345413: pdgid =   211, status =   1, q =  1, e =   0.4, theta =  0.81, phi =  1.37, mass =  0.14
+Simulating Hadron
+Made Track: tt39  :7964569610452205607:    0.34    0.24  0.81  1.37
+Made SmearedTrack: ts31  :7955562551863935007:    0.34    0.24  0.81  1.37
+Rejected SmearedTrack: ts31  :7955562551863935007:    0.34    0.24  0.81  1.37
+Made Cluster: ht40  :5658728530215698472:    0.37  1.53 -1.48 sub(ht40, )
+Made SmearedCluster: hs14  :5649785759159287822:    4.55  1.53 -1.48 sub(hs14, )
+Rejected SmearedCluster: hs14  :5649785759159287822:    4.55  1.53 -1.48 sub(hs14, )
+Simulating Particle :ps70  :10261406918174048326: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.56, phi = -2.43, mass =  0.00
+Simulating Photon
+Made Cluster: et47  :3352885089787707439:    0.36  0.56 -2.43 sub(et47, )
+Made SmearedCluster: es35  :3343862164722024483:    0.19  0.56 -2.43 sub(es35, )
+Rejected SmearedCluster: es35  :3343862164722024483:    0.19  0.56 -2.43 sub(es35, )
+Simulating Particle :ps71  :10261404348539994183: pdgid =  -211, status =   1, q = -1, e =   0.3, theta =  0.12, phi =  1.49, mass =  0.14
+Simulating Hadron
+Made Track: tt40  :7964566332622503976:    0.30    0.29  0.12  1.49
+Made SmearedTrack: ts31  :7955559391690752031:    0.30    0.30  0.12  1.49
+Rejected SmearedTrack: ts31  :7955559391690752031:    0.30    0.30  0.12  1.49
+Made Cluster: et48  :3352858214168264752:    0.12  1.36  2.50 sub(et48, )
+Made SmearedCluster: es35  :3343960163957604387:    9.03  1.36  2.50 sub(es35, )
+Made Cluster: ht41  :5658713981148201001:    0.21  1.38  2.81 sub(ht41, )
+Made SmearedCluster: hs14  :5647513932722601998:   -4.93  1.38  2.81 sub(hs14, )
+Rejected SmearedCluster: hs14  :5647513932722601998:   -4.93  1.38  2.81 sub(hs14, )
+Simulating Particle :ps72  :10261402016314032200: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.07, phi = -2.50, mass =  0.00
+Simulating Photon
+Made Cluster: et49  :3352880187927691313:    0.29  0.07 -2.50 sub(et49, )
+Made SmearedCluster: es36  :3343882096142712868:    0.42  0.07 -2.50 sub(es36, )
+Simulating Particle :ps73  :10261399777056915529: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.03, phi =  0.94, mass =  0.00
+Simulating Photon
+Made Cluster: et50  :3352877948670574642:    0.26  0.03  0.94 sub(et50, )
+Made SmearedCluster: es37  :3343840847192916005:    0.08  0.03  0.94 sub(es37, )
+Rejected SmearedCluster: es37  :3343840847192916005:    0.08  0.03  0.94 sub(es37, )
+Simulating Particle :ps74  :10261392126950506570: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.14, phi = -2.80, mass =  0.00
+Simulating Photon
+Made Cluster: et51  :3352870298564165683:    0.20 -0.14 -2.80 sub(et51, )
+Made SmearedCluster: es37  :3343882724434772005:    0.43 -0.14 -2.80 sub(es37, )
+Simulating Particle :ps76  :10261389196126060620: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.10, phi = -2.71, mass =  0.00
+Simulating Photon
+Made Cluster: et52  :3352867367739719732:    0.18  0.10 -2.71 sub(et52, )
+Made SmearedCluster: es38  :3343861997369294886:    0.19  0.10 -2.71 sub(es38, )
+Rejected SmearedCluster: es38  :3343861997369294886:    0.19  0.10 -2.71 sub(es38, )
+Simulating Particle :ps77  :10261388763911422029: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.18, phi =  0.79, mass =  0.00
+Simulating Photon
+Made Cluster: et53  :3352866935525081141:    0.18  0.18  0.79 sub(et53, )
+Made SmearedCluster: es38  :3343871075105636390:    0.27  0.18  0.79 sub(es38, )
+Rejected SmearedCluster: es38  :3343871075105636390:    0.27  0.18  0.79 sub(es38, )
+Simulating Particle :ps78  :10261387637226995790: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.32, phi =  1.46, mass =  0.00
+Simulating Photon
+Made Cluster: et54  :3352865808840654902:    0.17  0.32  1.46 sub(et54, )
+Made SmearedCluster: es38  :3343886577020436518:    0.49  0.32  1.46 sub(es38, )
+Simulating Particle :ps79  :10261376739961733199: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.74, phi =  3.14, mass =  0.00
+Simulating Photon
+Made Cluster: et55  :3352854911575392311:    0.11  0.74  3.14 sub(et55, )
+Made SmearedCluster: es39  :3341670923508908071:   -0.16  0.74  3.14 sub(es39, )
+Rejected SmearedCluster: es39  :3341670923508908071:   -0.16  0.74  3.14 sub(es39, )
+Simulating Particle :ps80  :10261372478504829008: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.62, phi = -2.96, mass =  0.00
+Simulating Photon
+Made Cluster: et56  :3352850650118488120:    0.09  0.62 -2.96 sub(et56, )
+Made SmearedCluster: es39  :3341670923508908071:   -0.09  0.62 -2.96 sub(es39, )
+Rejected SmearedCluster: es39  :3341670923508908071:   -0.09  0.62 -2.96 sub(es39, )
+Simulating Particle :ps81  :10261362973318578257: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.28, phi = -1.91, mass =  0.00
+Simulating Photon
+Made Cluster: et57  :3352841144932237369:    0.06 -0.27 -1.91 sub(et57, )
+Made SmearedCluster: es39  :3341670923508908071:   -0.05 -0.27 -1.91 sub(es39, )
+Rejected SmearedCluster: es39  :3341670923508908071:   -0.05 -0.27 -1.91 sub(es39, )
+Simulating Particle :ps82  :10261341939353780306: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  0.39, phi =  2.11, mass =  0.00
+Simulating Photon
+Made Cluster: et58  :3352820110967439418:    0.03  0.39  2.11 sub(et58, )
+Made SmearedCluster: es39  :3343853462206021671:    0.13  0.39  2.11 sub(es39, )
+Rejected SmearedCluster: es39  :3343853462206021671:    0.13  0.39  2.11 sub(es39, )
+Simulating Particle :ps83  :10261308924512698451: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -1.19, phi =  0.11, mass =  0.00
+Simulating Photon
+Made Cluster: et59  :3352787096126357563:    0.01 -1.19  0.11 sub(et59, )
+Made SmearedCluster: es39  :3343851096087986215:    0.12 -1.19  0.11 sub(es39, )
+Rejected SmearedCluster: es39  :3343851096087986215:    0.12 -1.19  0.11 sub(es39, )
+Simulating Particle :ps84  :10261280415083921492: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  0.70, phi = -1.07, mass =  0.00
+Simulating Photon
+Made Cluster: et60  :3352758586697580604:    0.00  0.70 -1.07 sub(et60, )
+Made SmearedCluster: es39  :3343862556084142119:    0.20  0.70 -1.07 sub(es39, )
+Rejected SmearedCluster: es39  :3343862556084142119:    0.20  0.70 -1.07 sub(es39, )
+Made MergedCluster: em0   :3289873729428914176:    1.67  0.13 -2.52 sub(es1, es25, es36, )
+Made MergedCluster: em1   :3289897666521071617:    4.12 -0.09 -2.77 sub(es11, es22, es2, es37, )
+Made MergedCluster: em2   :3289841466666385410:    0.46  0.54 -2.19 sub(es31, )
+Made MergedCluster: em3   :3289843381491990531:    0.49  0.32  1.46 sub(es38, )
+Made MergedCluster: em4   :3289844940791611396:    0.52  0.04 -2.64 sub(es30, )
+Made MergedCluster: em5   :3289846284447383557:    0.56  0.15 -2.41 sub(es32, )
+Made MergedCluster: em6   :3289846798968946694:    0.57  0.80 -2.76 sub(es6, )
+Made MergedCluster: em7   :3289846914297626631:    0.57  0.07 -2.70 sub(es33, )
+Made MergedCluster: em8   :3289847248935976968:    0.58  0.83  2.51 sub(es9, )
+Made MergedCluster: em9   :3289848238256947209:    0.61  0.42 -2.35 sub(es34, )
+Made MergedCluster: em10  :3289852176068771850:    0.72  0.23 -2.37 sub(es28, )
+Made MergedCluster: em11  :3289852980758577163:    0.75  0.29  3.01 sub(es24, )
+Made MergedCluster: em12  :3289855830993666060:    0.83 -0.20 -2.69 sub(es26, )
+Made MergedCluster: em13  :3289856255406899213:    0.84  0.06 -2.58 sub(es23, )
+Made MergedCluster: em14  :3289856644374069262:    0.85  0.59 -2.70 sub(es21, )
+Made MergedCluster: em15  :3289857517089193999:    0.87  0.48  1.94 sub(es12, )
+Made MergedCluster: em16  :3289882026965991440:    2.28  0.27 -2.43 sub(es18, es17, )
+Made MergedCluster: em17  :3289863229991288849:    1.07  0.50 -2.56 sub(es16, )
+Made MergedCluster: em18  :3289866936220909586:    1.28  0.10 -2.76 sub(es13, )
+Made MergedCluster: em19  :3289867383740563475:    1.31 -0.22 -2.53 sub(es20, )
+Made MergedCluster: em20  :3289888583709622292:    3.03  0.13  0.92 sub(es15, es14, )
+Made MergedCluster: em21  :3289870057884090389:    1.46  1.38  0.61 sub(es29, )
+Made MergedCluster: em22  :3289904045784825878:    5.57  0.36 -2.41 sub(es10, es8, )
+Made MergedCluster: em23  :3289881587692339223:    2.23  0.21  0.97 sub(es7, )
+Made MergedCluster: em24  :3289884384347291672:    2.55  0.36  1.32 sub(es3, )
+Made MergedCluster: em25  :3289885157099569177:    2.64  0.26 -1.56 sub(es19, )
+Made MergedCluster: em26  :3289889762499887130:    3.16 -1.27  1.56 sub(es27, )
+Made MergedCluster: em27  :3289889892328275995:    3.18  0.24  1.28 sub(es5, )
+Made MergedCluster: em28  :3289892246752591900:    3.45  0.04  1.10 sub(es4, )
+Made MergedCluster: em29  :3289896140442435613:    3.89  0.69  1.33 sub(es0, )
+Made MergedCluster: em30  :3289916968429158430:    9.03  1.36  2.50 sub(es35, )
+Made MergedCluster: hm0   :5595713447374356480:    1.48  1.27 -0.36 sub(hs12, )
+Made MergedCluster: hm1   :5595714173941055489:    1.52  0.51  2.24 sub(hs11, )
+Made MergedCluster: hm2   :5595730970260013058:    2.96 -0.06  0.15 sub(hs9, )
+Made MergedCluster: hm3   :5595732878970322947:    3.18  0.23 -2.93 sub(hs10, )
+Made MergedCluster: hm4   :5595736091060600836:    3.54  0.27  0.60 sub(hs8, )
+Made MergedCluster: hm5   :5595738322579226629:    3.79  1.29 -0.89 sub(hs13, )
+Made MergedCluster: hm6   :5595743092320763910:    4.67  0.10  1.28 sub(hs5, )
+Made MergedCluster: hm7   :5595744485855199239:    4.99 -0.07 -2.87 sub(hs3, )
+Made MergedCluster: hm8   :5595768095172984840:   12.72  0.26 -2.24 sub(hs0, hs4, )
+Made MergedCluster: hm9   :5595764356299096073:   11.02  0.21  1.53 sub(hs2, hs7, )
+Made MergedCluster: hm10  :5595749783116447754:    6.20  0.69  1.33 sub(hs1, )
+Made MergedCluster: hm11  :5595752170577199115:    6.74  0.05 -3.09 sub(hs6, )
+Made block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.5 (3289841466666385410)
+
+Made block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.5 (3289843381491990531)
+
+Made block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.5 (3289844940791611396)
+
+Made block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.6 (3289846284447383557)
+
+Made block:E1T1     :br4   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  2.7 (7955614560184958988)
+      e1 = em6       value=  0.6 (3289846798968946694)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.6 (3289846914297626631)
+
+Made block:E1       :br6   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.6 (3289847248935976968)
+
+Made block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  0.6 (3289848238256947209)
+
+Made block:E1H1T2   :br8   : ecals = 1 hcals = 1 tracks = 2
+    elements:
+      t0 = ts2       value=  7.0 (7955639476106035202)
+      t1 = ts5       value=  3.7 (7955623322958430213)
+      h2 = hm8       value= 12.7 (5595768095172984840)
+      e3 = em10      value=  0.7 (3289852176068771850)
+    distances:
+              t0      t1      h2      e3
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+      e3     ---  0.0397     ---       .
+
+Made block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  0.7 (3289852980758577163)
+
+Made block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  0.8 (3289855830993666060)
+
+Made block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  0.8 (3289856255406899213)
+
+Made block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  0.8 (3289856644374069262)
+
+Made block:E1H1T2   :br13  : ecals = 1 hcals = 1 tracks = 2
+    elements:
+      t0 = ts17      value=  1.8 (7955604660675411985)
+      t1 = ts19      value=  1.7 (7955602701220315155)
+      h2 = hm1       value=  1.5 (5595714173941055489)
+      e3 = em15      value=  0.9 (3289857517089193999)
+    distances:
+              t0      t1      h2      e3
+      t0       .
+      t1     ---       .
+      h2  0.1866  0.0000       .
+      e3     ---  0.0000     ---       .
+
+Made block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  1.1 (3289863229991288849)
+
+Made block:E1       :br15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em18      value=  1.3 (3289866936220909586)
+
+Made block:E1       :br16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  1.3 (3289867383740563475)
+
+Made block:E1T1     :br17  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts30      value=  0.6 (7955577513200058398)
+      e1 = em21      value=  1.5 (3289870057884090389)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  1.7 (3289873729428914176)
+
+Made block:E1       :br19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  2.2 (3289881587692339223)
+
+Made block:E1       :br20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  2.3 (3289882026965991440)
+
+Made block:E1T1     :br21  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts3       value=  4.1 (7955626791247282179)
+      e1 = em24      value=  2.6 (3289884384347291672)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :br22  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts26      value=  1.1 (7955593548896665626)
+      e1 = em25      value=  2.6 (3289885157099569177)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T3     :br23  : ecals = 1 hcals = 0 tracks = 3
+    elements:
+      t0 = ts21      value=  1.4 (7955598890082762773)
+      t1 = ts22      value=  1.3 (7955597169390518294)
+      t2 = ts24      value=  1.2 (7955594067197296664)
+      e3 = em20      value=  3.0 (3289888583709622292)
+    distances:
+              t0      t1      t2      e3
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      e3  0.0000  0.0000  0.0153       .
+
+Made block:E1T1     :br24  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts29      value=  0.6 (7955578357576368157)
+      e1 = em26      value=  3.2 (3289889762499887130)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em27      value=  3.2 (3289889892328275995)
+
+Made block:E1       :br26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em28      value=  3.4 (3289892246752591900)
+
+Made block:E1       :br27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em29      value=  3.9 (3289896140442435613)
+
+Made block:E1       :br28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  4.1 (3289897666521071617)
+
+Made block:E1T1     :br29  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  1.9 (7955607520939081743)
+      e1 = em22      value=  5.6 (3289904045784825878)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em30      value=  9.0 (3289916968429158430)
+
+Made block:H1T1     :br31  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts27      value=  0.9 (7955586714743865371)
+      h1 = hm0       value=  1.5 (5595713447374356480)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br32  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts16      value=  1.7 (7955603972853596176)
+      h1 = hm2       value=  3.0 (5595730970260013058)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T2     :br33  : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts10      value=  3.2 (7955619310861287434)
+      t1 = ts18      value=  1.7 (7955603337330556946)
+      h2 = hm3       value=  3.2 (5595732878970322947)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.1125  0.0000       .
+
+Made block:H1T1     :br34  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts14      value=  2.2 (7955610148859281422)
+      h1 = hm4       value=  3.5 (5595736091060600836)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1       :br35  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  3.8 (5595738322579226629)
+
+Made block:H1T1     :br36  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  3.7 (7955623307133321222)
+      h1 = hm6       value=  4.7 (5595743092320763910)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1       :br37  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm7       value=  5.0 (5595744485855199239)
+
+Made block:H1       :br38  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm10      value=  6.2 (5595749783116447754)
+
+Made block:H1T1     :br39  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  3.6 (7955622741629992967)
+      h1 = hm11      value=  6.7 (5595752170577199115)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br40  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  2.5 (7955612851761053709)
+      h1 = hm9       value= 11.0 (5595764356299096073)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:T1       :br41  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts28      value=  0.7 (7955579427321020444)
+
+Made block:T1       :br42  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts23      value=  1.1 (7955592660811513879)
+
+Made block:T1       :br43  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts25      value=  1.2 (7955594176142245913)
+
+Made block:T1       :br44  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts20      value=  1.6 (7955600931817521172)
+
+Made block:T1       :br45  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  3.0 (7955617510588416011)
+
+Made block:T1       :br46  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  3.2 (7955619349308375049)
+
+Made block:T1       :br47  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  3.5 (7955622255088631816)
+
+Made block:T1       :br48  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts4       value=  3.8 (7955624626195791876)
+
+Made block:T1       :br49  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 45.3 (7955686412678856705)
+
+Made block:T1       :br50  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 48.6 (7955688219771666432)
+
+Splitting block:E1T3     :br23  : ecals = 1 hcals = 0 tracks = 3
+    elements:
+      t0 = ts21      value=  1.4 (7955598890082762773)
+      t1 = ts22      value=  1.3 (7955597169390518294)
+      t2 = ts24      value=  1.2 (7955594067197296664)
+      e3 = em20      value=  3.0 (3289888583709622292)
+    distances:
+              t0      t1      t2      e3
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      e3  0.0000  0.0000  0.0153       .
+
+Made block:E1T3     :bs0   : ecals = 1 hcals = 0 tracks = 3
+    elements:
+      t0 = ts21      value=  1.4 (7955598890082762773)
+      t1 = ts22      value=  1.3 (7955597169390518294)
+      t2 = ts24      value=  1.2 (7955594067197296664)
+      e3 = em20      value=  3.0 (3289888583709622292)
+    distances:
+              t0      t1      t2      e3
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      e3  0.0000  0.0000  0.0153       .
+
+Splitting block:E1H1T2   :br13  : ecals = 1 hcals = 1 tracks = 2
+    elements:
+      t0 = ts17      value=  1.8 (7955604660675411985)
+      t1 = ts19      value=  1.7 (7955602701220315155)
+      h2 = hm1       value=  1.5 (5595714173941055489)
+      e3 = em15      value=  0.9 (3289857517089193999)
+    distances:
+              t0      t1      h2      e3
+      t0       .
+      t1     ---       .
+      h2  0.1866  0.0000       .
+      e3     ---  0.0000     ---       .
+
+Made block:E1H1T2   :bs1   : ecals = 1 hcals = 1 tracks = 2
+    elements:
+      t0 = ts17      value=  1.8 (7955604660675411985)
+      t1 = ts19      value=  1.7 (7955602701220315155)
+      h2 = hm1       value=  1.5 (5595714173941055489)
+      e3 = em15      value=  0.9 (3289857517089193999)
+    distances:
+              t0      t1      h2      e3
+      t0       .
+      t1     ---       .
+      h2  0.1866  0.0000       .
+      e3     ---  0.0000     ---       .
+
+Splitting block:E1H1T2   :br8   : ecals = 1 hcals = 1 tracks = 2
+    elements:
+      t0 = ts2       value=  7.0 (7955639476106035202)
+      t1 = ts5       value=  3.7 (7955623322958430213)
+      h2 = hm8       value= 12.7 (5595768095172984840)
+      e3 = em10      value=  0.7 (3289852176068771850)
+    distances:
+              t0      t1      h2      e3
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+      e3     ---  0.0397     ---       .
+
+Made block:E1H1T2   :bs2   : ecals = 1 hcals = 1 tracks = 2
+    elements:
+      t0 = ts2       value=  7.0 (7955639476106035202)
+      t1 = ts5       value=  3.7 (7955623322958430213)
+      h2 = hm8       value= 12.7 (5595768095172984840)
+      e3 = em10      value=  0.7 (3289852176068771850)
+    distances:
+              t0      t1      h2      e3
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+      e3     ---  0.0397     ---       .
+
+Splitting block:H1T2     :br33  : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts10      value=  3.2 (7955619310861287434)
+      t1 = ts18      value=  1.7 (7955603337330556946)
+      h2 = hm3       value=  3.2 (5595732878970322947)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.1125  0.0000       .
+
+Made block:H1T2     :bs3   : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts10      value=  3.2 (7955619310861287434)
+      t1 = ts18      value=  1.7 (7955603337330556946)
+      h2 = hm3       value=  3.2 (5595732878970322947)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.1125  0.0000       .
+
+Splitting block:H1T1     :br40  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  2.5 (7955612851761053709)
+      h1 = hm9       value= 11.0 (5595764356299096073)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs4   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  2.5 (7955612851761053709)
+      h1 = hm9       value= 11.0 (5595764356299096073)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br39  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  3.6 (7955622741629992967)
+      h1 = hm11      value=  6.7 (5595752170577199115)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs5   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  3.6 (7955622741629992967)
+      h1 = hm11      value=  6.7 (5595752170577199115)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br36  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  3.7 (7955623307133321222)
+      h1 = hm6       value=  4.7 (5595743092320763910)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs6   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  3.7 (7955623307133321222)
+      h1 = hm6       value=  4.7 (5595743092320763910)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br34  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts14      value=  2.2 (7955610148859281422)
+      h1 = hm4       value=  3.5 (5595736091060600836)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs7   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts14      value=  2.2 (7955610148859281422)
+      h1 = hm4       value=  3.5 (5595736091060600836)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br32  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts16      value=  1.7 (7955603972853596176)
+      h1 = hm2       value=  3.0 (5595730970260013058)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs8   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts16      value=  1.7 (7955603972853596176)
+      h1 = hm2       value=  3.0 (5595730970260013058)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br31  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts27      value=  0.9 (7955586714743865371)
+      h1 = hm0       value=  1.5 (5595713447374356480)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs9   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts27      value=  0.9 (7955586714743865371)
+      h1 = hm0       value=  1.5 (5595713447374356480)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:E1T1     :br29  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  1.9 (7955607520939081743)
+      e1 = em22      value=  5.6 (3289904045784825878)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs10  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  1.9 (7955607520939081743)
+      e1 = em22      value=  5.6 (3289904045784825878)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br24  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts29      value=  0.6 (7955578357576368157)
+      e1 = em26      value=  3.2 (3289889762499887130)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs11  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts29      value=  0.6 (7955578357576368157)
+      e1 = em26      value=  3.2 (3289889762499887130)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br22  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts26      value=  1.1 (7955593548896665626)
+      e1 = em25      value=  2.6 (3289885157099569177)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs12  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts26      value=  1.1 (7955593548896665626)
+      e1 = em25      value=  2.6 (3289885157099569177)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br21  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts3       value=  4.1 (7955626791247282179)
+      e1 = em24      value=  2.6 (3289884384347291672)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs13  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts3       value=  4.1 (7955626791247282179)
+      e1 = em24      value=  2.6 (3289884384347291672)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br17  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts30      value=  0.6 (7955577513200058398)
+      e1 = em21      value=  1.5 (3289870057884090389)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs14  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts30      value=  0.6 (7955577513200058398)
+      e1 = em21      value=  1.5 (3289870057884090389)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br4   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  2.7 (7955614560184958988)
+      e1 = em6       value=  0.6 (3289846798968946694)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs15  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  2.7 (7955614560184958988)
+      e1 = em6       value=  0.6 (3289846798968946694)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:T1       :br50  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 48.6 (7955688219771666432)
+
+Made block:T1       :bs16  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 48.6 (7955688219771666432)
+
+Splitting block:T1       :br49  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 45.3 (7955686412678856705)
+
+Made block:T1       :bs17  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 45.3 (7955686412678856705)
+
+Splitting block:T1       :br48  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts4       value=  3.8 (7955624626195791876)
+
+Made block:T1       :bs18  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts4       value=  3.8 (7955624626195791876)
+
+Splitting block:T1       :br47  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  3.5 (7955622255088631816)
+
+Made block:T1       :bs19  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  3.5 (7955622255088631816)
+
+Splitting block:T1       :br46  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  3.2 (7955619349308375049)
+
+Made block:T1       :bs20  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  3.2 (7955619349308375049)
+
+Splitting block:T1       :br45  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  3.0 (7955617510588416011)
+
+Made block:T1       :bs21  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  3.0 (7955617510588416011)
+
+Splitting block:T1       :br44  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts20      value=  1.6 (7955600931817521172)
+
+Made block:T1       :bs22  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts20      value=  1.6 (7955600931817521172)
+
+Splitting block:T1       :br43  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts25      value=  1.2 (7955594176142245913)
+
+Made block:T1       :bs23  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts25      value=  1.2 (7955594176142245913)
+
+Splitting block:T1       :br42  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts23      value=  1.1 (7955592660811513879)
+
+Made block:T1       :bs24  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts23      value=  1.1 (7955592660811513879)
+
+Splitting block:T1       :br41  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts28      value=  0.7 (7955579427321020444)
+
+Made block:T1       :bs25  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts28      value=  0.7 (7955579427321020444)
+
+Splitting block:H1       :br38  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm10      value=  6.2 (5595749783116447754)
+
+Made block:H1       :bs26  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm10      value=  6.2 (5595749783116447754)
+
+Splitting block:H1       :br37  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm7       value=  5.0 (5595744485855199239)
+
+Made block:H1       :bs27  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm7       value=  5.0 (5595744485855199239)
+
+Splitting block:H1       :br35  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  3.8 (5595738322579226629)
+
+Made block:H1       :bs28  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  3.8 (5595738322579226629)
+
+Splitting block:E1       :br30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em30      value=  9.0 (3289916968429158430)
+
+Made block:E1       :bs29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em30      value=  9.0 (3289916968429158430)
+
+Splitting block:E1       :br28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  4.1 (3289897666521071617)
+
+Made block:E1       :bs30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  4.1 (3289897666521071617)
+
+Splitting block:E1       :br27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em29      value=  3.9 (3289896140442435613)
+
+Made block:E1       :bs31  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em29      value=  3.9 (3289896140442435613)
+
+Splitting block:E1       :br26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em28      value=  3.4 (3289892246752591900)
+
+Made block:E1       :bs32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em28      value=  3.4 (3289892246752591900)
+
+Splitting block:E1       :br25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em27      value=  3.2 (3289889892328275995)
+
+Made block:E1       :bs33  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em27      value=  3.2 (3289889892328275995)
+
+Splitting block:E1       :br20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  2.3 (3289882026965991440)
+
+Made block:E1       :bs34  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  2.3 (3289882026965991440)
+
+Splitting block:E1       :br19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  2.2 (3289881587692339223)
+
+Made block:E1       :bs35  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  2.2 (3289881587692339223)
+
+Splitting block:E1       :br18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  1.7 (3289873729428914176)
+
+Made block:E1       :bs36  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  1.7 (3289873729428914176)
+
+Splitting block:E1       :br16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  1.3 (3289867383740563475)
+
+Made block:E1       :bs37  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  1.3 (3289867383740563475)
+
+Splitting block:E1       :br15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em18      value=  1.3 (3289866936220909586)
+
+Made block:E1       :bs38  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em18      value=  1.3 (3289866936220909586)
+
+Splitting block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  1.1 (3289863229991288849)
+
+Made block:E1       :bs39  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  1.1 (3289863229991288849)
+
+Splitting block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  0.8 (3289856644374069262)
+
+Made block:E1       :bs40  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  0.8 (3289856644374069262)
+
+Splitting block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  0.8 (3289856255406899213)
+
+Made block:E1       :bs41  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  0.8 (3289856255406899213)
+
+Splitting block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  0.8 (3289855830993666060)
+
+Made block:E1       :bs42  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  0.8 (3289855830993666060)
+
+Splitting block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  0.7 (3289852980758577163)
+
+Made block:E1       :bs43  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  0.7 (3289852980758577163)
+
+Splitting block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  0.6 (3289848238256947209)
+
+Made block:E1       :bs44  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  0.6 (3289848238256947209)
+
+Splitting block:E1       :br6   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.6 (3289847248935976968)
+
+Made block:E1       :bs45  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.6 (3289847248935976968)
+
+Splitting block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.6 (3289846914297626631)
+
+Made block:E1       :bs46  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.6 (3289846914297626631)
+
+Splitting block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.6 (3289846284447383557)
+
+Made block:E1       :bs47  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.6 (3289846284447383557)
+
+Splitting block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.5 (3289844940791611396)
+
+Made block:E1       :bs48  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.5 (3289844940791611396)
+
+Splitting block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.5 (3289843381491990531)
+
+Made block:E1       :bs49  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.5 (3289843381491990531)
+
+Splitting block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.5 (3289841466666385410)
+
+Made block:E1       :bs50  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.5 (3289841466666385410)
+
+Processing block:E1H1T2   :bs2   : ecals = 1 hcals = 1 tracks = 2
+    elements:
+      t0 = ts2       value=  7.0 (7955639476106035202)
+      t1 = ts5       value=  3.7 (7955623322958430213)
+      h2 = hm8       value= 12.7 (5595768095172984840)
+      e3 = em10      value=  0.7 (3289852176068771850)
+    distances:
+              t0      t1      h2      e3
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+      e3     ---  0.0397     ---       .
+
+Made Particle :pr0   :10252475292144631808: pdgid =  -211, status =   1, q = -1, e =   7.0, theta =  0.29, phi = -2.36, mass =  0.14 from SmearedTrack: ts2   :7955639476106035202:    6.99    6.69  0.29 -2.36
+Made Particle :pr1   :10252459156141244417: pdgid =  -211, status =   1, q = -1, e =   3.7, theta =  0.21, phi = -2.60, mass =  0.14 from SmearedTrack: ts5   :7955623322958430213:    3.66    3.57  0.21 -2.60
+Finished block
+Processing block:E1H1T2   :bs1   : ecals = 1 hcals = 1 tracks = 2
+    elements:
+      t0 = ts17      value=  1.8 (7955604660675411985)
+      t1 = ts19      value=  1.7 (7955602701220315155)
+      h2 = hm1       value=  1.5 (5595714173941055489)
+      e3 = em15      value=  0.9 (3289857517089193999)
+    distances:
+              t0      t1      h2      e3
+      t0       .
+      t1     ---       .
+      h2  0.1866  0.0000       .
+      e3     ---  0.0000     ---       .
+
+Made Particle :pr2   :10252440566610526210: pdgid =  -211, status =   1, q = -1, e =   1.8, theta =  0.40, phi =  1.48, mass =  0.14 from SmearedTrack: ts17  :7955604660675411985:    1.77    1.63  0.40  1.48
+Made Particle :pr3   :10252438613585297411: pdgid =  -211, status =   1, q = -1, e =   1.7, theta =  0.46, phi =  1.42, mass =  0.14 from SmearedTrack: ts19  :7955602701220315155:    1.66    1.49  0.46  1.42
+Finished block
+Processing block:E1T3     :bs0   : ecals = 1 hcals = 0 tracks = 3
+    elements:
+      t0 = ts21      value=  1.4 (7955598890082762773)
+      t1 = ts22      value=  1.3 (7955597169390518294)
+      t2 = ts24      value=  1.2 (7955594067197296664)
+      e3 = em20      value=  3.0 (3289888583709622292)
+    distances:
+              t0      t1      t2      e3
+      t0       .
+      t1     ---       .
+      t2     ---     ---       .
+      e3  0.0000  0.0000  0.0153       .
+
+Made Particle :pr4   :10252434817790509060: pdgid =   211, status =   1, q =  1, e =   1.4, theta =  0.12, phi =  1.49, mass =  0.14 from SmearedTrack: ts21  :7955598890082762773:    1.44    1.43  0.12  1.49
+Made Particle :pr5   :10252433105631576069: pdgid =   211, status =   1, q =  1, e =   1.3, theta =  0.13, phi =  1.50, mass =  0.14 from SmearedTrack: ts22  :7955597169390518294:    1.34    1.33  0.13  1.50
+Made Particle :pr6   :10252430022413385734: pdgid =   211, status =   1, q =  1, e =   1.2, theta =  0.13, phi =  1.58, mass =  0.14 from SmearedTrack: ts24  :7955594067197296664:    1.17    1.16  0.13  1.58
+Finished block
+Processing block:H1T2     :bs3   : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts10      value=  3.2 (7955619310861287434)
+      t1 = ts18      value=  1.7 (7955603337330556946)
+      h2 = hm3       value=  3.2 (5595732878970322947)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.1125  0.0000       .
+
+Made Particle :pr7   :10252455147351310343: pdgid =   211, status =   1, q =  1, e =   3.2, theta =  0.18, phi = -2.55, mass =  0.14 from SmearedTrack: ts10  :7955619310861287434:    3.20    3.15  0.18 -2.55
+Made Particle :pr8   :10252439247516598280: pdgid =   211, status =   1, q =  1, e =   1.7, theta =  0.21, phi = -2.20, mass =  0.14 from SmearedTrack: ts18  :7955603337330556946:    1.69    1.65  0.21 -2.20
+Finished block
+Processing block:E1T1     :bs15  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  2.7 (7955614560184958988)
+      e1 = em6       value=  0.6 (3289846798968946694)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr9   :10252450402049982473: pdgid =   211, status =   1, q =  1, e =   2.7, theta =  0.79, phi = -2.35, mass =  0.14 from SmearedTrack: ts12  :7955614560184958988:    2.66    1.88  0.79 -2.35
+Finished block
+Processing block:E1T1     :bs14  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts30      value=  0.6 (7955577513200058398)
+      e1 = em21      value=  1.5 (3289870057884090389)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr10  :10252413871188869130: pdgid =   211, status =   1, q =  1, e =   0.6, theta =  0.05, phi =  0.98, mass =  0.14 from SmearedTrack: ts30  :7955577513200058398:    0.61    0.61  0.05  0.98
+Finished block
+Processing block:E1T1     :bs13  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts3       value=  4.1 (7955626791247282179)
+      e1 = em24      value=  2.6 (3289884384347291672)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr11  :10252462611555680267: pdgid =  -211, status =   1, q = -1, e =   4.1, theta =  0.36, phi =  1.12, mass =  0.14 from SmearedTrack: ts3   :7955626791247282179:    4.10    3.84  0.36  1.12
+Finished block
+Processing block:E1T1     :bs12  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts26      value=  1.1 (7955593548896665626)
+      e1 = em25      value=  2.6 (3289885157099569177)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr12  :10252429507851976716: pdgid =  -211, status =   1, q = -1, e =   1.1, theta =  0.24, phi = -2.29, mass =  0.14 from SmearedTrack: ts26  :7955593548896665626:    1.14    1.10  0.24 -2.29
+Finished block
+Processing block:E1T1     :bs11  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts29      value=  0.6 (7955578357576368157)
+      e1 = em26      value=  3.2 (3289889762499887130)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr13  :10252414695384285197: pdgid =  -211, status =   1, q = -1, e =   0.7, theta = -0.49, phi =  0.88, mass =  0.14 from SmearedTrack: ts29  :7955578357576368157:    0.64    0.56 -0.49  0.88
+Finished block
+Processing block:E1T1     :bs10  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  1.9 (7955607520939081743)
+      e1 = em22      value=  5.6 (3289904045784825878)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr14  :10252443418814840846: pdgid =   211, status =   1, q =  1, e =   1.9, theta =  0.36, phi = -2.02, mass =  0.14 from SmearedTrack: ts15  :7955607520939081743:    1.93    1.81  0.36 -2.02
+Finished block
+Processing block:H1T1     :bs9   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts27      value=  0.9 (7955586714743865371)
+      h1 = hm0       value=  1.5 (5595713447374356480)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr15  :10252422911193251855: pdgid =   211, status =   1, q =  1, e =   0.9, theta =  0.81, phi =  1.94, mass =  0.14 from SmearedTrack: ts27  :7955586714743865371:    0.87    0.60  0.81  1.94
+Finished block
+Processing block:H1T1     :bs8   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts16      value=  1.7 (7955603972853596176)
+      h1 = hm2       value=  3.0 (5595730970260013058)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr16  :10252439880950874128: pdgid =   211, status =   1, q =  1, e =   1.7, theta = -0.06, phi =  0.82, mass =  0.14 from SmearedTrack: ts16  :7955603972853596176:    1.73    1.73 -0.06  0.82
+Finished block
+Processing block:H1T1     :bs7   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts14      value=  2.2 (7955610148859281422)
+      h1 = hm4       value=  3.5 (5595736091060600836)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr17  :10252445998118862865: pdgid =   211, status =   1, q =  1, e =   2.2, theta =  0.26, phi =  1.14, mass =  0.14 from SmearedTrack: ts14  :7955610148859281422:    2.16    2.09  0.26  1.14
+Finished block
+Processing block:H1T1     :bs6   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  3.7 (7955623307133321222)
+      h1 = hm6       value=  4.7 (5595743092320763910)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr18  :10252459140326621202: pdgid =  -211, status =   1, q = -1, e =   3.7, theta =  0.09, phi =  0.98, mass =  0.14 from SmearedTrack: ts6   :7955623307133321222:    3.66    3.64  0.09  0.98
+Finished block
+Processing block:H1T1     :bs5   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  3.6 (7955622741629992967)
+      h1 = hm11      value=  6.7 (5595752170577199115)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr19  :10252458575238529043: pdgid =   211, status =   1, q =  1, e =   3.6, theta =  0.05, phi = -2.79, mass =  0.14 from SmearedTrack: ts7   :7955622741629992967:    3.59    3.59  0.05 -2.79
+Finished block
+Processing block:H1T1     :bs4   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  2.5 (7955612851761053709)
+      h1 = hm9       value= 11.0 (5595764356299096073)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr20  :10252448696134270996: pdgid =  -211, status =   1, q = -1, e =   2.5, theta =  0.23, phi =  1.04, mass =  0.14 from SmearedTrack: ts13  :7955612851761053709:    2.47    2.40  0.23  1.04
+Made Particle :pr21  :10252480945449861141: pdgid =   130, status =   1, q =  0, e =   8.5, theta =  0.21, phi =  1.53, mass =  0.50 from MergedCluster: hm9   :5595764356299096073:   11.02  0.21  1.53 sub(hs2, hs7, )
+Finished block
+Processing block:E1       :bs50  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.5 (3289841466666385410)
+
+Made Particle :pr22  :10252406490581172246: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.54, phi = -2.19, mass =  0.00 from MergedCluster: em2   :3289841466666385410:    0.46  0.54 -2.19 sub(es31, )
+Finished block
+Processing block:E1       :bs49  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.5 (3289843381491990531)
+
+Made Particle :pr23  :10252408405406777367: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.32, phi =  1.46, mass =  0.00 from MergedCluster: em3   :3289843381491990531:    0.49  0.32  1.46 sub(es38, )
+Finished block
+Processing block:E1       :bs48  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.5 (3289844940791611396)
+
+Made Particle :pr24  :10252409964706398232: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.04, phi = -2.64, mass =  0.00 from MergedCluster: em4   :3289844940791611396:    0.52  0.04 -2.64 sub(es30, )
+Finished block
+Processing block:E1       :bs47  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.6 (3289846284447383557)
+
+Made Particle :pr25  :10252411308362170393: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.15, phi = -2.41, mass =  0.00 from MergedCluster: em5   :3289846284447383557:    0.56  0.15 -2.41 sub(es32, )
+Finished block
+Processing block:E1       :bs46  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.6 (3289846914297626631)
+
+Made Particle :pr26  :10252411938212413466: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.07, phi = -2.70, mass =  0.00 from MergedCluster: em7   :3289846914297626631:    0.57  0.07 -2.70 sub(es33, )
+Finished block
+Processing block:E1       :bs45  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.6 (3289847248935976968)
+
+Made Particle :pr27  :10252412272850763803: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.83, phi =  2.51, mass =  0.00 from MergedCluster: em8   :3289847248935976968:    0.58  0.83  2.51 sub(es9, )
+Finished block
+Processing block:E1       :bs44  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  0.6 (3289848238256947209)
+
+Made Particle :pr28  :10252413262171734044: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.42, phi = -2.35, mass =  0.00 from MergedCluster: em9   :3289848238256947209:    0.61  0.42 -2.35 sub(es34, )
+Finished block
+Processing block:E1       :bs43  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  0.7 (3289852980758577163)
+
+Made Particle :pr29  :10252418004673363997: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.29, phi =  3.01, mass =  0.00 from MergedCluster: em11  :3289852980758577163:    0.75  0.29  3.01 sub(es24, )
+Finished block
+Processing block:E1       :bs42  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  0.8 (3289855830993666060)
+
+Made Particle :pr30  :10252420854908452894: pdgid =    22, status =   1, q =  0, e =   0.8, theta = -0.20, phi = -2.69, mass =  0.00 from MergedCluster: em12  :3289855830993666060:    0.83 -0.20 -2.69 sub(es26, )
+Finished block
+Processing block:E1       :bs41  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  0.8 (3289856255406899213)
+
+Made Particle :pr31  :10252421279321686047: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.06, phi = -2.58, mass =  0.00 from MergedCluster: em13  :3289856255406899213:    0.84  0.06 -2.58 sub(es23, )
+Finished block
+Processing block:E1       :bs40  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  0.8 (3289856644374069262)
+
+Made Particle :pr32  :10252421668288856096: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.59, phi = -2.70, mass =  0.00 from MergedCluster: em14  :3289856644374069262:    0.85  0.59 -2.70 sub(es21, )
+Finished block
+Processing block:E1       :bs39  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  1.1 (3289863229991288849)
+
+Made Particle :pr33  :10252428253906075681: pdgid =    22, status =   1, q =  0, e =   1.1, theta =  0.50, phi = -2.56, mass =  0.00 from MergedCluster: em17  :3289863229991288849:    1.07  0.50 -2.56 sub(es16, )
+Finished block
+Processing block:E1       :bs38  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em18      value=  1.3 (3289866936220909586)
+
+Made Particle :pr34  :10252431960135696418: pdgid =    22, status =   1, q =  0, e =   1.3, theta =  0.10, phi = -2.76, mass =  0.00 from MergedCluster: em18  :3289866936220909586:    1.28  0.10 -2.76 sub(es13, )
+Finished block
+Processing block:E1       :bs37  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  1.3 (3289867383740563475)
+
+Made Particle :pr35  :10252432407655350307: pdgid =    22, status =   1, q =  0, e =   1.3, theta = -0.22, phi = -2.53, mass =  0.00 from MergedCluster: em19  :3289867383740563475:    1.31 -0.22 -2.53 sub(es20, )
+Finished block
+Processing block:E1       :bs36  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  1.7 (3289873729428914176)
+
+Made Particle :pr36  :10252438753343701028: pdgid =    22, status =   1, q =  0, e =   1.7, theta =  0.13, phi = -2.52, mass =  0.00 from MergedCluster: em0   :3289873729428914176:    1.67  0.13 -2.52 sub(es1, es25, es36, )
+Finished block
+Processing block:E1       :bs35  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  2.2 (3289881587692339223)
+
+Made Particle :pr37  :10252446611607126053: pdgid =    22, status =   1, q =  0, e =   2.2, theta =  0.21, phi =  0.97, mass =  0.00 from MergedCluster: em23  :3289881587692339223:    2.23  0.21  0.97 sub(es7, )
+Finished block
+Processing block:E1       :bs34  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  2.3 (3289882026965991440)
+
+Made Particle :pr38  :10252447050880778278: pdgid =    22, status =   1, q =  0, e =   2.3, theta =  0.27, phi = -2.43, mass =  0.00 from MergedCluster: em16  :3289882026965991440:    2.28  0.27 -2.43 sub(es18, es17, )
+Finished block
+Processing block:E1       :bs33  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em27      value=  3.2 (3289889892328275995)
+
+Made Particle :pr39  :10252454916243062823: pdgid =    22, status =   1, q =  0, e =   3.2, theta =  0.24, phi =  1.28, mass =  0.00 from MergedCluster: em27  :3289889892328275995:    3.18  0.24  1.28 sub(es5, )
+Finished block
+Processing block:E1       :bs32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em28      value=  3.4 (3289892246752591900)
+
+Made Particle :pr40  :10252457270667378728: pdgid =    22, status =   1, q =  0, e =   3.4, theta =  0.04, phi =  1.10, mass =  0.00 from MergedCluster: em28  :3289892246752591900:    3.45  0.04  1.10 sub(es4, )
+Finished block
+Processing block:E1       :bs31  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em29      value=  3.9 (3289896140442435613)
+
+Made Particle :pr41  :10252461164357222441: pdgid =    22, status =   1, q =  0, e =   3.9, theta =  0.69, phi =  1.33, mass =  0.00 from MergedCluster: em29  :3289896140442435613:    3.89  0.69  1.33 sub(es0, )
+Finished block
+Processing block:E1       :bs30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  4.1 (3289897666521071617)
+
+Made Particle :pr42  :10252462690435858474: pdgid =    22, status =   1, q =  0, e =   4.1, theta = -0.09, phi = -2.77, mass =  0.00 from MergedCluster: em1   :3289897666521071617:    4.12 -0.09 -2.77 sub(es11, es22, es2, es37, )
+Finished block
+Processing block:E1       :bs29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em30      value=  9.0 (3289916968429158430)
+
+Made Particle :pr43  :10252481992343945259: pdgid =    22, status =   1, q =  0, e =   9.0, theta =  1.36, phi =  2.50, mass =  0.00 from MergedCluster: em30  :3289916968429158430:    9.03  1.36  2.50 sub(es35, )
+Finished block
+Processing block:H1       :bs28  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  3.8 (5595738322579226629)
+
+Made Particle :pr44  :10252460337280319532: pdgid =   130, status =   1, q =  0, e =   3.8, theta =  1.29, phi = -0.89, mass =  0.50 from MergedCluster: hm5   :5595738322579226629:    3.79  1.29 -0.89 sub(hs13, )
+Finished block
+Processing block:H1       :bs27  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm7       value=  5.0 (5595744485855199239)
+
+Made Particle :pr45  :10252466500556292141: pdgid =   130, status =   1, q =  0, e =   5.0, theta = -0.07, phi = -2.87, mass =  0.50 from MergedCluster: hm7   :5595744485855199239:    4.99 -0.07 -2.87 sub(hs3, )
+Finished block
+Processing block:H1       :bs26  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm10      value=  6.2 (5595749783116447754)
+
+Made Particle :pr46  :10252471797817540654: pdgid =   130, status =   1, q =  0, e =   6.2, theta =  0.69, phi =  1.33, mass =  0.50 from MergedCluster: hm10  :5595749783116447754:    6.20  0.69  1.33 sub(hs1, )
+Finished block
+Processing block:T1       :bs25  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts28      value=  0.7 (7955579427321020444)
+
+Made Particle :pr47  :10252415741580017711: pdgid =  -211, status =   1, q = -1, e =   0.7, theta = -0.10, phi = -2.76, mass =  0.14 from SmearedTrack: ts28  :7955579427321020444:    0.67    0.66 -0.10 -2.76
+Finished block
+Processing block:T1       :bs24  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts23      value=  1.1 (7955592660811513879)
+
+Made Particle :pr48  :10252428626639192112: pdgid =   211, status =   1, q =  1, e =   1.1, theta =  0.49, phi =  1.21, mass =  0.14 from SmearedTrack: ts23  :7955592660811513879:    1.09    0.96  0.49  1.21
+Finished block
+Processing block:T1       :bs23  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts25      value=  1.2 (7955594176142245913)
+
+Made Particle :pr49  :10252430130599166001: pdgid =  -211, status =   1, q = -1, e =   1.2, theta =  0.02, phi =  1.51, mass =  0.14 from SmearedTrack: ts25  :7955594176142245913:    1.17    1.17  0.02  1.51
+Finished block
+Processing block:T1       :bs22  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts20      value=  1.6 (7955600931817521172)
+
+Made Particle :pr50  :10252436850775949362: pdgid =  -211, status =   1, q = -1, e =   1.6, theta =  0.21, phi = -2.21, mass =  0.14 from SmearedTrack: ts20  :7955600931817521172:    1.56    1.52  0.21 -2.21
+Finished block
+Processing block:T1       :bs21  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  3.0 (7955617510588416011)
+
+Made Particle :pr51  :10252453348886183987: pdgid =  -211, status =   1, q = -1, e =   3.0, theta =  0.36, phi =  1.28, mass =  0.14 from SmearedTrack: ts11  :7955617510588416011:    3.00    2.81  0.36  1.28
+Finished block
+Processing block:T1       :bs20  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  3.2 (7955619349308375049)
+
+Made Particle :pr52  :10252455185760649268: pdgid =  -211, status =   1, q = -1, e =   3.2, theta =  0.17, phi =  1.08, mass =  0.14 from SmearedTrack: ts9   :7955619349308375049:    3.21    3.16  0.17  1.08
+Finished block
+Processing block:T1       :bs19  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  3.5 (7955622255088631816)
+
+Made Particle :pr53  :10252458089066266677: pdgid =   211, status =   1, q =  1, e =   3.5, theta =  0.18, phi =  1.33, mass =  0.14 from SmearedTrack: ts8   :7955622255088631816:    3.54    3.48  0.18  1.33
+Finished block
+Processing block:T1       :bs18  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts4       value=  3.8 (7955624626195791876)
+
+Made Particle :pr54  :10252460458474733622: pdgid =   211, status =   1, q =  1, e =   3.8, theta =  0.20, phi =  1.27, mass =  0.14 from SmearedTrack: ts4   :7955624626195791876:    3.81    3.73  0.20  1.27
+Finished block
+Processing block:T1       :bs17  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 45.3 (7955686412678856705)
+
+Made Particle :pr55  :10252522222704918583: pdgid =    13, status =   1, q =  1, e =  45.3, theta =  0.70, phi = -1.07, mass =  0.11 from SmearedTrack: ts1   :7955686412678856705:   45.28   34.68  0.70 -1.07
+Finished block
+Processing block:T1       :bs16  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 48.6 (7955688219771666432)
+
+Made Particle :pr56  :10252524029793534008: pdgid =   -13, status =   1, q = -1, e =  48.6, theta = -1.36, phi =  0.53, mass =  0.10 from SmearedTrack: ts0   :7955688219771666432:   48.57   10.33 -1.36  0.53
+Finished block
+Finished reconstruction
+Event: 5
+Made Particle :ps0   :10261539073036386304: pdgid =    13, status =   1, q = -1, e =  62.8, theta = -0.06, phi = -2.03, mass =  0.11
+Made Particle :ps1   :10261527696316039169: pdgid =   -13, status =   1, q =  1, e =  42.1, theta = -0.19, phi =  2.03, mass =  0.11
+Made Particle :ps2   :10261508092965421058: pdgid =   211, status =   1, q =  1, e =  19.2, theta =  0.21, phi =  0.82, mass =  0.14
+Made Particle :ps3   :10261507063133765635: pdgid =   -13, status =   1, q =  1, e =  18.3, theta =  0.34, phi =  0.90, mass =  0.11
+Made Particle :ps4   :10261504740282073092: pdgid =  -211, status =   1, q = -1, e =  16.2, theta =  0.25, phi =  0.83, mass =  0.14
+Made Particle :ps5   :10261479324655812613: pdgid =  -211, status =   1, q = -1, e =   6.3, theta =  0.24, phi =  0.80, mass =  0.14
+Made Particle :ps6   :10261472651004346374: pdgid =   321, status =   1, q =  1, e =   4.8, theta = -0.55, phi = -1.79, mass =  0.49
+Made Particle :ps7   :10261472395906777095: pdgid =    22, status =   1, q =  0, e =   4.7, theta = -0.28, phi = -1.74, mass =  0.00
+Made Particle :ps8   :10261470966194372616: pdgid =  2112, status =   1, q =  0, e =   4.4, theta = -0.12, phi = -1.89, mass =  0.94
+Made Particle :ps9   :10261469895342424073: pdgid =   130, status =   1, q =  0, e =   4.1, theta = -0.31, phi = -1.73, mass =  0.50
+Made Particle :ps10  :10261466738719719434: pdgid =  -211, status =   1, q = -1, e =   3.7, theta =  0.22, phi =  0.83, mass =  0.14
+Made Particle :ps11  :10261460181686681611: pdgid =    22, status =   1, q =  0, e =   3.0, theta = -0.25, phi = -1.77, mass =  0.00
+Made Particle :ps12  :10261460085060403212: pdgid =   211, status =   1, q =  1, e =   2.9, theta =  0.19, phi =  0.95, mass =  0.14
+Made Particle :ps13  :10261457524934836237: pdgid =   211, status =   1, q =  1, e =   2.7, theta = -0.44, phi = -1.87, mass =  0.14
+Made Particle :ps14  :10261455624097234958: pdgid =    22, status =   1, q =  0, e =   2.4, theta = -0.35, phi = -1.73, mass =  0.00
+Made Particle :ps15  :10261454819977854991: pdgid =   130, status =   1, q =  0, e =   2.3, theta = -0.34, phi = -1.77, mass =  0.50
+Made Particle :ps16  :10261454673552605200: pdgid =  -211, status =   1, q = -1, e =   2.3, theta =  0.09, phi =  0.80, mass =  0.14
+Made Particle :ps17  :10261452270061223953: pdgid =   211, status =   1, q =  1, e =   2.1, theta =  0.19, phi = -1.56, mass =  0.14
+Made Particle :ps18  :10261450879710265362: pdgid =    22, status =   1, q =  0, e =   2.0, theta =  0.37, phi =  0.90, mass =  0.00
+Made Particle :ps19  :10261448099067068435: pdgid =    22, status =   1, q =  0, e =   1.8, theta = -0.30, phi = -1.68, mass =  0.00
+Made Particle :ps20  :10261447523822469140: pdgid =   211, status =   1, q =  1, e =   1.8, theta =  0.27, phi =  0.69, mass =  0.14
+Made Particle :ps21  :10261445826597355541: pdgid =  -211, status =   1, q = -1, e =   1.7, theta =  0.05, phi = -1.77, mass =  0.14
+Made Particle :ps22  :10261445570885320726: pdgid = -2112, status =   1, q =  0, e =   1.6, theta = -0.04, phi = -1.63, mass =  0.94
+Made Particle :ps23  :10261436542419468311: pdgid =  -211, status =   1, q = -1, e =   1.1, theta =  0.12, phi = -1.73, mass =  0.14
+Made Particle :ps24  :10261435813514444824: pdgid =    22, status =   1, q =  0, e =   1.1, theta = -0.06, phi = -1.92, mass =  0.00
+Made Particle :ps25  :10261435178733797401: pdgid =    22, status =   1, q =  0, e =   1.1, theta = -0.16, phi = -1.85, mass =  0.00
+Made Particle :ps26  :10261434444164366362: pdgid =  -211, status =   1, q = -1, e =   1.0, theta = -0.81, phi = -2.25, mass =  0.14
+Made Particle :ps27  :10261433820733505563: pdgid =   211, status =   1, q =  1, e =   1.0, theta = -0.09, phi = -1.15, mass =  0.14
+Made Particle :ps28  :10261425603368452124: pdgid =   211, status =   1, q =  1, e =   0.8, theta =  0.81, phi =  0.83, mass =  0.14
+Made Particle :ps29  :10261425569367326749: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.42, phi =  0.79, mass =  0.00
+Made Particle :ps30  :10261422785985249310: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.72, phi = -1.11, mass =  0.00
+Made Particle :ps31  :10261419617266171935: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.07, phi = -2.14, mass =  0.00
+Made Particle :ps32  :10261419048516452384: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.04, phi = -1.93, mass =  0.00
+Made Particle :ps33  :10261417877512912929: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.63, phi = -1.43, mass =  0.00
+Made Particle :ps34  :10261417078720299042: pdgid =  -211, status =   1, q = -1, e =   0.5, theta =  0.16, phi = -0.44, mass =  0.14
+Made Particle :ps35  :10261417028862607395: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.36, phi = -2.12, mass =  0.00
+Made Particle :ps36  :10261415407153840164: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.12, phi = -1.95, mass =  0.00
+Made Particle :ps37  :10261414136279728165: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.30, phi =  1.60, mass =  0.00
+Made Particle :ps38  :10261413648779968550: pdgid =  -211, status =   1, q = -1, e =   0.5, theta =  0.24, phi = -2.34, mass =  0.14
+Made Particle :ps39  :10261412774278070311: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.58, phi =  0.31, mass =  0.00
+Made Particle :ps40  :10261412169583165480: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.25, phi =  0.95, mass =  0.00
+Made Particle :ps41  :10261409375365103657: pdgid =  -211, status =   1, q = -1, e =   0.4, theta = -0.59, phi = -2.01, mass =  0.14
+Made Particle :ps42  :10261407740091957290: pdgid =  -211, status =   1, q = -1, e =   0.4, theta = -0.70, phi =  3.04, mass =  0.14
+Made Particle :ps43  :10261404745933520939: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.79, phi = -0.05, mass =  0.00
+Made Particle :ps44  :10261402636842434604: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.32, phi = -1.90, mass =  0.00
+Made Particle :ps45  :10261402277281529901: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.71, phi = -2.10, mass =  0.00
+Made Particle :ps46  :10261401536468877358: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.30, phi = -1.81, mass =  0.00
+Made Particle :ps47  :10261401025652981807: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.51, phi =  0.94, mass =  0.00
+Made Particle :ps48  :10261394420664369200: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.04, phi =  0.90, mass =  0.00
+Made Particle :ps49  :10261392899335782449: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.04, phi = -2.12, mass =  0.00
+Made Particle :ps50  :10261392706502656050: pdgid =  -211, status =   1, q = -1, e =   0.2, theta =  0.14, phi = -2.96, mass =  0.14
+Made Particle :ps51  :10261392697023529011: pdgid =   211, status =   1, q =  1, e =   0.2, theta =  0.72, phi = -2.14, mass =  0.14
+Made Particle :ps52  :10261390313885007924: pdgid =   211, status =   1, q =  1, e =   0.2, theta = -0.82, phi = -0.54, mass =  0.14
+Made Particle :ps53  :10261387066736640053: pdgid =   211, status =   1, q =  1, e =   0.2, theta =  0.52, phi = -1.81, mass =  0.14
+Made Particle :ps54  :10261386060435030070: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.72, phi = -1.29, mass =  0.00
+Made Particle :ps55  :10261379449003966519: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.41, phi =  0.99, mass =  0.00
+Made Particle :ps56  :10261364805807898680: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.08, phi = -1.23, mass =  0.00
+Made Particle :ps57  :10261363801043501113: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.38, phi =  0.52, mass =  0.00
+Simulating Particle :ps0   :10261539073036386304: pdgid =    13, status =   1, q = -1, e =  62.8, theta = -0.06, phi = -2.03, mass =  0.11
+Simulating Muon
+Made Track: tt0   :7964703263029198848:   62.84   62.73 -0.06 -2.03
+Made SmearedTrack: ts0   :7955695609634095104:   62.01   61.91 -0.06 -2.03
+Simulating Particle :ps1   :10261527696316039169: pdgid =   -13, status =   1, q =  1, e =  42.1, theta = -0.19, phi =  2.03, mass =  0.11
+Simulating Muon
+Made Track: tt1   :7964691886283685889:   42.14   41.42 -0.19  2.03
+Made SmearedTrack: ts1   :7955684619248992257:   42.02   41.30 -0.19  2.03
+Simulating Particle :ps2   :10261508092965421058: pdgid =   211, status =   1, q =  1, e =  19.2, theta =  0.21, phi =  0.82, mass =  0.14
+Simulating Hadron
+Made Track: tt2   :7964672282450722818:   19.24   18.81  0.21  0.82
+Made SmearedTrack: ts2   :7955664866262384642:   19.04   18.61  0.21  0.82
+Rejected SmearedTrack: ts2   :7955664866262384642:   19.04   18.61  0.21  0.82
+Made Cluster: ht0   :5658829273792774144:   19.24  0.22  0.80 sub(ht0, )
+Made SmearedCluster: hs0   :5649828028834906112:   24.66  0.22  0.80 sub(hs0, )
+Simulating Particle :ps3   :10261507063133765635: pdgid =   -13, status =   1, q =  1, e =  18.3, theta =  0.34, phi =  0.90, mass =  0.11
+Simulating Muon
+Made Track: tt3   :7964671252839268355:   18.31   17.27  0.34  0.90
+Made SmearedTrack: ts2   :7955664607092146178:   18.81   17.75  0.34  0.90
+Simulating Particle :ps4   :10261504740282073092: pdgid =  -211, status =   1, q = -1, e =  16.2, theta =  0.25, phi =  0.83, mass =  0.14
+Simulating Hadron
+Made Track: tt4   :7964668929660420100:   16.19   15.69  0.25  0.83
+Made SmearedTrack: ts3   :7955661762141880323:   16.22   15.72  0.25  0.83
+Made Cluster: et0   :3352912987802304512:    1.04  0.25  0.88 sub(et0, )
+Made SmearedCluster: es0   :3341670923508908032:   -0.22  0.25  0.88 sub(es0, )
+Rejected SmearedCluster: es0   :3341670923508908032:   -0.22  0.25  0.88 sub(es0, )
+Made Cluster: ht1   :5658823852669534209:   15.16  0.25  0.90 sub(ht1, )
+Made SmearedCluster: hs1   :5649808598071508993:   11.49  0.25  0.90 sub(hs1, )
+Simulating Particle :ps5   :10261479324655812613: pdgid =  -211, status =   1, q = -1, e =   6.3, theta =  0.24, phi =  0.80, mass =  0.14
+Simulating Hadron
+Made Track: tt5   :7964643507862241285:    6.27    6.09  0.24  0.80
+Made SmearedTrack: ts4   :7955636255534874628:    6.26    6.08  0.24  0.80
+Made Cluster: ht2   :5658800505483165698:    6.27  0.23  0.87 sub(ht2, )
+Made SmearedCluster: hs2   :5649800670428004354:    7.94  0.23  0.87 sub(hs2, )
+Simulating Particle :ps6   :10261472651004346374: pdgid =   321, status =   1, q =  1, e =   4.8, theta = -0.55, phi = -1.79, mass =  0.49
+Simulating Hadron
+Made Track: tt6   :7964636727960666118:    4.73    4.03 -0.55 -1.79
+Made SmearedTrack: ts5   :7955629273734184965:    4.67    3.98 -0.55 -1.79
+Made Cluster: et1   :3352936045149683713:    2.70 -0.55 -1.98 sub(et1, )
+Made SmearedCluster: es0   :3341670923508908032:   -0.50 -0.55 -1.98 sub(es0, )
+Rejected SmearedCluster: es0   :3341670923508908032:   -0.50 -0.55 -1.98 sub(es0, )
+Made Cluster: ht3   :5658773424930029571:    2.06 -0.56 -2.07 sub(ht3, )
+Made SmearedCluster: hs3   :5649746336243777539:    0.95 -0.56 -2.07 sub(hs3, )
+Rejected SmearedCluster: hs3   :5649746336243777539:    0.95 -0.56 -2.07 sub(hs3, )
+Simulating Particle :ps7   :10261472395906777095: pdgid =    22, status =   1, q =  0, e =   4.7, theta = -0.28, phi = -1.74, mass =  0.00
+Simulating Photon
+Made Cluster: et2   :3352950567520436226:    4.69 -0.28 -1.74 sub(et2, )
+Made SmearedCluster: es0   :3343944653331234816:    4.99 -0.28 -1.74 sub(es0, )
+Simulating Particle :ps8   :10261470966194372616: pdgid =  2112, status =   1, q =  0, e =   4.4, theta = -0.12, phi = -1.89, mass =  0.94
+Simulating Hadron
+Made Cluster: et3   :3352935884658835459:    2.68 -0.12 -1.89 sub(et3, )
+Made SmearedCluster: es1   :3341670923508908033:   -1.60 -0.12 -1.89 sub(es1, )
+Rejected SmearedCluster: es1   :3341670923508908033:   -1.60 -0.12 -1.89 sub(es1, )
+Made Cluster: ht4   :5658767499804540932:    1.69 -0.12 -1.89 sub(ht4, )
+Made SmearedCluster: hs3   :5649748274899320835:    1.01 -0.12 -1.89 sub(hs3, )
+Rejected SmearedCluster: hs3   :5649748274899320835:    1.01 -0.12 -1.89 sub(hs3, )
+Simulating Particle :ps9   :10261469895342424073: pdgid =   130, status =   1, q =  0, e =   4.1, theta = -0.31, phi = -1.73, mass =  0.50
+Simulating Hadron
+Made Cluster: ht5   :5658791076169777157:    4.13 -0.31 -1.73 sub(ht5, )
+Made SmearedCluster: hs3   :5649788575233867779:    5.19 -0.31 -1.73 sub(hs3, )
+Simulating Particle :ps10  :10261466738719719434: pdgid =  -211, status =   1, q = -1, e =   3.7, theta =  0.22, phi =  0.83, mass =  0.14
+Simulating Hadron
+Made Track: tt7   :7964630905622888455:    3.70    3.61  0.22  0.83
+Made SmearedTrack: ts6   :7955622872968331270:    3.61    3.52  0.22  0.83
+Made Cluster: et4   :3352899855832842244:    0.65  0.22  1.03 sub(et4, )
+Made SmearedCluster: es1   :3343946570394501121:    5.42  0.22  1.03 sub(es1, )
+Made Cluster: ht6   :5658782242095235078:    3.06  0.22  1.13 sub(ht6, )
+Made SmearedCluster: hs4   :5647513932722601988:   -1.96  0.22  1.13 sub(hs4, )
+Rejected SmearedCluster: hs4   :5647513932722601988:   -1.96  0.22  1.13 sub(hs4, )
+Simulating Particle :ps11  :10261460181686681611: pdgid =    22, status =   1, q =  0, e =   3.0, theta = -0.25, phi = -1.77, mass =  0.00
+Simulating Photon
+Made Cluster: et5   :3352938353300340741:    2.96 -0.25 -1.77 sub(et5, )
+Made SmearedCluster: es2   :3343928249265684482:    2.63 -0.25 -1.77 sub(es2, )
+Simulating Particle :ps12  :10261460085060403212: pdgid =   211, status =   1, q =  1, e =   2.9, theta =  0.19, phi =  0.95, mass =  0.14
+Simulating Hadron
+Made Track: tt8   :7964624246018146312:    2.94    2.89  0.19  0.95
+Made SmearedTrack: ts7   :7955616817393696775:    2.92    2.87  0.19  0.95
+Made Cluster: et6   :3352877239684300806:    0.25  0.19  0.70 sub(et6, )
+Made SmearedCluster: es3   :3343954088468414467:    7.13  0.19  0.70 sub(es3, )
+Made Cluster: ht7   :5658779055156101127:    2.70  0.19  0.57 sub(ht7, )
+Made SmearedCluster: hs4   :5647513932722601988:   -1.22  0.19  0.57 sub(hs4, )
+Rejected SmearedCluster: hs4   :5647513932722601988:   -1.22  0.19  0.57 sub(hs4, )
+Simulating Particle :ps13  :10261457524934836237: pdgid =   211, status =   1, q =  1, e =   2.7, theta = -0.44, phi = -1.87, mass =  0.14
+Simulating Hadron
+Made Track: tt9   :7964621682700713993:    2.65    2.40 -0.44 -1.87
+Made SmearedTrack: ts8   :7955614550879895560:    2.66    2.41 -0.44 -1.87
+Made Cluster: et7   :3352870337759936519:    0.20 -0.44 -2.18 sub(et7, )
+Made SmearedCluster: es4   :3341670923508908036:   -0.55 -0.44 -2.18 sub(es4, )
+Rejected SmearedCluster: es4   :3341670923508908036:   -0.55 -0.44 -2.18 sub(es4, )
+Made Cluster: ht8   :5658776932255268872:    2.45 -0.45 -2.33 sub(ht8, )
+Made SmearedCluster: hs4   :5649770513550016516:    2.54 -0.45 -2.33 sub(hs4, )
+Rejected SmearedCluster: hs4   :5649770513550016516:    2.54 -0.45 -2.33 sub(hs4, )
+Simulating Particle :ps14  :10261455624097234958: pdgid =    22, status =   1, q =  0, e =   2.4, theta = -0.35, phi = -1.73, mass =  0.00
+Simulating Photon
+Made Cluster: et8   :3352933795710894088:    2.44 -0.35 -1.73 sub(et8, )
+Made SmearedCluster: es4   :3343926518450487300:    2.43 -0.35 -1.73 sub(es4, )
+Simulating Particle :ps15  :10261454819977854991: pdgid =   130, status =   1, q =  0, e =   2.3, theta = -0.34, phi = -1.77, mass =  0.50
+Simulating Hadron
+Made Cluster: et9   :3352912819243712521:    1.03 -0.34 -1.77 sub(et9, )
+Made SmearedCluster: es5   :3341670923508908037:   -0.82 -0.34 -1.77 sub(es5, )
+Rejected SmearedCluster: es5   :3341670923508908037:   -0.82 -0.34 -1.77 sub(es5, )
+Made Cluster: ht9   :5658760988780920841:    1.32 -0.34 -1.77 sub(ht9, )
+Made SmearedCluster: hs4   :5649770050280751108:    2.49 -0.34 -1.77 sub(hs4, )
+Simulating Particle :ps16  :10261454673552605200: pdgid =  -211, status =   1, q = -1, e =   2.3, theta =  0.09, phi =  0.80, mass =  0.14
+Simulating Hadron
+Made Track: tt10  :7964618826826383370:    2.33    2.32  0.09  0.80
+Made SmearedTrack: ts9   :7955611146831003657:    2.27    2.26  0.09  0.80
+Made Cluster: et10  :3352913871470854154:    1.09  0.10  1.06 sub(et10, )
+Made SmearedCluster: es5   :3341670923508908037:   -0.10  0.10  1.06 sub(es5, )
+Rejected SmearedCluster: es5   :3341670923508908037:   -0.10  0.10  1.06 sub(es5, )
+Made Cluster: ht10  :5658759643703279626:    1.24  0.10  1.23 sub(ht10, )
+Made SmearedCluster: hs5   :5647513932722601989:   -1.68  0.10  1.23 sub(hs5, )
+Rejected SmearedCluster: hs5   :5647513932722601989:   -1.68  0.10  1.23 sub(hs5, )
+Simulating Particle :ps17  :10261452270061223953: pdgid =   211, status =   1, q =  1, e =   2.1, theta =  0.19, phi = -1.56, mass =  0.14
+Simulating Hadron
+Made Track: tt11  :7964616418444443659:    2.05    2.02  0.19 -1.56
+Made SmearedTrack: ts10  :7955609262412005386:    2.06    2.02  0.19 -1.56
+Made Cluster: et11  :3352918373812928523:    1.34  0.20 -1.93 sub(et11, )
+Made SmearedCluster: es5   :3341670923508908037:   -1.12  0.20 -1.93 sub(es5, )
+Rejected SmearedCluster: es5   :3341670923508908037:   -1.12  0.20 -1.93 sub(es5, )
+Made Cluster: ht11  :5658745329151901707:    0.72  0.20 -2.12 sub(ht11, )
+Made SmearedCluster: hs5   :5649781013681799173:    3.74  0.20 -2.12 sub(hs5, )
+Rejected SmearedCluster: hs5   :5649781013681799173:    3.74  0.20 -2.12 sub(hs5, )
+Simulating Particle :ps18  :10261450879710265362: pdgid =    22, status =   1, q =  0, e =   2.0, theta =  0.37, phi =  0.90, mass =  0.00
+Simulating Photon
+Made Cluster: et12  :3352929051323924492:    1.95  0.37  0.90 sub(et12, )
+Made SmearedCluster: es5   :3343919236159373317:    1.80  0.37  0.90 sub(es5, )
+Simulating Particle :ps19  :10261448099067068435: pdgid =    22, status =   1, q =  0, e =   1.8, theta = -0.30, phi = -1.68, mass =  0.00
+Simulating Photon
+Made Cluster: et13  :3352926270680727565:    1.79 -0.30 -1.68 sub(et13, )
+Made SmearedCluster: es6   :3343918143968903174:    1.74 -0.30 -1.68 sub(es6, )
+Simulating Particle :ps20  :10261447523822469140: pdgid =   211, status =   1, q =  1, e =   1.8, theta =  0.27, phi =  0.69, mass =  0.14
+Simulating Hadron
+Made Track: tt12  :7964611616337559564:    1.75    1.69  0.27  0.69
+Made SmearedTrack: ts11  :7955604414908071947:    1.75    1.69  0.27  0.69
+Made Cluster: et14  :3352900138952556558:    0.65  0.26  0.32 sub(et14, )
+Made SmearedCluster: es7   :3343923662582448135:    2.11  0.26  0.32 sub(es7, )
+Made Cluster: ht12  :5658757208182095884:    1.11  0.28  0.08 sub(ht12, )
+Made SmearedCluster: hs5   :5649759403228790789:    1.64  0.28  0.08 sub(hs5, )
+Rejected SmearedCluster: hs5   :5649759403228790789:    1.64  0.28  0.08 sub(hs5, )
+Simulating Particle :ps21  :10261445826597355541: pdgid =  -211, status =   1, q = -1, e =   1.7, theta =  0.05, phi = -1.77, mass =  0.14
+Simulating Hadron
+Made Track: tt13  :7964609913435455501:    1.66    1.66  0.05 -1.77
+Made SmearedTrack: ts12  :7955602700746358796:    1.66    1.65  0.05 -1.77
+Made Cluster: et15  :3352909950432051215:    0.93  0.05 -1.30 sub(et15, )
+Made SmearedCluster: es8   :3343934097989828616:    3.29  0.05 -1.30 sub(es8, )
+Made Cluster: ht13  :5658745870829486093:    0.73  0.06 -1.05 sub(ht13, )
+Made SmearedCluster: hs5   :5647513932722601989:   -4.05  0.06 -1.05 sub(hs5, )
+Rejected SmearedCluster: hs5   :5647513932722601989:   -4.05  0.06 -1.05 sub(hs5, )
+Simulating Particle :ps22  :10261445570885320726: pdgid = -2112, status =   1, q =  0, e =   1.6, theta = -0.04, phi = -1.63, mass =  0.94
+Simulating Hadron
+Made Cluster: et16  :3352912286856511504:    1.00 -0.04 -1.63 sub(et16, )
+Made SmearedCluster: es9   :3341670923508908041:   -3.69 -0.04 -1.63 sub(es9, )
+Rejected SmearedCluster: es9   :3341670923508908041:   -3.69 -0.04 -1.63 sub(es9, )
+Made Cluster: ht14  :5658743022983053326:    0.65 -0.04 -1.63 sub(ht14, )
+Made SmearedCluster: hs5   :5649734490809958405:    0.61 -0.04 -1.63 sub(hs5, )
+Rejected SmearedCluster: hs5   :5649734490809958405:    0.61 -0.04 -1.63 sub(hs5, )
+Simulating Particle :ps23  :10261436542419468311: pdgid =  -211, status =   1, q = -1, e =   1.1, theta =  0.12, phi = -1.73, mass =  0.14
+Simulating Hadron
+Made Track: tt14  :7964600580987420686:    1.13    1.12  0.12 -1.73
+Made SmearedTrack: ts13  :7955593453730005005:    1.13    1.12  0.12 -1.73
+Made Cluster: ht15  :5658757723246821391:    1.14  0.16 -0.50 sub(ht15, )
+Made SmearedCluster: hs5   :5649764101597954053:    1.91  0.16 -0.50 sub(hs5, )
+Simulating Particle :ps24  :10261435813514444824: pdgid =    22, status =   1, q =  0, e =   1.1, theta = -0.06, phi = -1.92, mass =  0.00
+Simulating Photon
+Made Cluster: et17  :3352913985128103953:    1.09 -0.06 -1.92 sub(et17, )
+Made SmearedCluster: es9   :3343907014989316105:    1.11 -0.06 -1.92 sub(es9, )
+Simulating Particle :ps25  :10261435178733797401: pdgid =    22, status =   1, q =  0, e =   1.1, theta = -0.16, phi = -1.85, mass =  0.00
+Simulating Photon
+Made Cluster: et18  :3352913350347456530:    1.06 -0.16 -1.85 sub(et18, )
+Made SmearedCluster: es10  :3343905176906891274:    1.00 -0.16 -1.85 sub(es10, )
+Simulating Particle :ps26  :10261434444164366362: pdgid =  -211, status =   1, q = -1, e =   1.0, theta = -0.81, phi = -2.25, mass =  0.14
+Simulating Hadron
+Made Track: tt15  :7964598464791183375:    1.01    0.69 -0.81 -2.25
+Made SmearedTrack: ts14  :7955591493526224910:    1.02    0.70 -0.81 -2.25
+Made Cluster: et19  :3352886962089361427:    0.39 -1.02 -0.69 sub(et19, )
+Made SmearedCluster: es11  :3341670923508908043:   -2.03 -1.02 -0.69 sub(es11, )
+Rejected SmearedCluster: es11  :3341670923508908043:   -2.03 -1.02 -0.69 sub(es11, )
+Made Cluster: ht16  :5658742206249304080:    0.63 -1.17 -0.23 sub(ht16, )
+Made SmearedCluster: hs6   :5647513932722601990:   -0.26 -1.17 -0.23 sub(hs6, )
+Rejected SmearedCluster: hs6   :5647513932722601990:   -0.26 -1.17 -0.23 sub(hs6, )
+Simulating Particle :ps27  :10261433820733505563: pdgid =   211, status =   1, q =  1, e =   1.0, theta = -0.09, phi = -1.15, mass =  0.14
+Simulating Hadron
+Made Track: tt16  :7964597663022710800:    0.98    0.98 -0.09 -1.15
+Made SmearedTrack: ts15  :7955590967128489999:    0.99    0.99 -0.09 -1.15
+Made Cluster: et20  :3352899486994137108:    0.63 -0.10 -2.01 sub(et20, )
+Made SmearedCluster: es11  :3343893125390139403:    0.66 -0.10 -2.01 sub(es11, )
+Made Cluster: ht17  :5658727573752905745:    0.36 -1.01 -3.00 sub(ht17, )
+Made SmearedCluster: hs6   :5647513932722601990:   -2.86 -1.01 -3.00 sub(hs6, )
+Rejected SmearedCluster: hs6   :5647513932722601990:   -2.86 -1.01 -3.00 sub(hs6, )
+Simulating Particle :ps28  :10261425603368452124: pdgid =   211, status =   1, q =  1, e =   0.8, theta =  0.81, phi =  0.83, mass =  0.14
+Simulating Hadron
+Made Track: tt17  :7964589336700125201:    0.74    0.51  0.81  0.83
+Made SmearedTrack: ts16  :7955581738390913040:    0.73    0.50  0.81  0.83
+Made Cluster: et21  :3352822285347061781:    0.03  1.20 -1.28 sub(et21, )
+Made SmearedCluster: es12  :3341670923508908044:   -1.80  1.20 -1.28 sub(es12, )
+Rejected SmearedCluster: es12  :3341670923508908044:   -1.80  1.20 -1.28 sub(es12, )
+Made Cluster: ht18  :5658745749813329938:    0.73  1.44 -1.92 sub(ht18, )
+Made SmearedCluster: hs6   :5649781604279648262:    3.80  1.44 -1.92 sub(hs6, )
+Simulating Particle :ps29  :10261425569367326749: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.42, phi =  0.79, mass =  0.00
+Simulating Photon
+Made Cluster: et22  :3352903740980985878:    0.76  0.42  0.79 sub(et22, )
+Made SmearedCluster: es12  :3343889808842817548:    0.56  0.42  0.79 sub(es12, )
+Simulating Particle :ps30  :10261422785985249310: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.72, phi = -1.11, mass =  0.00
+Simulating Photon
+Made Cluster: et23  :3352900957598908439:    0.68  0.72 -1.11 sub(et23, )
+Made SmearedCluster: es13  :3343879926622191629:    0.39  0.72 -1.11 sub(es13, )
+Simulating Particle :ps31  :10261419617266171935: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.07, phi = -2.14, mass =  0.00
+Simulating Photon
+Made Cluster: et24  :3352897788879831064:    0.59 -0.07 -2.14 sub(et24, )
+Made SmearedCluster: es14  :3343875816405598222:    0.33 -0.07 -2.14 sub(es14, )
+Simulating Particle :ps32  :10261419048516452384: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.04, phi = -1.93, mass =  0.00
+Simulating Photon
+Made Cluster: et25  :3352897220130111513:    0.57  0.04 -1.93 sub(et25, )
+Made SmearedCluster: es15  :3343851624931000335:    0.12  0.04 -1.93 sub(es15, )
+Rejected SmearedCluster: es15  :3343851624931000335:    0.12  0.04 -1.93 sub(es15, )
+Simulating Particle :ps33  :10261417877512912929: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.63, phi = -1.43, mass =  0.00
+Simulating Photon
+Made Cluster: et26  :3352896049126572058:    0.54 -0.63 -1.43 sub(et26, )
+Made SmearedCluster: es15  :3343892155341996047:    0.63 -0.63 -1.43 sub(es15, )
+Simulating Particle :ps34  :10261417078720299042: pdgid =  -211, status =   1, q = -1, e =   0.5, theta =  0.16, phi = -0.44, mass =  0.14
+Simulating Hadron
+Made Track: tt18  :7964580423453900818:    0.50    0.49  0.16 -0.44
+Made SmearedTrack: ts17  :7955573646011924497:    0.50    0.50  0.16 -0.44
+Rejected SmearedTrack: ts17  :7955573646011924497:    0.50    0.50  0.16 -0.44
+Made Cluster: et27  :3352853371307425819:    0.10  1.17  1.24 sub(et27, )
+Made SmearedCluster: es16  :3343947151842476048:    5.55  1.17  1.24 sub(es16, )
+Made Cluster: ht19  :5658731521215823891:    0.41  1.46  2.37 sub(ht19, )
+Made SmearedCluster: hs7   :5647513932722601991:   -7.67  1.46  2.37 sub(hs7, )
+Rejected SmearedCluster: hs7   :5647513932722601991:   -7.67  1.46  2.37 sub(hs7, )
+Simulating Particle :ps35  :10261417028862607395: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.36, phi = -2.12, mass =  0.00
+Simulating Photon
+Made Cluster: et28  :3352895200476266524:    0.51 -0.36 -2.12 sub(et28, )
+Made SmearedCluster: es17  :3343887331143712785:    0.50 -0.36 -2.12 sub(es17, )
+Simulating Particle :ps36  :10261415407153840164: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.12, phi = -1.95, mass =  0.00
+Simulating Photon
+Made Cluster: et29  :3352893578767499293:    0.48 -0.12 -1.95 sub(et29, )
+Made SmearedCluster: es18  :3343884891247869970:    0.46 -0.12 -1.95 sub(es18, )
+Simulating Particle :ps37  :10261414136279728165: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.30, phi =  1.60, mass =  0.00
+Simulating Photon
+Made Cluster: et30  :3352892307893387294:    0.47  0.30  1.59 sub(et30, )
+Made SmearedCluster: es19  :3343875967526371347:    0.34  0.30  1.59 sub(es19, )
+Simulating Particle :ps38  :10261413648779968550: pdgid =  -211, status =   1, q = -1, e =   0.5, theta =  0.24, phi = -2.34, mass =  0.14
+Simulating Hadron
+Made Track: tt19  :7964576307772129299:    0.44    0.42  0.24 -2.34
+Made SmearedTrack: ts17  :7955569091735978001:    0.44    0.42  0.24 -2.34
+Rejected SmearedTrack: ts17  :7955569091735978001:    0.44    0.42  0.24 -2.34
+Made Cluster: ht20  :5658734829607321620:    0.46  1.29 -0.71 sub(ht20, )
+Made SmearedCluster: hs7   :5647513932722601991:   -0.13  1.29 -0.71 sub(hs7, )
+Rejected SmearedCluster: hs7   :5647513932722601991:   -0.13  1.29 -0.71 sub(hs7, )
+Simulating Particle :ps39  :10261412774278070311: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.58, phi =  0.31, mass =  0.00
+Simulating Photon
+Made Cluster: et31  :3352890945891729439:    0.45 -0.58  0.31 sub(et31, )
+Made SmearedCluster: es20  :3343878707241549844:    0.37 -0.58  0.31 sub(es20, )
+Simulating Particle :ps40  :10261412169583165480: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.25, phi =  0.95, mass =  0.00
+Simulating Photon
+Made Cluster: et32  :3352890341196824608:    0.44  0.25  0.95 sub(et32, )
+Made SmearedCluster: es21  :3343886557930061845:    0.49  0.25  0.95 sub(es21, )
+Simulating Particle :ps41  :10261409375365103657: pdgid =  -211, status =   1, q = -1, e =   0.4, theta = -0.59, phi = -2.01, mass =  0.14
+Simulating Hadron
+Made Track: tt20  :7964571785939124244:    0.37    0.31 -0.59 -2.01
+Made SmearedTrack: ts17  :7955564593755979793:    0.37    0.31 -0.59 -2.01
+Rejected SmearedTrack: ts17  :7955564593755979793:    0.37    0.31 -0.59 -2.01
+Made Cluster: ht21  :5658730556192456725:    0.40 -1.41 -1.10 sub(ht21, )
+Made SmearedCluster: hs7   :5647513932722601991:   -1.44 -1.41 -1.10 sub(hs7, )
+Rejected SmearedCluster: hs7   :5647513932722601991:   -1.44 -1.41 -1.10 sub(hs7, )
+Simulating Particle :ps42  :10261407740091957290: pdgid =  -211, status =   1, q = -1, e =   0.4, theta = -0.70, phi =  3.04, mass =  0.14
+Simulating Hadron
+Made Track: tt21  :7964570031988146197:    0.35    0.27 -0.70  3.04
+Made SmearedTrack: ts17  :7955562595323215889:    0.34    0.26 -0.70  3.04
+Rejected SmearedTrack: ts17  :7955562595323215889:    0.34    0.26 -0.70  3.04
+Made Cluster: et33  :3352844148781613089:    0.07 -1.36 -1.32 sub(et33, )
+Made SmearedCluster: es22  :3343944921903005718:    5.05 -1.36 -1.32 sub(es22, )
+Made Cluster: ht22  :5658723976088649750:    0.30 -1.52 -2.94 sub(ht22, )
+Made SmearedCluster: hs7   :5649803860200390663:    9.34 -1.52 -2.94 sub(hs7, )
+Simulating Particle :ps43  :10261404745933520939: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.79, phi = -0.05, mass =  0.00
+Simulating Photon
+Made Cluster: et34  :3352882917547180066:    0.33 -0.79 -0.05 sub(et34, )
+Made SmearedCluster: es23  :3343879340499664919:    0.38 -0.79 -0.05 sub(es23, )
+Simulating Particle :ps44  :10261402636842434604: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.32, phi = -1.90, mass =  0.00
+Simulating Photon
+Made Cluster: et35  :3352880808456093731:    0.30  0.32 -1.90 sub(et35, )
+Made SmearedCluster: es24  :3343876512131579928:    0.34  0.32 -1.90 sub(es24, )
+Simulating Particle :ps45  :10261402277281529901: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.71, phi = -2.10, mass =  0.00
+Simulating Photon
+Made Cluster: et36  :3352880448895189028:    0.30 -0.71 -2.10 sub(et36, )
+Made SmearedCluster: es25  :3343873650066456601:    0.30 -0.71 -2.10 sub(es25, )
+Simulating Particle :ps46  :10261401536468877358: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.30, phi = -1.81, mass =  0.00
+Simulating Photon
+Made Cluster: et37  :3352879708082536485:    0.29 -0.30 -1.81 sub(et37, )
+Made SmearedCluster: es26  :3343865299261718554:    0.22 -0.30 -1.81 sub(es26, )
+Rejected SmearedCluster: es26  :3343865299261718554:    0.22 -0.30 -1.81 sub(es26, )
+Simulating Particle :ps47  :10261401025652981807: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.51, phi =  0.94, mass =  0.00
+Simulating Photon
+Made Cluster: et38  :3352879197266640934:    0.28 -0.50  0.94 sub(et38, )
+Made SmearedCluster: es26  :3343878010299219994:    0.36 -0.50  0.94 sub(es26, )
+Simulating Particle :ps48  :10261394420664369200: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.04, phi =  0.90, mass =  0.00
+Simulating Photon
+Made Cluster: et39  :3352872592278028327:    0.22  0.04  0.91 sub(et39, )
+Made SmearedCluster: es27  :3343860858622050331:    0.19  0.04  0.91 sub(es27, )
+Rejected SmearedCluster: es27  :3343860858622050331:    0.19  0.04  0.91 sub(es27, )
+Simulating Particle :ps49  :10261392899335782449: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.04, phi = -2.12, mass =  0.00
+Simulating Photon
+Made Cluster: et40  :3352871070949441576:    0.21 -0.04 -2.12 sub(et40, )
+Made SmearedCluster: es27  :3343859927868243995:    0.18 -0.04 -2.12 sub(es27, )
+Rejected SmearedCluster: es27  :3343859927868243995:    0.18 -0.04 -2.12 sub(es27, )
+Simulating Particle :ps54  :10261386060435030070: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.72, phi = -1.29, mass =  0.00
+Simulating Photon
+Made Cluster: et41  :3352864232048689193:    0.16 -0.72 -1.29 sub(et41, )
+Made SmearedCluster: es27  :3343855526667616283:    0.15 -0.72 -1.29 sub(es27, )
+Rejected SmearedCluster: es27  :3343855526667616283:    0.15 -0.72 -1.29 sub(es27, )
+Simulating Particle :ps55  :10261379449003966519: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.41, phi =  0.99, mass =  0.00
+Simulating Photon
+Made Cluster: et42  :3352857620617625642:    0.12  0.40  1.00 sub(et42, )
+Made SmearedCluster: es27  :3343819866818740251:    0.04  0.40  1.00 sub(es27, )
+Rejected SmearedCluster: es27  :3343819866818740251:    0.04  0.40  1.00 sub(es27, )
+Simulating Particle :ps56  :10261364805807898680: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.08, phi = -1.23, mass =  0.00
+Simulating Photon
+Made Cluster: et43  :3352842977421557803:    0.07  0.08 -1.23 sub(et43, )
+Made SmearedCluster: es27  :3341670923508908059:   -0.10  0.08 -1.23 sub(es27, )
+Rejected SmearedCluster: es27  :3341670923508908059:   -0.10  0.08 -1.23 sub(es27, )
+Simulating Particle :ps57  :10261363801043501113: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.38, phi =  0.52, mass =  0.00
+Simulating Photon
+Made Cluster: et44  :3352841972657160236:    0.06 -0.38  0.52 sub(et44, )
+Made SmearedCluster: es27  :3341670923508908059:   -0.05 -0.38  0.52 sub(es27, )
+Rejected SmearedCluster: es27  :3341670923508908059:   -0.05 -0.38  0.52 sub(es27, )
+Made MergedCluster: em0   :3289830454538010624:    0.30 -0.71 -2.10 sub(es25, )
+Made MergedCluster: em1   :3289832620877152257:    0.33 -0.07 -2.14 sub(es14, )
+Made MergedCluster: em2   :3289832771997925378:    0.34  0.30  1.59 sub(es19, )
+Made MergedCluster: em3   :3289833316603133955:    0.34  0.32 -1.90 sub(es24, )
+Made MergedCluster: em4   :3289834814770774020:    0.36 -0.50  0.94 sub(es26, )
+Made MergedCluster: em5   :3289835511713103877:    0.37 -0.58  0.31 sub(es20, )
+Made MergedCluster: em6   :3289836144971218950:    0.38 -0.79 -0.05 sub(es23, )
+Made MergedCluster: em7   :3289836731093745671:    0.39  0.72 -1.11 sub(es13, )
+Made MergedCluster: em8   :3289864066901737480:    1.12 -0.11 -1.99 sub(es11, es18, )
+Made MergedCluster: em9   :3289843362401615881:    0.49  0.25  0.95 sub(es21, )
+Made MergedCluster: em10  :3289844135615266826:    0.50 -0.36 -2.12 sub(es17, )
+Made MergedCluster: em11  :3289846613314371595:    0.56  0.42  0.79 sub(es12, )
+Made MergedCluster: em12  :3289848959813550092:    0.63 -0.63 -1.43 sub(es15, )
+Made MergedCluster: em13  :3289861981378445325:    1.00 -0.16 -1.85 sub(es10, )
+Made MergedCluster: em14  :3289863819460870158:    1.11 -0.06 -1.92 sub(es9, )
+Made MergedCluster: em15  :3289874948440457231:    1.74 -0.30 -1.68 sub(es6, )
+Made MergedCluster: em16  :3289876040630927376:    1.80  0.37  0.90 sub(es5, )
+Made MergedCluster: em17  :3289880467054002193:    2.11  0.26  0.32 sub(es7, )
+Made MergedCluster: em18  :3289883322922041362:    2.43 -0.35 -1.73 sub(es4, )
+Made MergedCluster: em19  :3289913016866308115:    7.61 -0.27 -1.75 sub(es0, es2, )
+Made MergedCluster: em20  :3289890902461382676:    3.29  0.05 -1.30 sub(es8, )
+Made MergedCluster: em21  :3289901726374559765:    5.05 -1.36 -1.32 sub(es22, )
+Made MergedCluster: em22  :3289903374866055190:    5.42  0.22  1.03 sub(es1, )
+Made MergedCluster: em23  :3289903956314030103:    5.55  1.17  1.24 sub(es16, )
+Made MergedCluster: em24  :3289910892939968536:    7.13  0.19  0.70 sub(es3, )
+Made MergedCluster: hm0   :5595720906069508096:    1.91  0.16 -0.50 sub(hs5, )
+Made MergedCluster: hm1   :5595756334669627393:    7.68 -0.32 -1.75 sub(hs3, hs4, )
+Made MergedCluster: hm2   :5595738408751202306:    3.80  1.44 -1.92 sub(hs6, )
+Made MergedCluster: hm3   :5595799555103784963:   44.10  0.23  0.84 sub(hs0, hs1, hs2, )
+Made MergedCluster: hm4   :5595760664671944708:    9.34 -1.52 -2.94 sub(hs7, )
+Made block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289830454538010624)
+
+Made block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.3 (3289832620877152257)
+
+Made block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.3 (3289832771997925378)
+
+Made block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.3 (3289833316603133955)
+
+Made block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.4 (3289834814770774020)
+
+Made block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.4 (3289835511713103877)
+
+Made block:E1       :br6   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.4 (3289836144971218950)
+
+Made block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.4 (3289836731093745671)
+
+Made block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  0.5 (3289843362401615881)
+
+Made block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  0.5 (3289844135615266826)
+
+Made block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  0.6 (3289846613314371595)
+
+Made block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  0.6 (3289848959813550092)
+
+Made block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  1.0 (3289861981378445325)
+
+Made block:E1       :br13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  1.1 (3289863819460870158)
+
+Made block:E1T2     :br14  : ecals = 1 hcals = 0 tracks = 2
+    elements:
+      t0 = ts0       value= 62.0 (7955695609634095104)
+      t1 = ts15      value=  1.0 (7955590967128489999)
+      e2 = em8       value=  1.1 (3289864066901737480)
+    distances:
+              t0      t1      e2
+      t0       .
+      t1     ---       .
+      e2  0.0518  0.0000       .
+
+Made block:E1       :br15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  1.7 (3289874948440457231)
+
+Made block:E1       :br16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  1.8 (3289876040630927376)
+
+Made block:E1T1     :br17  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  1.8 (7955604414908071947)
+      e1 = em17      value=  2.1 (3289880467054002193)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em18      value=  2.4 (3289883322922041362)
+
+Made block:E1T1     :br19  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.7 (7955602700746358796)
+      e1 = em20      value=  3.3 (3289890902461382676)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  5.0 (3289901726374559765)
+
+Made block:E1T1     :br21  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts6       value=  3.6 (7955622872968331270)
+      e1 = em22      value=  5.4 (3289903374866055190)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  5.6 (3289903956314030103)
+
+Made block:E1T1     :br23  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts7       value=  2.9 (7955616817393696775)
+      e1 = em24      value=  7.1 (3289910892939968536)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  7.6 (3289913016866308115)
+
+Made block:H1T1     :br25  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  1.1 (7955593453730005005)
+      h1 = hm0       value=  1.9 (5595720906069508096)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br26  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts16      value=  0.7 (7955581738390913040)
+      h1 = hm2       value=  3.8 (5595738408751202306)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1       :br27  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm1       value=  7.7 (5595756334669627393)
+
+Made block:H1       :br28  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm4       value=  9.3 (5595760664671944708)
+
+Made block:H1T2     :br29  : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts3       value= 16.2 (7955661762141880323)
+      t1 = ts4       value=  6.3 (7955636255534874628)
+      h2 = hm3       value= 44.1 (5595799555103784963)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+
+Made block:T1       :br30  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.0 (7955591493526224910)
+
+Made block:T1       :br31  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  2.1 (7955609262412005386)
+
+Made block:T1       :br32  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  2.3 (7955611146831003657)
+
+Made block:T1       :br33  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  2.7 (7955614550879895560)
+
+Made block:T1       :br34  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts5       value=  4.7 (7955629273734184965)
+
+Made block:T1       :br35  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts2       value= 18.8 (7955664607092146178)
+
+Made block:T1       :br36  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 42.0 (7955684619248992257)
+
+Splitting block:H1T2     :br29  : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts3       value= 16.2 (7955661762141880323)
+      t1 = ts4       value=  6.3 (7955636255534874628)
+      h2 = hm3       value= 44.1 (5595799555103784963)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+
+Made block:H1T2     :bs0   : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts3       value= 16.2 (7955661762141880323)
+      t1 = ts4       value=  6.3 (7955636255534874628)
+      h2 = hm3       value= 44.1 (5595799555103784963)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+
+Splitting block:E1T2     :br14  : ecals = 1 hcals = 0 tracks = 2
+    elements:
+      t0 = ts0       value= 62.0 (7955695609634095104)
+      t1 = ts15      value=  1.0 (7955590967128489999)
+      e2 = em8       value=  1.1 (3289864066901737480)
+    distances:
+              t0      t1      e2
+      t0       .
+      t1     ---       .
+      e2  0.0518  0.0000       .
+
+Made block:E1T2     :bs1   : ecals = 1 hcals = 0 tracks = 2
+    elements:
+      t0 = ts0       value= 62.0 (7955695609634095104)
+      t1 = ts15      value=  1.0 (7955590967128489999)
+      e2 = em8       value=  1.1 (3289864066901737480)
+    distances:
+              t0      t1      e2
+      t0       .
+      t1     ---       .
+      e2  0.0518  0.0000       .
+
+Splitting block:H1T1     :br26  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts16      value=  0.7 (7955581738390913040)
+      h1 = hm2       value=  3.8 (5595738408751202306)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs2   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts16      value=  0.7 (7955581738390913040)
+      h1 = hm2       value=  3.8 (5595738408751202306)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br25  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  1.1 (7955593453730005005)
+      h1 = hm0       value=  1.9 (5595720906069508096)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs3   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  1.1 (7955593453730005005)
+      h1 = hm0       value=  1.9 (5595720906069508096)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:E1T1     :br23  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts7       value=  2.9 (7955616817393696775)
+      e1 = em24      value=  7.1 (3289910892939968536)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs4   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts7       value=  2.9 (7955616817393696775)
+      e1 = em24      value=  7.1 (3289910892939968536)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br21  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts6       value=  3.6 (7955622872968331270)
+      e1 = em22      value=  5.4 (3289903374866055190)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs5   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts6       value=  3.6 (7955622872968331270)
+      e1 = em22      value=  5.4 (3289903374866055190)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br19  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.7 (7955602700746358796)
+      e1 = em20      value=  3.3 (3289890902461382676)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs6   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.7 (7955602700746358796)
+      e1 = em20      value=  3.3 (3289890902461382676)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br17  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  1.8 (7955604414908071947)
+      e1 = em17      value=  2.1 (3289880467054002193)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs7   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  1.8 (7955604414908071947)
+      e1 = em17      value=  2.1 (3289880467054002193)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:T1       :br36  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 42.0 (7955684619248992257)
+
+Made block:T1       :bs8   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 42.0 (7955684619248992257)
+
+Splitting block:T1       :br35  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts2       value= 18.8 (7955664607092146178)
+
+Made block:T1       :bs9   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts2       value= 18.8 (7955664607092146178)
+
+Splitting block:T1       :br34  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts5       value=  4.7 (7955629273734184965)
+
+Made block:T1       :bs10  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts5       value=  4.7 (7955629273734184965)
+
+Splitting block:T1       :br33  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  2.7 (7955614550879895560)
+
+Made block:T1       :bs11  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  2.7 (7955614550879895560)
+
+Splitting block:T1       :br32  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  2.3 (7955611146831003657)
+
+Made block:T1       :bs12  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  2.3 (7955611146831003657)
+
+Splitting block:T1       :br31  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  2.1 (7955609262412005386)
+
+Made block:T1       :bs13  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  2.1 (7955609262412005386)
+
+Splitting block:T1       :br30  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.0 (7955591493526224910)
+
+Made block:T1       :bs14  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.0 (7955591493526224910)
+
+Splitting block:H1       :br28  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm4       value=  9.3 (5595760664671944708)
+
+Made block:H1       :bs15  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm4       value=  9.3 (5595760664671944708)
+
+Splitting block:H1       :br27  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm1       value=  7.7 (5595756334669627393)
+
+Made block:H1       :bs16  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm1       value=  7.7 (5595756334669627393)
+
+Splitting block:E1       :br24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  7.6 (3289913016866308115)
+
+Made block:E1       :bs17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  7.6 (3289913016866308115)
+
+Splitting block:E1       :br22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  5.6 (3289903956314030103)
+
+Made block:E1       :bs18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  5.6 (3289903956314030103)
+
+Splitting block:E1       :br20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  5.0 (3289901726374559765)
+
+Made block:E1       :bs19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  5.0 (3289901726374559765)
+
+Splitting block:E1       :br18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em18      value=  2.4 (3289883322922041362)
+
+Made block:E1       :bs20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em18      value=  2.4 (3289883322922041362)
+
+Splitting block:E1       :br16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  1.8 (3289876040630927376)
+
+Made block:E1       :bs21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  1.8 (3289876040630927376)
+
+Splitting block:E1       :br15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  1.7 (3289874948440457231)
+
+Made block:E1       :bs22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  1.7 (3289874948440457231)
+
+Splitting block:E1       :br13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  1.1 (3289863819460870158)
+
+Made block:E1       :bs23  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  1.1 (3289863819460870158)
+
+Splitting block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  1.0 (3289861981378445325)
+
+Made block:E1       :bs24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  1.0 (3289861981378445325)
+
+Splitting block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  0.6 (3289848959813550092)
+
+Made block:E1       :bs25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  0.6 (3289848959813550092)
+
+Splitting block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  0.6 (3289846613314371595)
+
+Made block:E1       :bs26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  0.6 (3289846613314371595)
+
+Splitting block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  0.5 (3289844135615266826)
+
+Made block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  0.5 (3289844135615266826)
+
+Splitting block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  0.5 (3289843362401615881)
+
+Made block:E1       :bs28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  0.5 (3289843362401615881)
+
+Splitting block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.4 (3289836731093745671)
+
+Made block:E1       :bs29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.4 (3289836731093745671)
+
+Splitting block:E1       :br6   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.4 (3289836144971218950)
+
+Made block:E1       :bs30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.4 (3289836144971218950)
+
+Splitting block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.4 (3289835511713103877)
+
+Made block:E1       :bs31  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.4 (3289835511713103877)
+
+Splitting block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.4 (3289834814770774020)
+
+Made block:E1       :bs32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.4 (3289834814770774020)
+
+Splitting block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.3 (3289833316603133955)
+
+Made block:E1       :bs33  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.3 (3289833316603133955)
+
+Splitting block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.3 (3289832771997925378)
+
+Made block:E1       :bs34  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.3 (3289832771997925378)
+
+Splitting block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.3 (3289832620877152257)
+
+Made block:E1       :bs35  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.3 (3289832620877152257)
+
+Splitting block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289830454538010624)
+
+Made block:E1       :bs36  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289830454538010624)
+
+Processing block:E1T2     :bs1   : ecals = 1 hcals = 0 tracks = 2
+    elements:
+      t0 = ts0       value= 62.0 (7955695609634095104)
+      t1 = ts15      value=  1.0 (7955590967128489999)
+      e2 = em8       value=  1.1 (3289864066901737480)
+    distances:
+              t0      t1      e2
+      t0       .
+      t1     ---       .
+      e2  0.0518  0.0000       .
+
+Made Particle :pr0   :10252531419641282560: pdgid =   -13, status =   1, q = -1, e =  62.0, theta = -0.06, phi = -2.03, mass =  0.10 from SmearedTrack: ts0   :7955695609634095104:   62.01   61.91 -0.06 -2.03
+Made Particle :pr1   :10252427038314987521: pdgid =   211, status =   1, q =  1, e =   1.0, theta = -0.09, phi = -1.15, mass =  0.14 from SmearedTrack: ts15  :7955590967128489999:    0.99    0.99 -0.09 -1.15
+Finished block
+Processing block:H1T2     :bs0   : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts3       value= 16.2 (7955661762141880323)
+      t1 = ts4       value=  6.3 (7955636255534874628)
+      h2 = hm3       value= 44.1 (5595799555103784963)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.0000       .
+
+Made Particle :pr2   :10252497572755144706: pdgid =  -211, status =   1, q = -1, e =  16.2, theta =  0.25, phi =  0.83, mass =  0.14 from SmearedTrack: ts3   :7955661762141880323:   16.22   15.72  0.25  0.83
+Made Particle :pr3   :10252472072286502915: pdgid =  -211, status =   1, q = -1, e =   6.3, theta =  0.24, phi =  0.80, mass =  0.14 from SmearedTrack: ts4   :7955636255534874628:    6.26    6.08  0.24  0.80
+Made Particle :pr4   :10252503504690085892: pdgid =   130, status =   1, q =  0, e =  21.6, theta =  0.23, phi =  0.84, mass =  0.50 from MergedCluster: hm3   :5595799555103784963:   44.10  0.23  0.84 sub(hs0, hs1, hs2, )
+Finished block
+Processing block:E1T1     :bs7   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  1.8 (7955604414908071947)
+      e1 = em17      value=  2.1 (3289880467054002193)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr5   :10252440321604452357: pdgid =   211, status =   1, q =  1, e =   1.8, theta =  0.27, phi =  0.69, mass =  0.14 from SmearedTrack: ts11  :7955604414908071947:    1.75    1.69  0.27  0.69
+Finished block
+Processing block:E1T1     :bs6   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.7 (7955602700746358796)
+      e1 = em20      value=  3.3 (3289890902461382676)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr6   :10252438613113438214: pdgid =  -211, status =   1, q = -1, e =   1.7, theta =  0.05, phi = -1.77, mass =  0.14 from SmearedTrack: ts12  :7955602700746358796:    1.66    1.65  0.05 -1.77
+Finished block
+Processing block:E1T1     :bs5   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts6       value=  3.6 (7955622872968331270)
+      e1 = em22      value=  5.4 (3289903374866055190)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr7   :10252458706480398343: pdgid =  -211, status =   1, q = -1, e =   3.6, theta =  0.22, phi =  0.83, mass =  0.14 from SmearedTrack: ts6   :7955622872968331270:    3.61    3.52  0.22  0.83
+Finished block
+Processing block:E1T1     :bs4   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts7       value=  2.9 (7955616817393696775)
+      e1 = em24      value=  7.1 (3289910892939968536)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr8   :10252452656456925192: pdgid =   211, status =   1, q =  1, e =   2.9, theta =  0.19, phi =  0.95, mass =  0.14 from SmearedTrack: ts7   :7955616817393696775:    2.92    2.87  0.19  0.95
+Finished block
+Processing block:H1T1     :bs3   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  1.1 (7955593453730005005)
+      h1 = hm0       value=  1.9 (5595720906069508096)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr9   :10252429413394153481: pdgid =  -211, status =   1, q = -1, e =   1.1, theta =  0.12, phi = -1.73, mass =  0.14 from SmearedTrack: ts13  :7955593453730005005:    1.13    1.12  0.12 -1.73
+Finished block
+Processing block:H1T1     :bs2   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts16      value=  0.7 (7955581738390913040)
+      h1 = hm2       value=  3.8 (5595738408751202306)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr10  :10252418008259493898: pdgid =   211, status =   1, q =  1, e =   0.7, theta =  0.81, phi =  0.83, mass =  0.14 from SmearedTrack: ts16  :7955581738390913040:    0.73    0.50  0.81  0.83
+Finished block
+Processing block:E1       :bs36  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289830454538010624)
+
+Made Particle :pr11  :10252395478452797451: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.71, phi = -2.10, mass =  0.00 from MergedCluster: em0   :3289830454538010624:    0.30 -0.71 -2.10 sub(es25, )
+Finished block
+Processing block:E1       :bs35  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.3 (3289832620877152257)
+
+Made Particle :pr12  :10252397644791939084: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.07, phi = -2.14, mass =  0.00 from MergedCluster: em1   :3289832620877152257:    0.33 -0.07 -2.14 sub(es14, )
+Finished block
+Processing block:E1       :bs34  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.3 (3289832771997925378)
+
+Made Particle :pr13  :10252397795912712205: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.30, phi =  1.59, mass =  0.00 from MergedCluster: em2   :3289832771997925378:    0.34  0.30  1.59 sub(es19, )
+Finished block
+Processing block:E1       :bs33  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.3 (3289833316603133955)
+
+Made Particle :pr14  :10252398340517920782: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.32, phi = -1.90, mass =  0.00 from MergedCluster: em3   :3289833316603133955:    0.34  0.32 -1.90 sub(es24, )
+Finished block
+Processing block:E1       :bs32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.4 (3289834814770774020)
+
+Made Particle :pr15  :10252399838685560847: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.50, phi =  0.94, mass =  0.00 from MergedCluster: em4   :3289834814770774020:    0.36 -0.50  0.94 sub(es26, )
+Finished block
+Processing block:E1       :bs31  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.4 (3289835511713103877)
+
+Made Particle :pr16  :10252400535627890704: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.58, phi =  0.31, mass =  0.00 from MergedCluster: em5   :3289835511713103877:    0.37 -0.58  0.31 sub(es20, )
+Finished block
+Processing block:E1       :bs30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.4 (3289836144971218950)
+
+Made Particle :pr17  :10252401168886005777: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.79, phi = -0.05, mass =  0.00 from MergedCluster: em6   :3289836144971218950:    0.38 -0.79 -0.05 sub(es23, )
+Finished block
+Processing block:E1       :bs29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.4 (3289836731093745671)
+
+Made Particle :pr18  :10252401755008532498: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.72, phi = -1.11, mass =  0.00 from MergedCluster: em7   :3289836731093745671:    0.39  0.72 -1.11 sub(es13, )
+Finished block
+Processing block:E1       :bs28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  0.5 (3289843362401615881)
+
+Made Particle :pr19  :10252408386316402707: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.25, phi =  0.95, mass =  0.00 from MergedCluster: em9   :3289843362401615881:    0.49  0.25  0.95 sub(es21, )
+Finished block
+Processing block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  0.5 (3289844135615266826)
+
+Made Particle :pr20  :10252409159530053652: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.36, phi = -2.12, mass =  0.00 from MergedCluster: em10  :3289844135615266826:    0.50 -0.36 -2.12 sub(es17, )
+Finished block
+Processing block:E1       :bs26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  0.6 (3289846613314371595)
+
+Made Particle :pr21  :10252411637229158421: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.42, phi =  0.79, mass =  0.00 from MergedCluster: em11  :3289846613314371595:    0.56  0.42  0.79 sub(es12, )
+Finished block
+Processing block:E1       :bs25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  0.6 (3289848959813550092)
+
+Made Particle :pr22  :10252413983728336918: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.63, phi = -1.43, mass =  0.00 from MergedCluster: em12  :3289848959813550092:    0.63 -0.63 -1.43 sub(es15, )
+Finished block
+Processing block:E1       :bs24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  1.0 (3289861981378445325)
+
+Made Particle :pr23  :10252427005293232151: pdgid =    22, status =   1, q =  0, e =   1.0, theta = -0.16, phi = -1.85, mass =  0.00 from MergedCluster: em13  :3289861981378445325:    1.00 -0.16 -1.85 sub(es10, )
+Finished block
+Processing block:E1       :bs23  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  1.1 (3289863819460870158)
+
+Made Particle :pr24  :10252428843375656984: pdgid =    22, status =   1, q =  0, e =   1.1, theta = -0.06, phi = -1.92, mass =  0.00 from MergedCluster: em14  :3289863819460870158:    1.11 -0.06 -1.92 sub(es9, )
+Finished block
+Processing block:E1       :bs22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  1.7 (3289874948440457231)
+
+Made Particle :pr25  :10252439972355244057: pdgid =    22, status =   1, q =  0, e =   1.7, theta = -0.30, phi = -1.68, mass =  0.00 from MergedCluster: em15  :3289874948440457231:    1.74 -0.30 -1.68 sub(es6, )
+Finished block
+Processing block:E1       :bs21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  1.8 (3289876040630927376)
+
+Made Particle :pr26  :10252441064545714202: pdgid =    22, status =   1, q =  0, e =   1.8, theta =  0.37, phi =  0.90, mass =  0.00 from MergedCluster: em16  :3289876040630927376:    1.80  0.37  0.90 sub(es5, )
+Finished block
+Processing block:E1       :bs20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em18      value=  2.4 (3289883322922041362)
+
+Made Particle :pr27  :10252448346836828187: pdgid =    22, status =   1, q =  0, e =   2.4, theta = -0.35, phi = -1.73, mass =  0.00 from MergedCluster: em18  :3289883322922041362:    2.43 -0.35 -1.73 sub(es4, )
+Finished block
+Processing block:E1       :bs19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  5.0 (3289901726374559765)
+
+Made Particle :pr28  :10252466750289346588: pdgid =    22, status =   1, q =  0, e =   5.0, theta = -1.36, phi = -1.32, mass =  0.00 from MergedCluster: em21  :3289901726374559765:    5.05 -1.36 -1.32 sub(es22, )
+Finished block
+Processing block:E1       :bs18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  5.6 (3289903956314030103)
+
+Made Particle :pr29  :10252468980228816925: pdgid =    22, status =   1, q =  0, e =   5.6, theta =  1.17, phi =  1.24, mass =  0.00 from MergedCluster: em23  :3289903956314030103:    5.55  1.17  1.24 sub(es16, )
+Finished block
+Processing block:E1       :bs17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  7.6 (3289913016866308115)
+
+Made Particle :pr30  :10252478040781094942: pdgid =    22, status =   1, q =  0, e =   7.6, theta = -0.27, phi = -1.75, mass =  0.00 from MergedCluster: em19  :3289913016866308115:    7.61 -0.27 -1.75 sub(es0, es2, )
+Finished block
+Processing block:H1       :bs16  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm1       value=  7.7 (5595756334669627393)
+
+Made Particle :pr31  :10252478349370720287: pdgid =   130, status =   1, q =  0, e =   7.7, theta = -0.32, phi = -1.75, mass =  0.50 from MergedCluster: hm1   :5595756334669627393:    7.68 -0.32 -1.75 sub(hs3, hs4, )
+Finished block
+Processing block:H1       :bs15  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm4       value=  9.3 (5595760664671944708)
+
+Made Particle :pr32  :10252482679373037600: pdgid =   130, status =   1, q =  0, e =   9.3, theta = -1.52, phi = -2.94, mass =  0.50 from MergedCluster: hm4   :5595760664671944708:    9.34 -1.52 -2.94 sub(hs7, )
+Finished block
+Processing block:T1       :bs14  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.0 (7955591493526224910)
+
+Made Particle :pr33  :10252427469407649825: pdgid =  -211, status =   1, q = -1, e =   1.0, theta = -0.81, phi = -2.25, mass =  0.14 from SmearedTrack: ts14  :7955591493526224910:    1.02    0.70 -0.81 -2.25
+Finished block
+Processing block:T1       :bs13  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  2.1 (7955609262412005386)
+
+Made Particle :pr34  :10252445113590480930: pdgid =   211, status =   1, q =  1, e =   2.1, theta =  0.19, phi = -1.56, mass =  0.14 from SmearedTrack: ts10  :7955609262412005386:    2.06    2.02  0.19 -1.56
+Finished block
+Processing block:T1       :bs12  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  2.3 (7955611146831003657)
+
+Made Particle :pr35  :10252446994131845155: pdgid =  -211, status =   1, q = -1, e =   2.3, theta =  0.09, phi =  0.80, mass =  0.14 from SmearedTrack: ts9   :7955611146831003657:    2.27    2.26  0.09  0.80
+Finished block
+Processing block:T1       :bs11  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  2.7 (7955614550879895560)
+
+Made Particle :pr36  :10252450392757501988: pdgid =   211, status =   1, q =  1, e =   2.7, theta = -0.44, phi = -1.87, mass =  0.14 from SmearedTrack: ts8   :7955614550879895560:    2.66    2.41 -0.44 -1.87
+Finished block
+Processing block:T1       :bs10  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts5       value=  4.7 (7955629273734184965)
+
+Made Particle :pr37  :10252465092792680485: pdgid =   211, status =   1, q =  1, e =   4.7, theta = -0.55, phi = -1.79, mass =  0.14 from SmearedTrack: ts5   :7955629273734184965:    4.67    3.98 -0.55 -1.79
+Finished block
+Processing block:T1       :bs9   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts2       value= 18.8 (7955664607092146178)
+
+Made Particle :pr38  :10252500417371963430: pdgid =    13, status =   1, q =  1, e =  18.8, theta =  0.34, phi =  0.90, mass =  0.11 from SmearedTrack: ts2   :7955664607092146178:   18.81   17.75  0.34  0.90
+Finished block
+Processing block:T1       :bs8   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 42.0 (7955684619248992257)
+
+Made Particle :pr39  :10252520429279248423: pdgid =    13, status =   1, q =  1, e =  42.0, theta = -0.19, phi =  2.03, mass =  0.11 from SmearedTrack: ts1   :7955684619248992257:   42.02   41.30 -0.19  2.03
+Finished block
+Finished reconstruction
+Event: 6
+Made Particle :ps0   :10261541683780911104: pdgid =   -13, status =   1, q =  1, e =  71.2, theta =  0.42, phi =  2.54, mass =  0.11
+Made Particle :ps1   :10261522908868247553: pdgid =    13, status =   1, q = -1, e =  33.4, theta = -1.15, phi = -0.86, mass =  0.11
+Made Particle :ps2   :10261500880845012994: pdgid =   321, status =   1, q =  1, e =  14.3, theta = -0.51, phi =  3.11, mass =  0.49
+Made Particle :ps3   :10261491920526114819: pdgid =    22, status =   1, q =  0, e =  10.3, theta =  0.30, phi = -0.36, mass =  0.00
+Made Particle :ps4   :10261491659028037636: pdgid =    22, status =   1, q =  0, e =  10.1, theta =  0.30, phi = -0.38, mass =  0.00
+Made Particle :ps5   :10261489251568844805: pdgid =    22, status =   1, q =  0, e =   9.1, theta =  0.28, phi = -0.40, mass =  0.00
+Made Particle :ps6   :10261485347764436998: pdgid =    22, status =   1, q =  0, e =   7.6, theta =  0.35, phi = -0.31, mass =  0.00
+Made Particle :ps7   :10261474408658894855: pdgid =  -211, status =   1, q = -1, e =   5.2, theta = -0.48, phi =  3.06, mass =  0.14
+Made Particle :ps8   :10261473312467058696: pdgid =    22, status =   1, q =  0, e =   4.9, theta =  0.30, phi = -0.34, mass =  0.00
+Made Particle :ps9   :10261471347236405257: pdgid =    22, status =   1, q =  0, e =   4.5, theta =  0.16, phi = -0.24, mass =  0.00
+Made Particle :ps10  :10261470947271770122: pdgid =  2112, status =   1, q =  0, e =   4.4, theta =  0.12, phi = -0.17, mass =  0.94
+Made Particle :ps11  :10261470860147687435: pdgid =   211, status =   1, q =  1, e =   4.3, theta =  0.28, phi = -0.17, mass =  0.14
+Made Particle :ps12  :10261469456003760140: pdgid =  -211, status =   1, q = -1, e =   4.0, theta =  0.37, phi = -0.32, mass =  0.14
+Made Particle :ps13  :10261462558542135309: pdgid =   211, status =   1, q =  1, e =   3.2, theta =  0.24, phi = -0.29, mass =  0.14
+Made Particle :ps14  :10261459607633264654: pdgid =   211, status =   1, q =  1, e =   2.9, theta = -0.51, phi =  3.05, mass =  0.14
+Made Particle :ps15  :10261457647590965263: pdgid =    22, status =   1, q =  0, e =   2.7, theta =  0.34, phi = -0.43, mass =  0.00
+Made Particle :ps16  :10261457432687411216: pdgid =   211, status =   1, q =  1, e =   2.6, theta = -0.51, phi = -3.03, mass =  0.14
+Made Particle :ps17  :10261456423657406481: pdgid = -2112, status =   1, q =  0, e =   2.5, theta =  0.04, phi = -0.21, mass =  0.94
+Made Particle :ps18  :10261453519808626706: pdgid =    22, status =   1, q =  0, e =   2.2, theta =  0.22, phi = -0.37, mass =  0.00
+Made Particle :ps19  :10261453209042157587: pdgid =  -211, status =   1, q = -1, e =   2.2, theta = -0.43, phi =  3.08, mass =  0.14
+Made Particle :ps20  :10261452936890548244: pdgid =    22, status =   1, q =  0, e =   2.1, theta =  0.28, phi = -0.37, mass =  0.00
+Made Particle :ps21  :10261452492174786581: pdgid =  -211, status =   1, q = -1, e =   2.1, theta =  0.23, phi = -0.13, mass =  0.14
+Made Particle :ps22  :10261448666269089814: pdgid =    22, status =   1, q =  0, e =   1.8, theta =  0.35, phi = -0.24, mass =  0.00
+Made Particle :ps23  :10261448119063412759: pdgid =    22, status =   1, q =  0, e =   1.8, theta =  0.26, phi = -0.31, mass =  0.00
+Made Particle :ps24  :10261447484653961240: pdgid =  -211, status =   1, q = -1, e =   1.8, theta = -0.56, phi = -3.11, mass =  0.14
+Made Particle :ps25  :10261443366218629145: pdgid =    22, status =   1, q =  0, e =   1.5, theta =  0.43, phi = -0.42, mass =  0.00
+Made Particle :ps26  :10261441118977654810: pdgid =   211, status =   1, q =  1, e =   1.4, theta = -0.81, phi =  2.85, mass =  0.14
+Made Particle :ps27  :10261438892869681179: pdgid =    22, status =   1, q =  0, e =   1.3, theta =  0.31, phi = -0.29, mass =  0.00
+Made Particle :ps28  :10261438716402728988: pdgid =    22, status =   1, q =  0, e =   1.3, theta =  0.31, phi = -0.36, mass =  0.00
+Made Particle :ps29  :10261437509810520093: pdgid =    22, status =   1, q =  0, e =   1.2, theta = -0.54, phi = -3.10, mass =  0.00
+Made Particle :ps30  :10261436385550401566: pdgid =   211, status =   1, q =  1, e =   1.1, theta = -0.19, phi = -0.57, mass =  0.14
+Made Particle :ps31  :10261435356572287007: pdgid =  -211, status =   1, q = -1, e =   1.1, theta = -0.49, phi =  0.42, mass =  0.14
+Made Particle :ps32  :10261434411671093280: pdgid =    22, status =   1, q =  0, e =   1.0, theta =  0.57, phi = -0.57, mass =  0.00
+Made Particle :ps33  :10261433000193425441: pdgid =    22, status =   1, q =  0, e =   1.0, theta =  0.33, phi = -0.38, mass =  0.00
+Made Particle :ps34  :10261432966299254818: pdgid =    22, status =   1, q =  0, e =   1.0, theta = -0.25, phi = -3.02, mass =  0.00
+Made Particle :ps35  :10261431390627168291: pdgid =    22, status =   1, q =  0, e =   0.9, theta =  0.35, phi = -0.14, mass =  0.00
+Made Particle :ps36  :10261429674768859172: pdgid =   211, status =   1, q =  1, e =   0.9, theta =  0.28, phi = -0.16, mass =  0.14
+Made Particle :ps37  :10261425485445595173: pdgid =   211, status =   1, q =  1, e =   0.8, theta = -0.86, phi =  2.81, mass =  0.14
+Made Particle :ps38  :10261425438008016934: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.38, phi = -0.31, mass =  0.00
+Made Particle :ps39  :10261425363710115879: pdgid =    22, status =   1, q =  0, e =   0.8, theta = -0.61, phi = -2.96, mass =  0.00
+Made Particle :ps40  :10261424555941691432: pdgid =  -321, status =   1, q = -1, e =   0.7, theta = -1.55, phi =  1.76, mass =  0.49
+Made Particle :ps41  :10261421259583651881: pdgid =   321, status =   1, q =  1, e =   0.6, theta = -0.38, phi = -2.34, mass =  0.49
+Made Particle :ps42  :10261417699554885674: pdgid =   211, status =   1, q =  1, e =   0.5, theta =  0.10, phi = -1.41, mass =  0.14
+Made Particle :ps43  :10261410698342957099: pdgid =   211, status =   1, q =  1, e =   0.4, theta = -0.35, phi = -0.74, mass =  0.14
+Made Particle :ps44  :10261405554953945132: pdgid =  -211, status =   1, q = -1, e =   0.3, theta =  0.31, phi =  0.74, mass =  0.14
+Made Particle :ps45  :10261405447974027309: pdgid =  -211, status =   1, q = -1, e =   0.3, theta = -1.00, phi =  2.46, mass =  0.14
+Made Particle :ps46  :10261403687077281838: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.64, phi = -0.74, mass =  0.00
+Made Particle :ps47  :10261401368052891695: pdgid =  -211, status =   1, q = -1, e =   0.3, theta = -0.68, phi = -2.40, mass =  0.14
+Made Particle :ps48  :10261400902931841072: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.50, phi = -2.94, mass =  0.00
+Made Particle :ps49  :10261400802968993841: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  1.14, phi =  2.80, mass =  0.00
+Made Particle :ps50  :10261399528236122162: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.11, phi = -0.23, mass =  0.00
+Made Particle :ps51  :10261398606722367539: pdgid =  -211, status =   1, q = -1, e =   0.2, theta =  0.59, phi = -0.20, mass =  0.14
+Made Particle :ps52  :10261393232684384308: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.64, phi = -0.28, mass =  0.00
+Made Particle :ps53  :10261390997023883317: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.90, phi = -2.38, mass =  0.00
+Made Particle :ps54  :10261382659525574710: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.50, phi =  2.82, mass =  0.00
+Made Particle :ps55  :10261380652106514487: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.36, phi = -0.21, mass =  0.00
+Made Particle :ps56  :10261372072366178360: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.30, phi =  0.10, mass =  0.00
+Made Particle :ps57  :10261343006854479929: pdgid =    11, status =   1, q = -1, e =   0.0, theta =  0.00, phi = -1.94, mass =  0.00
+Made Particle :ps58  :10261252241434345530: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  0.61, phi = -2.76, mass =  0.00
+Made Particle :ps59  :10261241481201188923: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  0.18, phi =  2.80, mass =  0.00
+Simulating Particle :ps0   :10261541683780911104: pdgid =   -13, status =   1, q =  1, e =  71.2, theta =  0.42, phi =  2.54, mass =  0.11
+Simulating Muon
+Made Track: tt0   :7964705873800986624:   71.17   65.12  0.42  2.54
+Made SmearedTrack: ts0   :7955699125750595584:   72.82   66.62  0.42  2.54
+Simulating Particle :ps1   :10261522908868247553: pdgid =    13, status =   1, q = -1, e =  33.4, theta = -1.15, phi = -0.86, mass =  0.11
+Simulating Muon
+Made Track: tt1   :7964687098819117057:   33.44   13.72 -1.15 -0.86
+Made SmearedTrack: ts1   :7955680253397958657:   34.08   13.98 -1.15 -0.86
+Simulating Particle :ps2   :10261500880845012994: pdgid =   321, status =   1, q =  1, e =  14.3, theta = -0.51, phi =  3.11, mass =  0.49
+Simulating Hadron
+Made Track: tt2   :7964665052194144258:   14.33   12.52 -0.51  3.11
+Made SmearedTrack: ts2   :7955657442784706562:   14.15   12.36 -0.51  3.11
+Made Cluster: et0   :3352951831402643456:    4.98 -0.51  3.06 sub(et0, )
+Made SmearedCluster: es0   :3343921915382202368:    1.95 -0.51  3.06 sub(es0, )
+Made Cluster: ht0   :5658811107257614336:    9.36 -0.51  3.03 sub(ht0, )
+Made SmearedCluster: hs0   :5649814552479531008:   14.20 -0.51  3.03 sub(hs0, )
+Simulating Particle :ps3   :10261491920526114819: pdgid =    22, status =   1, q =  0, e =  10.3, theta =  0.30, phi = -0.36, mass =  0.00
+Simulating Photon
+Event: 7
+Made Particle :ps0   :10261539759165800448: pdgid =    13, status =   1, q = -1, e =  64.2, theta =  0.46, phi = -1.63, mass =  0.11
+Made Particle :ps1   :10261526673744723969: pdgid =   -13, status =   1, q =  1, e =  40.3, theta = -0.06, phi =  0.61, mass =  0.11
+Made Particle :ps2   :10261495652617814018: pdgid =    22, status =   1, q =  0, e =  12.0, theta = -1.03, phi =  1.51, mass =  0.00
+Made Particle :ps3   :10261490894469332995: pdgid =   211, status =   1, q =  1, e =   9.8, theta = -1.06, phi =  1.36, mass =  0.14
+Made Particle :ps4   :10261488009434103812: pdgid =  -211, status =   1, q = -1, e =   8.5, theta = -1.10, phi =  1.49, mass =  0.14
+Made Particle :ps5   :10261487738742112261: pdgid =   321, status =   1, q =  1, e =   8.4, theta = -1.01, phi =  1.58, mass =  0.49
+Made Particle :ps6   :10261483552702988294: pdgid =  -211, status =   1, q = -1, e =   7.2, theta =  1.03, phi =  3.08, mass =  0.14
+Made Particle :ps7   :10261481126426050567: pdgid =    22, status =   1, q =  0, e =   6.7, theta = -1.06, phi =  1.44, mass =  0.00
+Made Particle :ps8   :10261480262521061384: pdgid =    22, status =   1, q =  0, e =   6.5, theta = -1.05, phi =  1.49, mass =  0.00
+Made Particle :ps9   :10261473131780636681: pdgid =   130, status =   1, q =  0, e =   4.9, theta =  1.02, phi = -3.08, mass =  0.50
+Made Particle :ps10  :10261471587465166858: pdgid =    22, status =   1, q =  0, e =   4.5, theta =  0.91, phi = -3.10, mass =  0.00
+Made Particle :ps11  :10261471418294206475: pdgid =    22, status =   1, q =  0, e =   4.5, theta =  0.80, phi = -2.96, mass =  0.00
+Made Particle :ps12  :10261471063602888716: pdgid =   211, status =   1, q =  1, e =   4.4, theta =  0.83, phi = -2.93, mass =  0.14
+Made Particle :ps13  :10261470782293016589: pdgid =    22, status =   1, q =  0, e =   4.3, theta = -1.07, phi =  1.58, mass =  0.00
+Made Particle :ps14  :10261469681044946958: pdgid =  -321, status =   1, q = -1, e =   4.1, theta = -1.07, phi =  1.20, mass =  0.49
+Made Particle :ps15  :10261462816456179727: pdgid =    22, status =   1, q =  0, e =   3.3, theta = -1.00, phi =  1.45, mass =  0.00
+Made Particle :ps16  :10261462475304075280: pdgid =   211, status =   1, q =  1, e =   3.2, theta =  0.86, phi = -2.95, mass =  0.14
+Made Particle :ps17  :10261461075195068433: pdgid =    22, status =   1, q =  0, e =   3.1, theta =  0.85, phi = -2.98, mass =  0.00
+Made Particle :ps18  :10261458383236235282: pdgid =    22, status =   1, q =  0, e =   2.8, theta =  0.85, phi = -3.05, mass =  0.00
+Made Particle :ps19  :10261455085538115603: pdgid =   211, status =   1, q =  1, e =   2.4, theta = -1.11, phi =  1.54, mass =  0.14
+Made Particle :ps20  :10261454777355337748: pdgid =    22, status =   1, q =  0, e =   2.3, theta = -1.07, phi =  1.51, mass =  0.00
+Made Particle :ps21  :10261454198696574997: pdgid =    22, status =   1, q =  0, e =   2.3, theta =  0.97, phi = -2.89, mass =  0.00
+Made Particle :ps22  :10261454085381160982: pdgid =   211, status =   1, q =  1, e =   2.3, theta =  0.85, phi = -2.85, mass =  0.14
+Made Particle :ps23  :10261453972774584343: pdgid =  -211, status =   1, q = -1, e =   2.3, theta =  0.81, phi = -3.06, mass =  0.14
+Made Particle :ps24  :10261453529906413592: pdgid =    22, status =   1, q =  0, e =   2.2, theta = -1.20, phi =  1.57, mass =  0.00
+Made Particle :ps25  :10261447819346837529: pdgid =    22, status =   1, q =  0, e =   1.8, theta =  0.83, phi = -2.95, mass =  0.00
+Made Particle :ps26  :10261446638302134298: pdgid =    22, status =   1, q =  0, e =   1.7, theta = -1.17, phi =  1.49, mass =  0.00
+Made Particle :ps27  :10261446622378459163: pdgid =    22, status =   1, q =  0, e =   1.7, theta = -1.10, phi =  1.43, mass =  0.00
+Made Particle :ps28  :10261446399627362332: pdgid =  -211, status =   1, q = -1, e =   1.7, theta = -0.87, phi =  1.31, mass =  0.14
+Made Particle :ps29  :10261444179055869981: pdgid =  -211, status =   1, q = -1, e =   1.6, theta =  0.84, phi = -3.01, mass =  0.14
+Made Particle :ps30  :10261443033799065630: pdgid =    22, status =   1, q =  0, e =   1.5, theta =  0.92, phi = -2.80, mass =  0.00
+Made Particle :ps31  :10261442412494716959: pdgid =    22, status =   1, q =  0, e =   1.5, theta = -1.18, phi =  1.58, mass =  0.00
+Made Particle :ps32  :10261442362758660128: pdgid =   321, status =   1, q =  1, e =   1.5, theta =  0.66, phi =  2.39, mass =  0.49
+Made Particle :ps33  :10261440724090224673: pdgid =    22, status =   1, q =  0, e =   1.4, theta =  1.05, phi = -2.87, mass =  0.00
+Made Particle :ps34  :10261436048269639714: pdgid =    22, status =   1, q =  0, e =   1.1, theta =  1.07, phi = -2.72, mass =  0.00
+Made Particle :ps35  :10261431921691066403: pdgid =    22, status =   1, q =  0, e =   0.9, theta = -1.07, phi =  1.56, mass =  0.00
+Made Particle :ps36  :10261431269931876388: pdgid =    22, status =   1, q =  0, e =   0.9, theta =  0.94, phi = -2.76, mass =  0.00
+Made Particle :ps37  :10261430672079978533: pdgid =   211, status =   1, q =  1, e =   0.9, theta =  0.97, phi = -2.37, mass =  0.14
+Made Particle :ps38  :10261429875862667302: pdgid =  -211, status =   1, q = -1, e =   0.9, theta =  0.69, phi =  2.32, mass =  0.14
+Made Particle :ps39  :10261428469153923111: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  1.10, phi =  2.93, mass =  0.00
+Made Particle :ps40  :10261421844684865576: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.96, phi = -2.93, mass =  0.00
+Made Particle :ps41  :10261419919476260905: pdgid =  -211, status =   1, q = -1, e =   0.6, theta = -1.07, phi = -2.54, mass =  0.14
+Made Particle :ps42  :10261418976642859050: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.99, phi = -3.14, mass =  0.00
+Made Particle :ps43  :10261412616224112683: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.98, phi =  1.61, mass =  0.00
+Made Particle :ps44  :10261409761928937516: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -1.05, phi =  1.62, mass =  0.00
+Made Particle :ps45  :10261408407363780653: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.98, phi = -2.78, mass =  0.00
+Made Particle :ps46  :10261405596748087342: pdgid =  -211, status =   1, q = -1, e =   0.3, theta =  0.79, phi = -2.80, mass =  0.14
+Made Particle :ps47  :10261390098754961455: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.66, phi = -2.77, mass =  0.00
+Made Particle :ps48  :10261388001395343408: pdgid =   211, status =   1, q =  1, e =   0.2, theta = -1.35, phi =  0.27, mass =  0.14
+Made Particle :ps49  :10261376569228394545: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.63, phi = -3.07, mass =  0.00
+Made Particle :ps50  :10261367584314097714: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.84, phi = -2.39, mass =  0.00
+Made Particle :ps51  :10261364981163360307: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -1.27, phi =  1.17, mass =  0.00
+Made Particle :ps52  :10261333066058301492: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.35, phi =  0.05, mass =  0.00
+Made Particle :ps53  :10261317773806272565: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.85, phi = -0.72, mass =  0.00
+Simulating Particle :ps0   :10261539759165800448: pdgid =    13, status =   1, q = -1, e =  64.2, theta =  0.46, phi = -1.63, mass =  0.11
+Simulating Muon
+Made Track: tt0   :7964703949183778816:   64.17   57.46  0.46 -1.63
+Made SmearedTrack: ts0   :7955694662570737664:   60.29   53.99  0.46 -1.63
+Simulating Particle :ps1   :10261526673744723969: pdgid =   -13, status =   1, q =  1, e =  40.3, theta = -0.06, phi =  0.61, mass =  0.11
+Simulating Muon
+Made Track: tt1   :7964690863708176385:   40.28   40.22 -0.06  0.61
+Made SmearedTrack: ts1   :7955683257217974273:   39.54   39.48 -0.06  0.61
+Simulating Particle :ps2   :10261495652617814018: pdgid =    22, status =   1, q =  0, e =  12.0, theta = -1.03, phi =  1.51, mass =  0.00
+Simulating Photon
+Made Cluster: et0   :3352973824231473152:   11.96 -1.03  1.51 sub(et0, )
+Made SmearedCluster: es0   :3343967340814401536:   12.29 -1.03  1.51 sub(es0, )
+Simulating Particle :ps3   :10261490894469332995: pdgid =   211, status =   1, q =  1, e =   9.8, theta = -1.06, phi =  1.36, mass =  0.14
+Simulating Hadron
+Made Track: tt2   :7964655082325147650:    9.80    4.76 -1.06  1.36
+Made SmearedTrack: ts2   :7955648006064177154:    9.86    4.79 -1.06  1.36
+Made Cluster: ht0   :5658812075296686080:    9.80 -1.07  1.19 sub(ht0, )
+Made SmearedCluster: hs0   :5647513932722601984:   -5.81 -1.07  1.19 sub(hs0, )
+Rejected SmearedCluster: hs0   :5647513932722601984:   -5.81 -1.07  1.19 sub(hs0, )
+Simulating Particle :ps4   :10261488009434103812: pdgid =  -211, status =   1, q = -1, e =   8.5, theta = -1.10, phi =  1.49, mass =  0.14
+Simulating Hadron
+Made Track: tt3   :7964652196952276995:    8.49    3.83 -1.10  1.49
+Made SmearedTrack: ts3   :7955644983885692931:    8.48    3.83 -1.10  1.49
+Rejected SmearedTrack: ts3   :7955644983885692931:    8.48    3.83 -1.10  1.49
+Made Cluster: ht1   :5658809190261456897:    8.49 -1.10  1.69 sub(ht1, )
+Made SmearedCluster: hs0   :5649818989210107904:   16.44 -1.10  1.69 sub(hs0, )
+Rejected SmearedCluster: hs0   :5649818989210107904:   16.44 -1.10  1.69 sub(hs0, )
+Simulating Particle :ps5   :10261487738742112261: pdgid =   321, status =   1, q =  1, e =   8.4, theta = -1.01, phi =  1.58, mass =  0.49
+Simulating Hadron
+Made Track: tt4   :7964651896719802372:    8.35    4.44 -1.01  1.58
+Made SmearedTrack: ts3   :7955644816132407299:    8.40    4.47 -1.01  1.58
+Made Cluster: et1   :3352951342388740097:    4.87 -1.01  1.42 sub(et1, )
+Made SmearedCluster: es1   :3343944151719739393:    4.87 -1.01  1.42 sub(es1, )
+Made Cluster: ht2   :5658786082347548674:    3.50 -1.01  1.37 sub(ht2, )
+Made SmearedCluster: hs0   :5647513932722601984:   -1.40 -1.01  1.37 sub(hs0, )
+Rejected SmearedCluster: hs0   :5647513932722601984:   -1.40 -1.01  1.37 sub(hs0, )
+Simulating Particle :ps6   :10261483552702988294: pdgid =  -211, status =   1, q = -1, e =   7.2, theta =  1.03, phi =  3.08, mass =  0.14
+Simulating Hadron
+Made Track: tt5   :7964647736817483781:    7.23    3.73  1.03  3.08
+Made SmearedTrack: ts4   :7955640775138607108:    7.28    3.76  1.03  3.08
+Made Cluster: ht3   :5658804733530341379:    7.23  1.03 -2.97 sub(ht3, )
+Made SmearedCluster: hs0   :5649805509520261120:   10.09  1.03 -2.97 sub(hs0, )
+Simulating Particle :ps7   :10261481126426050567: pdgid =    22, status =   1, q =  0, e =   6.7, theta = -1.06, phi =  1.44, mass =  0.00
+Simulating Photon
+Made Cluster: et2   :3352959298039709698:    6.68 -1.06  1.44 sub(et2, )
+Made SmearedCluster: es2   :3343953371011743746:    6.97 -1.06  1.44 sub(es2, )
+Simulating Particle :ps8   :10261480262521061384: pdgid =    22, status =   1, q =  0, e =   6.5, theta = -1.05, phi =  1.49, mass =  0.00
+Simulating Photon
+Made Cluster: et3   :3352958434134720515:    6.48 -1.05  1.49 sub(et3, )
+Made SmearedCluster: es3   :3343952292723294211:    6.72 -1.05  1.49 sub(es3, )
+Simulating Particle :ps9   :10261473131780636681: pdgid =   130, status =   1, q =  0, e =   4.9, theta =  1.02, phi = -3.08, mass =  0.50
+Simulating Hadron
+Made Cluster: ht4   :5658794312607989764:    4.86  1.02 -3.08 sub(ht4, )
+Made SmearedCluster: hs1   :5647513932722601985:   -1.06  1.02 -3.08 sub(hs1, )
+Rejected SmearedCluster: hs1   :5647513932722601985:   -1.06  1.02 -3.08 sub(hs1, )
+Simulating Particle :ps10  :10261471587465166858: pdgid =    22, status =   1, q =  0, e =   4.5, theta =  0.91, phi = -3.10, mass =  0.00
+Simulating Photon
+Made Cluster: et4   :3352949759078825988:    4.51  0.91 -3.10 sub(et4, )
+Made SmearedCluster: es4   :3343942196878376964:    4.43  0.91 -3.10 sub(es4, )
+Simulating Particle :ps11  :10261471418294206475: pdgid =    22, status =   1, q =  0, e =   4.5, theta =  0.80, phi = -2.96, mass =  0.00
+Simulating Photon
+Made Cluster: et5   :3352949589907865605:    4.47  0.80 -2.96 sub(et5, )
+Made SmearedCluster: es5   :3343941416989491205:    4.25  0.80 -2.96 sub(es5, )
+Simulating Particle :ps12  :10261471063602888716: pdgid =   211, status =   1, q =  1, e =   4.4, theta =  0.83, phi = -2.93, mass =  0.14
+Simulating Hadron
+Made Track: tt6   :7964635243887984646:    4.39    2.96  0.83 -2.93
+Made SmearedTrack: ts5   :7955627777930035205:    4.33    2.92  0.83 -2.93
+Made Cluster: et6   :3352918470732808198:    1.35  0.83  3.10 sub(et6, )
+Made SmearedCluster: es6   :3341670923508908038:   -0.32  0.83  3.10 sub(es6, )
+Rejected SmearedCluster: es6   :3341670923508908038:   -0.32  0.83  3.10 sub(es6, )
+Made Cluster: ht5   :5658782098620678149:    3.04  0.84  2.98 sub(ht5, )
+Made SmearedCluster: hs1   :5649724174137032705:    0.41  0.84  2.98 sub(hs1, )
+Rejected SmearedCluster: hs1   :5649724174137032705:    0.41  0.84  2.98 sub(hs1, )
+Simulating Particle :ps13  :10261470782293016589: pdgid =    22, status =   1, q =  0, e =   4.3, theta = -1.07, phi =  1.58, mass =  0.00
+Simulating Photon
+Made Cluster: et7   :3352948953906675719:    4.33 -1.07  1.58 sub(et7, )
+Made SmearedCluster: es6   :3343942008409423878:    4.38 -1.07  1.58 sub(es6, )
+Simulating Particle :ps14  :10261469681044946958: pdgid =  -321, status =   1, q = -1, e =   4.1, theta = -1.07, phi =  1.20, mass =  0.49
+Simulating Hadron
+Made Track: tt7   :7964633739139481607:    4.05    1.95 -1.07  1.20
+Made SmearedTrack: ts6   :7955626772236599302:    4.10    1.97 -1.07  1.20
+Made Cluster: ht6   :5658790861872300038:    4.08 -1.08  1.62 sub(ht6, )
+Made SmearedCluster: hs1   :5649804758874062849:    9.75 -1.08  1.62 sub(hs1, )
+Simulating Particle :ps15  :10261462816456179727: pdgid =    22, status =   1, q =  0, e =   3.3, theta = -1.00, phi =  1.45, mass =  0.00
+Simulating Photon
+Made Cluster: et8   :3352940988069838856:    3.26 -1.00  1.45 sub(et8, )
+Made SmearedCluster: es7   :3343933515721867271:    3.23 -1.00  1.45 sub(es7, )
+Simulating Particle :ps16  :10261462475304075280: pdgid =   211, status =   1, q =  1, e =   3.2, theta =  0.86, phi = -2.95, mass =  0.14
+Simulating Hadron
+Made Track: tt8   :7964626638719680520:    3.22    2.09  0.86 -2.95
+Made SmearedTrack: ts7   :7955619701491499015:    3.25    2.11  0.86 -2.95
+Made Cluster: ht7   :5658783656131428359:    3.22  0.89  2.84 sub(ht7, )
+Made SmearedCluster: hs2   :5649786409563717634:    4.70  0.89  2.84 sub(hs2, )
+Simulating Particle :ps17  :10261461075195068433: pdgid =    22, status =   1, q =  0, e =   3.1, theta =  0.85, phi = -2.98, mass =  0.00
+Simulating Photon
+Made Cluster: et9   :3352939246808727561:    3.06  0.85 -2.98 sub(et9, )
+Made SmearedCluster: es8   :3343934062101266440:    3.29  0.85 -2.98 sub(es8, )
+Simulating Particle :ps18  :10261458383236235282: pdgid =    22, status =   1, q =  0, e =   2.8, theta =  0.85, phi = -3.05, mass =  0.00
+Simulating Photon
+Made Cluster: et10  :3352936554849894410:    2.75  0.85 -3.05 sub(et10, )
+Made SmearedCluster: es9   :3343931085709901833:    2.95  0.85 -3.05 sub(es9, )
+Simulating Particle :ps19  :10261455085538115603: pdgid =   211, status =   1, q =  1, e =   2.4, theta = -1.11, phi =  1.54, mass =  0.14
+Simulating Hadron
+Made Track: tt9   :7964619239537508361:    2.37    1.05 -1.11  1.54
+Made SmearedTrack: ts8   :7955611987625377800:    2.37    1.05 -1.11  1.54
+Made Cluster: et11  :3352910898032279563:    0.96 -1.13  1.00 sub(et11, )
+Made SmearedCluster: es10  :3343952851331186698:    6.85 -1.13  1.00 sub(es10, )
+Made Cluster: ht8   :5658762724933369864:    1.42 -1.14  0.84 sub(ht8, )
+Made SmearedCluster: hs3   :5649783283135807491:    4.00 -1.14  0.84 sub(hs3, )
+Simulating Particle :ps20  :10261454777355337748: pdgid =    22, status =   1, q =  0, e =   2.3, theta = -1.07, phi =  1.51, mass =  0.00
+Simulating Photon
+Made Cluster: et12  :3352932948968996876:    2.34 -1.07  1.51 sub(et12, )
+Made SmearedCluster: es11  :3343922984141193227:    2.03 -1.07  1.51 sub(es11, )
+Simulating Particle :ps21  :10261454198696574997: pdgid =    22, status =   1, q =  0, e =   2.3, theta =  0.97, phi = -2.89, mass =  0.00
+Simulating Photon
+Made Cluster: et13  :3352932370310234125:    2.28  0.97 -2.89 sub(et13, )
+Made SmearedCluster: es12  :3343924784065937420:    2.23  0.97 -2.89 sub(es12, )
+Simulating Particle :ps22  :10261454085381160982: pdgid =   211, status =   1, q =  1, e =   2.3, theta =  0.85, phi = -2.85, mass =  0.14
+Simulating Hadron
+Made Track: tt10  :7964618237568614410:    2.26    1.49  0.85 -2.85
+Made SmearedTrack: ts9   :7955611315775471625:    2.29    1.51  0.85 -2.85
+Made Cluster: et14  :3352918054731251726:    1.33  0.88  2.92 sub(et14, )
+Made SmearedCluster: es13  :3343930846515036173:    2.92  0.88  2.92 sub(es13, )
+Made Cluster: ht9   :5658753228592906249:    0.94  0.91  2.62 sub(ht9, )
+Made SmearedCluster: hs4   :5649789155339665412:    5.33  0.91  2.62 sub(hs4, )
+Simulating Particle :ps23  :10261453972774584343: pdgid =  -211, status =   1, q = -1, e =   2.3, theta =  0.81, phi = -3.06, mass =  0.14
+Simulating Hadron
+Made Track: tt11  :7964618124746031115:    2.25    1.56  0.81 -3.06
+Made SmearedTrack: ts10  :7955610784543801354:    2.23    1.55  0.81 -3.06
+Made Cluster: et15  :3352880316378251279:    0.30  0.83 -2.57 sub(et15, )
+Made SmearedCluster: es14  :3341670923508908046:   -1.95  0.83 -2.57 sub(es14, )
+Rejected SmearedCluster: es14  :3341670923508908046:   -1.95  0.83 -2.57 sub(es14, )
+Made Cluster: ht10  :5658772184777097226:    1.96  0.86 -2.30 sub(ht10, )
+Made SmearedCluster: hs5   :5649735451173453829:    0.64  0.86 -2.30 sub(hs5, )
+Rejected SmearedCluster: hs5   :5649735451173453829:    0.64  0.86 -2.30 sub(hs5, )
+Simulating Particle :ps24  :10261453529906413592: pdgid =    22, status =   1, q =  0, e =   2.2, theta = -1.20, phi =  1.57, mass =  0.00
+Simulating Photon
+Made Cluster: et16  :3352931701520072720:    2.20 -1.20  1.57 sub(et16, )
+Made SmearedCluster: es14  :3343923269586649102:    2.06 -1.20  1.57 sub(es14, )
+Simulating Particle :ps25  :10261447819346837529: pdgid =    22, status =   1, q =  0, e =   1.8, theta =  0.83, phi = -2.95, mass =  0.00
+Simulating Photon
+Made Cluster: et17  :3352925990960496657:    1.78  0.84 -2.95 sub(et17, )
+Made SmearedCluster: es15  :3343914140872736783:    1.51  0.84 -2.95 sub(es15, )
+Simulating Particle :ps26  :10261446638302134298: pdgid =    22, status =   1, q =  0, e =   1.7, theta = -1.17, phi =  1.49, mass =  0.00
+Simulating Photon
+Made Cluster: et18  :3352924809915793426:    1.71 -1.17  1.49 sub(et18, )
+Made SmearedCluster: es16  :3343923022783315984:    2.03 -1.17  1.49 sub(es16, )
+Simulating Particle :ps27  :10261446622378459163: pdgid =    22, status =   1, q =  0, e =   1.7, theta = -1.10, phi =  1.43, mass =  0.00
+Simulating Photon
+Made Cluster: et19  :3352924793992118291:    1.71 -1.10  1.43 sub(et19, )
+Made SmearedCluster: es17  :3343921743176663057:    1.94 -1.10  1.43 sub(es17, )
+Simulating Particle :ps28  :10261446399627362332: pdgid =  -211, status =   1, q = -1, e =   1.7, theta = -0.87, phi =  1.31, mass =  0.14
+Simulating Hadron
+Made Track: tt12  :7964610488455659532:    1.69    1.10 -0.87  1.31
+Made SmearedTrack: ts11  :7955603274682335243:    1.69    1.10 -0.87  1.31
+Made Cluster: et20  :3352861178157072404:    0.14 -0.91  2.06 sub(et20, )
+Made SmearedCluster: es18  :3341670923508908050:   -0.93 -0.91  2.06 sub(es18, )
+Rejected SmearedCluster: es18  :3341670923508908050:   -0.93 -0.91  2.06 sub(es18, )
+Made Cluster: ht11  :5658765178389397515:    1.56 -0.98  2.46 sub(ht11, )
+Made SmearedCluster: hs5   :5649764526353022981:    1.93 -0.98  2.46 sub(hs5, )
+Rejected SmearedCluster: hs5   :5649764526353022981:    1.93 -0.98  2.46 sub(hs5, )
+Simulating Particle :ps29  :10261444179055869981: pdgid =  -211, status =   1, q = -1, e =   1.6, theta =  0.84, phi = -3.01, mass =  0.14
+Simulating Hadron
+Made Track: tt13  :7964608259713662989:    1.56    1.04  0.84 -3.01
+Made SmearedTrack: ts12  :7955601641942548492:    1.60    1.06  0.84 -3.01
+Made Cluster: et21  :3352905167337947157:    0.80  0.90 -2.21 sub(et21, )
+Made SmearedCluster: es18  :3341670923508908050:   -0.03  0.90 -2.21 sub(es18, )
+Rejected SmearedCluster: es18  :3341670923508908050:   -0.03  0.90 -2.21 sub(es18, )
+Made Cluster: ht12  :5658747358840619020:    0.77  0.98 -1.74 sub(ht12, )
+Made SmearedCluster: hs5   :5649741862968229893:    0.82  0.98 -1.74 sub(hs5, )
+Rejected SmearedCluster: hs5   :5649741862968229893:    0.82  0.98 -1.74 sub(hs5, )
+Simulating Particle :ps30  :10261443033799065630: pdgid =    22, status =   1, q =  0, e =   1.5, theta =  0.92, phi = -2.80, mass =  0.00
+Simulating Photon
+Made Cluster: et22  :3352921205412724758:    1.50  0.92 -2.80 sub(et22, )
+Made SmearedCluster: es18  :3343912997144756242:    1.45  0.92 -2.80 sub(es18, )
+Simulating Particle :ps31  :10261442412494716959: pdgid =    22, status =   1, q =  0, e =   1.5, theta = -1.18, phi =  1.58, mass =  0.00
+Simulating Photon
+Made Cluster: et23  :3352920584108376087:    1.47 -1.18  1.58 sub(et23, )
+Made SmearedCluster: es19  :3343909538045624339:    1.25 -1.18  1.58 sub(es19, )
+Simulating Particle :ps32  :10261442362758660128: pdgid =   321, status =   1, q =  1, e =   1.5, theta =  0.66, phi =  2.39, mass =  0.49
+Simulating Hadron
+Made Track: tt14  :7964605046847438862:    1.38    1.09  0.66  2.39
+Made SmearedTrack: ts13  :7955597734996606989:    1.37    1.09  0.66  2.39
+Made Cluster: et24  :3352844023707467800:    0.07  0.71  1.65 sub(et24, )
+Made SmearedCluster: es20  :3343903326273011732:    0.95  0.71  1.65 sub(es20, )
+Made Cluster: ht13  :5658762315196006413:    1.40  0.85  0.95 sub(ht13, )
+Made SmearedCluster: hs5   :5649762598260834309:    1.82  0.85  0.95 sub(hs5, )
+Simulating Particle :ps33  :10261440724090224673: pdgid =    22, status =   1, q =  0, e =   1.4, theta =  1.05, phi = -2.87, mass =  0.00
+Simulating Photon
+Made Cluster: et25  :3352918895703883801:    1.37  1.05 -2.87 sub(et25, )
+Made SmearedCluster: es21  :3343912279774068757:    1.41  1.05 -2.87 sub(es21, )
+Simulating Particle :ps34  :10261436048269639714: pdgid =    22, status =   1, q =  0, e =   1.1, theta =  1.07, phi = -2.72, mass =  0.00
+Simulating Photon
+Made Cluster: et26  :3352914219883298842:    1.11  1.06 -2.72 sub(et26, )
+Made SmearedCluster: es22  :3343912664221876246:    1.43  1.06 -2.72 sub(es22, )
+Simulating Particle :ps35  :10261431921691066403: pdgid =    22, status =   1, q =  0, e =   0.9, theta = -1.07, phi =  1.56, mass =  0.00
+Simulating Photon
+Made Cluster: et27  :3352910093304725531:    0.94 -1.07  1.56 sub(et27, )
+Made SmearedCluster: es23  :3343904679942684695:    0.99 -1.07  1.56 sub(es23, )
+Simulating Particle :ps36  :10261431269931876388: pdgid =    22, status =   1, q =  0, e =   0.9, theta =  0.94, phi = -2.76, mass =  0.00
+Simulating Photon
+Made Cluster: et28  :3352909441545535516:    0.92  0.94 -2.76 sub(et28, )
+Made SmearedCluster: es24  :3343903802091634712:    0.96  0.94 -2.76 sub(es24, )
+Simulating Particle :ps37  :10261430672079978533: pdgid =   211, status =   1, q =  1, e =   0.9, theta =  0.97, phi = -2.37, mass =  0.14
+Simulating Hadron
+Made Track: tt15  :7964594479422242831:    0.89    0.50  0.97 -2.37
+Made SmearedTrack: ts14  :7955587180798148622:    0.89    0.50  0.97 -2.37
+Made Cluster: ht14  :5658751852907331598:    0.90  1.27  1.90 sub(ht14, )
+Made SmearedCluster: hs6   :5647513932722601990:   -8.07  1.27  1.90 sub(hs6, )
+Rejected SmearedCluster: hs6   :5647513932722601990:   -8.07  1.27  1.90 sub(hs6, )
+Simulating Particle :ps38  :10261429875862667302: pdgid =  -211, status =   1, q = -1, e =   0.9, theta =  0.69, phi =  2.32, mass =  0.14
+Simulating Hadron
+Made Track: tt16  :7964593673218293776:    0.87    0.67  0.69  2.32
+Made SmearedTrack: ts15  :7955586144349978639:    0.86    0.66  0.69  2.32
+Made Cluster: et29  :3352882803776684061:    0.33  1.09 -1.90 sub(et29, )
+Made SmearedCluster: es25  :3341670923508908057:   -1.51  1.09 -1.90 sub(es25, )
+Rejected SmearedCluster: es25  :3341670923508908057:   -1.51  1.09 -1.90 sub(es25, )
+Made Cluster: ht15  :5658739431717208079:    0.55  1.37 -1.28 sub(ht15, )
+Made SmearedCluster: hs6   :5647513932722601990:   -4.25  1.37 -1.28 sub(hs6, )
+Rejected SmearedCluster: hs6   :5647513932722601990:   -4.25  1.37 -1.28 sub(hs6, )
+Simulating Particle :ps39  :10261428469153923111: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  1.10, phi =  2.93, mass =  0.00
+Simulating Photon
+Made Cluster: et30  :3352906640767582238:    0.84  1.10  2.93 sub(et30, )
+Made SmearedCluster: es25  :3343903040496205849:    0.94  1.10  2.93 sub(es25, )
+Simulating Particle :ps40  :10261421844684865576: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.96, phi = -2.93, mass =  0.00
+Simulating Photon
+Made Cluster: et31  :3352900016298524703:    0.65  0.96 -2.93 sub(et31, )
+Made SmearedCluster: es26  :3343886070440787994:    0.48  0.96 -2.93 sub(es26, )
+Simulating Particle :ps41  :10261419919476260905: pdgid =  -211, status =   1, q = -1, e =   0.6, theta = -1.07, phi = -2.54, mass =  0.14
+Simulating Hadron
+Made Track: tt17  :7964583525714231313:    0.58    0.28 -1.07 -2.54
+Made SmearedTrack: ts16  :7955576224810532880:    0.58    0.28 -1.07 -2.54
+Rejected SmearedTrack: ts16  :7955576224810532880:    0.58    0.28 -1.07 -2.54
+Made Cluster: ht16  :5658741100303613968:    0.60 -1.53  0.37 sub(ht16, )
+Made SmearedCluster: hs6   :5647513932722601990:   -4.83 -1.53  0.37 sub(hs6, )
+Rejected SmearedCluster: hs6   :5647513932722601990:   -4.83 -1.53  0.37 sub(hs6, )
+Simulating Particle :ps42  :10261418976642859050: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.99, phi = -3.14, mass =  0.00
+Simulating Photon
+Made Cluster: et32  :3352897148256518176:    0.57  0.99 -3.14 sub(et32, )
+Made SmearedCluster: es27  :3343892519428554779:    0.64  0.99 -3.14 sub(es27, )
+Simulating Particle :ps43  :10261412616224112683: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.98, phi =  1.61, mass =  0.00
+Simulating Photon
+Made Cluster: et33  :3352890787837771809:    0.44 -0.98  1.61 sub(et33, )
+Made SmearedCluster: es28  :3341670923508908060:   -0.04 -0.98  1.61 sub(es28, )
+Rejected SmearedCluster: es28  :3341670923508908060:   -0.04 -0.98  1.61 sub(es28, )
+Simulating Particle :ps44  :10261409761928937516: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -1.05, phi =  1.62, mass =  0.00
+Simulating Photon
+Made Cluster: et34  :3352887933542596642:    0.40 -1.05  1.62 sub(et34, )
+Made SmearedCluster: es28  :3343877799556415516:    0.36 -1.05  1.62 sub(es28, )
+Simulating Particle :ps45  :10261408407363780653: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.98, phi = -2.78, mass =  0.00
+Simulating Photon
+Made Cluster: et35  :3352886578977439779:    0.38 -0.98 -2.78 sub(et35, )
+Made SmearedCluster: es29  :3343879442024890397:    0.38 -0.98 -2.78 sub(es29, )
+Simulating Particle :ps46  :10261405596748087342: pdgid =  -211, status =   1, q = -1, e =   0.3, theta =  0.79, phi = -2.80, mass =  0.14
+Simulating Hadron
+Made Track: tt18  :7964567705588072466:    0.31    0.22  0.79 -2.80
+Made SmearedTrack: ts16  :7955560594663276560:    0.32    0.22  0.79 -2.80
+Rejected SmearedTrack: ts16  :7955560594663276560:    0.32    0.22  0.79 -2.80
+Made Cluster: et36  :3352861639129956388:    0.14  1.39 -1.26 sub(et36, )
+Made SmearedCluster: es30  :3341670923508908062:   -1.39  1.39 -1.26 sub(es30, )
+Rejected SmearedCluster: es30  :3341670923508908062:   -1.39  1.39 -1.26 sub(es30, )
+Made Cluster: ht17  :5658713722435141649:    0.20  1.52 -2.82 sub(ht17, )
+Made SmearedCluster: hs6   :5649738769014718470:    0.73  1.52 -2.82 sub(hs6, )
+Rejected SmearedCluster: hs6   :5649738769014718470:    0.73  1.52 -2.82 sub(hs6, )
+Simulating Particle :ps47  :10261390098754961455: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  0.66, phi = -2.77, mass =  0.00
+Simulating Photon
+Made Cluster: et37  :3352868270368620581:    0.19  0.66 -2.77 sub(et37, )
+Made SmearedCluster: es30  :3343876018493456414:    0.34  0.66 -2.77 sub(es30, )
+Simulating Particle :ps49  :10261376569228394545: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.63, phi = -3.07, mass =  0.00
+Simulating Photon
+Made Cluster: et38  :3352854740842053670:    0.11  0.63 -3.07 sub(et38, )
+Made SmearedCluster: es31  :3341670923508908063:   -0.01  0.63 -3.07 sub(es31, )
+Rejected SmearedCluster: es31  :3341670923508908063:   -0.01  0.63 -3.07 sub(es31, )
+Simulating Particle :ps50  :10261367584314097714: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  0.84, phi = -2.39, mass =  0.00
+Simulating Photon
+Made Cluster: et39  :3352845755927756839:    0.08  0.84 -2.39 sub(et39, )
+Made SmearedCluster: es31  :3341670923508908063:   -0.08  0.84 -2.39 sub(es31, )
+Rejected SmearedCluster: es31  :3341670923508908063:   -0.08  0.84 -2.39 sub(es31, )
+Simulating Particle :ps51  :10261364981163360307: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -1.27, phi =  1.17, mass =  0.00
+Simulating Photon
+Made Cluster: et40  :3352843152777019432:    0.07 -1.26  1.17 sub(et40, )
+Made SmearedCluster: es31  :3341670923508908063:   -0.48 -1.26  1.17 sub(es31, )
+Rejected SmearedCluster: es31  :3341670923508908063:   -0.48 -1.26  1.17 sub(es31, )
+Simulating Particle :ps52  :10261333066058301492: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.35, phi =  0.05, mass =  0.00
+Simulating Photon
+Made Cluster: et41  :3352811237671960617:    0.02 -0.35  0.05 sub(et41, )
+Made SmearedCluster: es31  :3343801357984333855:    0.02 -0.35  0.05 sub(es31, )
+Rejected SmearedCluster: es31  :3343801357984333855:    0.02 -0.35  0.05 sub(es31, )
+Simulating Particle :ps53  :10261317773806272565: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.85, phi = -0.72, mass =  0.00
+Simulating Photon
+Made Cluster: et42  :3352795945419931690:    0.01 -0.86 -0.72 sub(et42, )
+Made SmearedCluster: es31  :3341670923508908063:   -0.14 -0.86 -0.72 sub(es31, )
+Rejected SmearedCluster: es31  :3341670923508908063:   -0.14 -0.86 -0.72 sub(es31, )
+Made MergedCluster: em0   :3289832822965010432:    0.34  0.66 -2.77 sub(es30, )
+Made MergedCluster: em1   :3289834604027969537:    0.36 -1.05  1.62 sub(es28, )
+Made MergedCluster: em2   :3289836246496444418:    0.38 -0.98 -2.78 sub(es29, )
+Made MergedCluster: em3   :3289842874912342019:    0.48  0.96 -2.93 sub(es26, )
+Made MergedCluster: em4   :3289849323900108804:    0.64  0.99 -3.14 sub(es27, )
+Made MergedCluster: em5   :3289859844967759877:    0.94  1.10  2.93 sub(es25, )
+Made MergedCluster: em6   :3289860130744565766:    0.95  0.71  1.65 sub(es20, )
+Made MergedCluster: em7   :3289860606563188743:    0.96  0.94 -2.76 sub(es24, )
+Made MergedCluster: em8   :3289903154526683144:    5.37 -1.07  1.57 sub(es6, es23, )
+Made MergedCluster: em9   :3289891073605763081:    3.31 -1.19  1.57 sub(es14, es19, )
+Made MergedCluster: em10  :3289869084245622794:    1.41  1.05 -2.87 sub(es21, )
+Made MergedCluster: em11  :3289869468693430283:    1.43  1.06 -2.72 sub(es22, )
+Made MergedCluster: em12  :3289869801616310284:    1.45  0.92 -2.80 sub(es18, )
+Made MergedCluster: em13  :3289917024794312717:    9.05  0.83 -2.97 sub(es5, es8, es15, )
+Made MergedCluster: em14  :3289878547648217102:    1.94 -1.10  1.43 sub(es17, )
+Made MergedCluster: em15  :3289937848794349583:   21.04 -1.04  1.51 sub(es0, es3, es11, )
+Made MergedCluster: em16  :3289879827254870032:    2.03 -1.17  1.49 sub(es16, )
+Made MergedCluster: em17  :3289881588537491473:    2.23  0.97 -2.89 sub(es12, )
+Made MergedCluster: em18  :3289887650986590226:    2.92  0.88  2.92 sub(es13, )
+Made MergedCluster: em19  :3289887890181455891:    2.95  0.85 -3.05 sub(es9, )
+Made MergedCluster: em20  :3289914930324570132:    8.10 -1.01  1.43 sub(es1, es7, )
+Made MergedCluster: em21  :3289899001349931029:    4.43  0.91 -3.10 sub(es4, )
+Made MergedCluster: em22  :3289909655802740758:    6.85 -1.13  1.00 sub(es10, )
+Made MergedCluster: em23  :3289910175483297815:    6.97 -1.06  1.44 sub(es2, )
+Made MergedCluster: hm0   :5595719402732388352:    1.82  0.85  0.95 sub(hs5, )
+Made MergedCluster: hm1   :5595740087607361537:    4.00 -1.14  0.84 sub(hs3, )
+Made MergedCluster: hm2   :5595743214035271682:    4.70  0.89  2.84 sub(hs2, )
+Made MergedCluster: hm3   :5595745959811219459:    5.33  0.91  2.62 sub(hs4, )
+Made MergedCluster: hm4   :5595761563345616900:    9.75 -1.08  1.62 sub(hs1, )
+Made MergedCluster: hm5   :5595762313991815173:   10.09  1.03 -2.97 sub(hs0, )
+Made block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289832822965010432)
+
+Made block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.4 (3289834604027969537)
+
+Made block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.4 (3289836246496444418)
+
+Made block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.5 (3289842874912342019)
+
+Made block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.6 (3289849323900108804)
+
+Made block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.9 (3289859844967759877)
+
+Made block:E1H1T1   :br6   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  1.4 (7955597734996606989)
+      h1 = hm0       value=  1.8 (5595719402732388352)
+      e2 = em6       value=  0.9 (3289860130744565766)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  1.0 (3289860606563188743)
+
+Made block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  1.4 (3289869084245622794)
+
+Made block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.4 (3289869468693430283)
+
+Made block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  1.4 (3289869801616310284)
+
+Made block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  1.9 (3289878547648217102)
+
+Made block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  2.0 (3289879827254870032)
+
+Made block:E1       :br13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  2.2 (3289881588537491473)
+
+Made block:E1H1T1   :br14  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  2.3 (7955611315775471625)
+      h1 = hm3       value=  5.3 (5595745959811219459)
+      e2 = em18      value=  2.9 (3289887650986590226)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1       :br15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  3.0 (3289887890181455891)
+
+Made block:E1       :br16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  3.3 (3289891073605763081)
+
+Made block:E1       :br17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  4.4 (3289899001349931029)
+
+Made block:E1       :br18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  5.4 (3289903154526683144)
+
+Made block:E1H1T1   :br19  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts8       value=  2.4 (7955611987625377800)
+      h1 = hm1       value=  4.0 (5595740087607361537)
+      e2 = em22      value=  6.9 (3289909655802740758)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1       :br20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  7.0 (3289910175483297815)
+
+Made block:E1T1     :br21  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts3       value=  8.4 (7955644816132407299)
+      e1 = em20      value=  8.1 (3289914930324570132)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  9.1 (3289917024794312717)
+
+Made block:E1H1T1   :br23  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  4.1 (7955626772236599302)
+      h1 = hm4       value=  9.7 (5595761563345616900)
+      e2 = em15      value= 21.0 (3289937848794349583)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0290     ---       .
+
+Made block:H1T1     :br24  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  3.2 (7955619701491499015)
+      h1 = hm2       value=  4.7 (5595743214035271682)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br25  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  7.3 (7955640775138607108)
+      h1 = hm5       value= 10.1 (5595762313991815173)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:T1       :br26  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  0.9 (7955586144349978639)
+
+Made block:T1       :br27  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  0.9 (7955587180798148622)
+
+Made block:T1       :br28  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.6 (7955601641942548492)
+
+Made block:T1       :br29  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  1.7 (7955603274682335243)
+
+Made block:T1       :br30  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  2.2 (7955610784543801354)
+
+Made block:T1       :br31  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts5       value=  4.3 (7955627777930035205)
+
+Made block:T1       :br32  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts2       value=  9.9 (7955648006064177154)
+
+Made block:T1       :br33  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 39.5 (7955683257217974273)
+
+Made block:T1       :br34  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 60.3 (7955694662570737664)
+
+Splitting block:E1H1T1   :br23  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  4.1 (7955626772236599302)
+      h1 = hm4       value=  9.7 (5595761563345616900)
+      e2 = em15      value= 21.0 (3289937848794349583)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0290     ---       .
+
+Made block:E1H1T1   :bs0   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  4.1 (7955626772236599302)
+      h1 = hm4       value=  9.7 (5595761563345616900)
+      e2 = em15      value= 21.0 (3289937848794349583)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0290     ---       .
+
+Splitting block:E1H1T1   :br19  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts8       value=  2.4 (7955611987625377800)
+      h1 = hm1       value=  4.0 (5595740087607361537)
+      e2 = em22      value=  6.9 (3289909655802740758)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs1   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts8       value=  2.4 (7955611987625377800)
+      h1 = hm1       value=  4.0 (5595740087607361537)
+      e2 = em22      value=  6.9 (3289909655802740758)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:E1H1T1   :br14  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  2.3 (7955611315775471625)
+      h1 = hm3       value=  5.3 (5595745959811219459)
+      e2 = em18      value=  2.9 (3289887650986590226)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  2.3 (7955611315775471625)
+      h1 = hm3       value=  5.3 (5595745959811219459)
+      e2 = em18      value=  2.9 (3289887650986590226)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:E1H1T1   :br6   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  1.4 (7955597734996606989)
+      h1 = hm0       value=  1.8 (5595719402732388352)
+      e2 = em6       value=  0.9 (3289860130744565766)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs3   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  1.4 (7955597734996606989)
+      h1 = hm0       value=  1.8 (5595719402732388352)
+      e2 = em6       value=  0.9 (3289860130744565766)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:H1T1     :br25  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  7.3 (7955640775138607108)
+      h1 = hm5       value= 10.1 (5595762313991815173)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs4   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  7.3 (7955640775138607108)
+      h1 = hm5       value= 10.1 (5595762313991815173)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br24  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  3.2 (7955619701491499015)
+      h1 = hm2       value=  4.7 (5595743214035271682)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs5   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  3.2 (7955619701491499015)
+      h1 = hm2       value=  4.7 (5595743214035271682)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:E1T1     :br21  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts3       value=  8.4 (7955644816132407299)
+      e1 = em20      value=  8.1 (3289914930324570132)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs6   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts3       value=  8.4 (7955644816132407299)
+      e1 = em20      value=  8.1 (3289914930324570132)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:T1       :br34  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 60.3 (7955694662570737664)
+
+Made block:T1       :bs7   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 60.3 (7955694662570737664)
+
+Splitting block:T1       :br33  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 39.5 (7955683257217974273)
+
+Made block:T1       :bs8   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 39.5 (7955683257217974273)
+
+Splitting block:T1       :br32  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts2       value=  9.9 (7955648006064177154)
+
+Made block:T1       :bs9   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts2       value=  9.9 (7955648006064177154)
+
+Splitting block:T1       :br31  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts5       value=  4.3 (7955627777930035205)
+
+Made block:T1       :bs10  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts5       value=  4.3 (7955627777930035205)
+
+Splitting block:T1       :br30  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  2.2 (7955610784543801354)
+
+Made block:T1       :bs11  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  2.2 (7955610784543801354)
+
+Splitting block:T1       :br29  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  1.7 (7955603274682335243)
+
+Made block:T1       :bs12  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  1.7 (7955603274682335243)
+
+Splitting block:T1       :br28  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.6 (7955601641942548492)
+
+Made block:T1       :bs13  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.6 (7955601641942548492)
+
+Splitting block:T1       :br27  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  0.9 (7955587180798148622)
+
+Made block:T1       :bs14  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  0.9 (7955587180798148622)
+
+Splitting block:T1       :br26  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  0.9 (7955586144349978639)
+
+Made block:T1       :bs15  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  0.9 (7955586144349978639)
+
+Splitting block:E1       :br22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  9.1 (3289917024794312717)
+
+Made block:E1       :bs16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  9.1 (3289917024794312717)
+
+Splitting block:E1       :br20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  7.0 (3289910175483297815)
+
+Made block:E1       :bs17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  7.0 (3289910175483297815)
+
+Splitting block:E1       :br18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  5.4 (3289903154526683144)
+
+Made block:E1       :bs18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  5.4 (3289903154526683144)
+
+Splitting block:E1       :br17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  4.4 (3289899001349931029)
+
+Made block:E1       :bs19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  4.4 (3289899001349931029)
+
+Splitting block:E1       :br16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  3.3 (3289891073605763081)
+
+Made block:E1       :bs20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  3.3 (3289891073605763081)
+
+Splitting block:E1       :br15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  3.0 (3289887890181455891)
+
+Made block:E1       :bs21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  3.0 (3289887890181455891)
+
+Splitting block:E1       :br13  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  2.2 (3289881588537491473)
+
+Made block:E1       :bs22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  2.2 (3289881588537491473)
+
+Splitting block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  2.0 (3289879827254870032)
+
+Made block:E1       :bs23  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  2.0 (3289879827254870032)
+
+Splitting block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  1.9 (3289878547648217102)
+
+Made block:E1       :bs24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  1.9 (3289878547648217102)
+
+Splitting block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  1.4 (3289869801616310284)
+
+Made block:E1       :bs25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  1.4 (3289869801616310284)
+
+Splitting block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.4 (3289869468693430283)
+
+Made block:E1       :bs26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.4 (3289869468693430283)
+
+Splitting block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  1.4 (3289869084245622794)
+
+Made block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  1.4 (3289869084245622794)
+
+Splitting block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  1.0 (3289860606563188743)
+
+Made block:E1       :bs28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  1.0 (3289860606563188743)
+
+Splitting block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.9 (3289859844967759877)
+
+Made block:E1       :bs29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.9 (3289859844967759877)
+
+Splitting block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.6 (3289849323900108804)
+
+Made block:E1       :bs30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.6 (3289849323900108804)
+
+Splitting block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.5 (3289842874912342019)
+
+Made block:E1       :bs31  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.5 (3289842874912342019)
+
+Splitting block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.4 (3289836246496444418)
+
+Made block:E1       :bs32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.4 (3289836246496444418)
+
+Splitting block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.4 (3289834604027969537)
+
+Made block:E1       :bs33  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.4 (3289834604027969537)
+
+Splitting block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289832822965010432)
+
+Made block:E1       :bs34  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289832822965010432)
+
+Processing block:E1H1T1   :bs3   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts13      value=  1.4 (7955597734996606989)
+      h1 = hm0       value=  1.8 (5595719402732388352)
+      e2 = em6       value=  0.9 (3289860130744565766)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr0   :10252433668301651968: pdgid =   211, status =   1, q =  1, e =   1.4, theta =  0.66, phi =  2.39, mass =  0.14 from SmearedTrack: ts13  :7955597734996606989:    1.37    1.09  0.66  2.39
+Finished block
+Processing block:E1H1T1   :bs2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  2.3 (7955611315775471625)
+      h1 = hm3       value=  5.3 (5595745959811219459)
+      e2 = em18      value=  2.9 (3289887650986590226)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr1   :10252447162763837441: pdgid =   211, status =   1, q =  1, e =   2.3, theta =  0.85, phi = -2.85, mass =  0.14 from SmearedTrack: ts9   :7955611315775471625:    2.29    1.51  0.85 -2.85
+Finished block
+Processing block:E1H1T1   :bs1   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts8       value=  2.4 (7955611987625377800)
+      h1 = hm1       value=  4.0 (5595740087607361537)
+      e2 = em22      value=  6.9 (3289909655802740758)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr2   :10252447833422561282: pdgid =   211, status =   1, q =  1, e =   2.4, theta = -1.11, phi =  1.54, mass =  0.14 from SmearedTrack: ts8   :7955611987625377800:    2.37    1.05 -1.11  1.54
+Finished block
+Processing block:E1H1T1   :bs0   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  4.1 (7955626772236599302)
+      h1 = hm4       value=  9.7 (5595761563345616900)
+      e2 = em15      value= 21.0 (3289937848794349583)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0290     ---       .
+
+Made Particle :pr3   :10252462592555483139: pdgid =  -211, status =   1, q = -1, e =   4.1, theta = -1.07, phi =  1.20, mass =  0.14 from SmearedTrack: ts6   :7955626772236599302:    4.10    1.97 -1.07  1.20
+Made Particle :pr4   :10252469389523681284: pdgid =   130, status =   1, q =  0, e =   5.6, theta = -1.08, phi =  1.62, mass =  0.50 from MergedCluster: hm4   :5595761563345616900:    9.75 -1.08  1.62 sub(hs1, )
+Made Particle :pr5   :10252502872709136389: pdgid =    22, status =   1, q =  0, e =  21.0, theta = -1.08, phi =  1.62, mass =  0.00 from MergedCluster: hm4   :5595761563345616900:    9.75 -1.08  1.62 sub(hs1, )
+Finished block
+Processing block:E1T1     :bs6   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts3       value=  8.4 (7955644816132407299)
+      e1 = em20      value=  8.1 (3289914930324570132)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr6   :10252480628618428422: pdgid =   211, status =   1, q =  1, e =   8.4, theta = -1.01, phi =  1.58, mass =  0.14 from SmearedTrack: ts3   :7955644816132407299:    8.40    4.47 -1.01  1.58
+Finished block
+Processing block:H1T1     :bs5   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  3.2 (7955619701491499015)
+      h1 = hm2       value=  4.7 (5595743214035271682)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr7   :10252455537616617479: pdgid =   211, status =   1, q =  1, e =   3.2, theta =  0.86, phi = -2.95, mass =  0.14 from SmearedTrack: ts7   :7955619701491499015:    3.25    2.11  0.86 -2.95
+Finished block
+Processing block:H1T1     :bs4   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  7.3 (7955640775138607108)
+      h1 = hm5       value= 10.1 (5595762313991815173)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr8   :10252476590931836936: pdgid =  -211, status =   1, q = -1, e =   7.3, theta =  1.03, phi =  3.08, mass =  0.14 from SmearedTrack: ts4   :7955640775138607108:    7.28    3.76  1.03  3.08
+Finished block
+Processing block:E1       :bs34  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289832822965010432)
+
+Made Particle :pr9   :10252397846879797257: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.66, phi = -2.77, mass =  0.00 from MergedCluster: em0   :3289832822965010432:    0.34  0.66 -2.77 sub(es30, )
+Finished block
+Processing block:E1       :bs33  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.4 (3289834604027969537)
+
+Made Particle :pr10  :10252399627942756362: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -1.05, phi =  1.62, mass =  0.00 from MergedCluster: em1   :3289834604027969537:    0.36 -1.05  1.62 sub(es28, )
+Finished block
+Processing block:E1       :bs32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.4 (3289836246496444418)
+
+Made Particle :pr11  :10252401270411231243: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.98, phi = -2.78, mass =  0.00 from MergedCluster: em2   :3289836246496444418:    0.38 -0.98 -2.78 sub(es29, )
+Finished block
+Processing block:E1       :bs31  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.5 (3289842874912342019)
+
+Made Particle :pr12  :10252407898827128844: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.96, phi = -2.93, mass =  0.00 from MergedCluster: em3   :3289842874912342019:    0.48  0.96 -2.93 sub(es26, )
+Finished block
+Processing block:E1       :bs30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.6 (3289849323900108804)
+
+Made Particle :pr13  :10252414347814895629: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.99, phi = -3.14, mass =  0.00 from MergedCluster: em4   :3289849323900108804:    0.64  0.99 -3.14 sub(es27, )
+Finished block
+Processing block:E1       :bs29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value=  0.9 (3289859844967759877)
+
+Made Particle :pr14  :10252424868882546702: pdgid =    22, status =   1, q =  0, e =   0.9, theta =  1.10, phi =  2.93, mass =  0.00 from MergedCluster: em5   :3289859844967759877:    0.94  1.10  2.93 sub(es25, )
+Finished block
+Processing block:E1       :bs28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  1.0 (3289860606563188743)
+
+Made Particle :pr15  :10252425630477975567: pdgid =    22, status =   1, q =  0, e =   1.0, theta =  0.94, phi = -2.76, mass =  0.00 from MergedCluster: em7   :3289860606563188743:    0.96  0.94 -2.76 sub(es24, )
+Finished block
+Processing block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  1.4 (3289869084245622794)
+
+Made Particle :pr16  :10252434108160409616: pdgid =    22, status =   1, q =  0, e =   1.4, theta =  1.05, phi = -2.87, mass =  0.00 from MergedCluster: em10  :3289869084245622794:    1.41  1.05 -2.87 sub(es21, )
+Finished block
+Processing block:E1       :bs26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.4 (3289869468693430283)
+
+Made Particle :pr17  :10252434492608217105: pdgid =    22, status =   1, q =  0, e =   1.4, theta =  1.06, phi = -2.72, mass =  0.00 from MergedCluster: em11  :3289869468693430283:    1.43  1.06 -2.72 sub(es22, )
+Finished block
+Processing block:E1       :bs25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  1.4 (3289869801616310284)
+
+Made Particle :pr18  :10252434825531097106: pdgid =    22, status =   1, q =  0, e =   1.4, theta =  0.92, phi = -2.80, mass =  0.00 from MergedCluster: em12  :3289869801616310284:    1.45  0.92 -2.80 sub(es18, )
+Finished block
+Processing block:E1       :bs24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  1.9 (3289878547648217102)
+
+Made Particle :pr19  :10252443571563003923: pdgid =    22, status =   1, q =  0, e =   1.9, theta = -1.10, phi =  1.43, mass =  0.00 from MergedCluster: em14  :3289878547648217102:    1.94 -1.10  1.43 sub(es17, )
+Finished block
+Processing block:E1       :bs23  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em16      value=  2.0 (3289879827254870032)
+
+Made Particle :pr20  :10252444851169656852: pdgid =    22, status =   1, q =  0, e =   2.0, theta = -1.17, phi =  1.49, mass =  0.00 from MergedCluster: em16  :3289879827254870032:    2.03 -1.17  1.49 sub(es16, )
+Finished block
+Processing block:E1       :bs22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  2.2 (3289881588537491473)
+
+Made Particle :pr21  :10252446612452278293: pdgid =    22, status =   1, q =  0, e =   2.2, theta =  0.97, phi = -2.89, mass =  0.00 from MergedCluster: em17  :3289881588537491473:    2.23  0.97 -2.89 sub(es12, )
+Finished block
+Processing block:E1       :bs21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  3.0 (3289887890181455891)
+
+Made Particle :pr22  :10252452914096242710: pdgid =    22, status =   1, q =  0, e =   3.0, theta =  0.85, phi = -3.05, mass =  0.00 from MergedCluster: em19  :3289887890181455891:    2.95  0.85 -3.05 sub(es9, )
+Finished block
+Processing block:E1       :bs20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  3.3 (3289891073605763081)
+
+Made Particle :pr23  :10252456097520549911: pdgid =    22, status =   1, q =  0, e =   3.3, theta = -1.19, phi =  1.57, mass =  0.00 from MergedCluster: em9   :3289891073605763081:    3.31 -1.19  1.57 sub(es14, es19, )
+Finished block
+Processing block:E1       :bs19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  4.4 (3289899001349931029)
+
+Made Particle :pr24  :10252464025264717848: pdgid =    22, status =   1, q =  0, e =   4.4, theta =  0.91, phi = -3.10, mass =  0.00 from MergedCluster: em21  :3289899001349931029:    4.43  0.91 -3.10 sub(es4, )
+Finished block
+Processing block:E1       :bs18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  5.4 (3289903154526683144)
+
+Made Particle :pr25  :10252468178441469977: pdgid =    22, status =   1, q =  0, e =   5.4, theta = -1.07, phi =  1.57, mass =  0.00 from MergedCluster: em8   :3289903154526683144:    5.37 -1.07  1.57 sub(es6, es23, )
+Finished block
+Processing block:E1       :bs17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  7.0 (3289910175483297815)
+
+Made Particle :pr26  :10252475199398084634: pdgid =    22, status =   1, q =  0, e =   7.0, theta = -1.06, phi =  1.44, mass =  0.00 from MergedCluster: em23  :3289910175483297815:    6.97 -1.06  1.44 sub(es2, )
+Finished block
+Processing block:E1       :bs16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  9.1 (3289917024794312717)
+
+Made Particle :pr27  :10252482048709099547: pdgid =    22, status =   1, q =  0, e =   9.1, theta =  0.83, phi = -2.97, mass =  0.00 from MergedCluster: em13  :3289917024794312717:    9.05  0.83 -2.97 sub(es5, es8, es15, )
+Finished block
+Processing block:T1       :bs15  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  0.9 (7955586144349978639)
+
+Made Particle :pr28  :10252422348013568028: pdgid =  -211, status =   1, q = -1, e =   0.9, theta =  0.69, phi =  2.32, mass =  0.14 from SmearedTrack: ts15  :7955586144349978639:    0.86    0.66  0.69  2.32
+Finished block
+Processing block:T1       :bs14  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  0.9 (7955587180798148622)
+
+Made Particle :pr29  :10252423371549573149: pdgid =   211, status =   1, q =  1, e =   0.9, theta =  0.97, phi = -2.37, mass =  0.14 from SmearedTrack: ts14  :7955587180798148622:    0.89    0.50  0.97 -2.37
+Finished block
+Processing block:T1       :bs13  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  1.6 (7955601641942548492)
+
+Made Particle :pr30  :10252437558157901854: pdgid =  -211, status =   1, q = -1, e =   1.6, theta =  0.84, phi = -3.01, mass =  0.14 from SmearedTrack: ts12  :7955601641942548492:    1.60    1.06  0.84 -3.01
+Finished block
+Processing block:T1       :bs12  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  1.7 (7955603274682335243)
+
+Made Particle :pr31  :10252439185078091807: pdgid =  -211, status =   1, q = -1, e =   1.7, theta = -0.87, phi =  1.31, mass =  0.14 from SmearedTrack: ts11  :7955603274682335243:    1.69    1.10 -0.87  1.31
+Finished block
+Processing block:T1       :bs11  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  2.2 (7955610784543801354)
+
+Made Particle :pr32  :10252446632534605856: pdgid =  -211, status =   1, q = -1, e =   2.2, theta =  0.81, phi = -3.06, mass =  0.14 from SmearedTrack: ts10  :7955610784543801354:    2.23    1.55  0.81 -3.06
+Finished block
+Processing block:T1       :bs10  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts5       value=  4.3 (7955627777930035205)
+
+Made Particle :pr33  :10252463597701562401: pdgid =   211, status =   1, q =  1, e =   4.3, theta =  0.83, phi = -2.93, mass =  0.14 from SmearedTrack: ts5   :7955627777930035205:    4.33    2.92  0.83 -2.93
+Finished block
+Processing block:T1       :bs9   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts2       value=  9.9 (7955648006064177154)
+
+Made Particle :pr34  :10252483818179002402: pdgid =   211, status =   1, q =  1, e =   9.9, theta = -1.06, phi =  1.36, mass =  0.14 from SmearedTrack: ts2   :7955648006064177154:    9.86    4.79 -1.06  1.36
+Finished block
+Processing block:T1       :bs8   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 39.5 (7955683257217974273)
+
+Made Particle :pr35  :10252519067252424739: pdgid =    13, status =   1, q =  1, e =  39.5, theta = -0.06, phi =  0.61, mass =  0.10 from SmearedTrack: ts1   :7955683257217974273:   39.54   39.48 -0.06  0.61
+Finished block
+Processing block:T1       :bs7   : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 60.3 (7955694662570737664)
+
+Made Particle :pr36  :10252530472580022308: pdgid =   -13, status =   1, q = -1, e =  60.3, theta =  0.46, phi = -1.63, mass =  0.10 from SmearedTrack: ts0   :7955694662570737664:   60.29   53.99  0.46 -1.63
+Finished block
+Finished reconstruction
+Event: 8
+Made Particle :ps0   :10261534607033761792: pdgid =    13, status =   1, q = -1, e =  54.7, theta = -1.25, phi =  1.40, mass =  0.11
+Made Particle :ps1   :10261526215483457537: pdgid =   -13, status =   1, q =  1, e =  39.5, theta =  0.96, phi = -0.32, mass =  0.11
+Made Particle :ps2   :10261499699649314818: pdgid =    22, status =   1, q =  0, e =  13.8, theta = -1.57, phi = -2.91, mass =  0.00
+Made Particle :ps3   :10261488267782258691: pdgid =   211, status =   1, q =  1, e =   8.6, theta = -0.92, phi = -2.18, mass =  0.14
+Made Particle :ps4   :10261480000825851908: pdgid =  -211, status =   1, q = -1, e =   6.4, theta = -0.78, phi = -2.24, mass =  0.14
+Made Particle :ps5   :10261479734659514373: pdgid =   211, status =   1, q =  1, e =   6.4, theta =  1.45, phi =  2.79, mass =  0.14
+Made Particle :ps6   :10261476669904650246: pdgid =    22, status =   1, q =  0, e =   5.7, theta =  1.42, phi =  1.87, mass =  0.00
+Made Particle :ps7   :10261475226749501447: pdgid =   211, status =   1, q =  1, e =   5.3, theta = -0.87, phi = -2.17, mass =  0.14
+Made Particle :ps8   :10261469065990111240: pdgid =   211, status =   1, q =  1, e =   4.0, theta =  1.33, phi =  1.94, mass =  0.14
+Made Particle :ps9   :10261468950617391113: pdgid =    22, status =   1, q =  0, e =   4.0, theta =  1.46, phi =  0.58, mass =  0.00
+Made Particle :ps10  :10261468590318288906: pdgid =    22, status =   1, q =  0, e =   3.9, theta = -0.92, phi = -2.61, mass =  0.00
+Made Particle :ps11  :10261467841907654667: pdgid =  -211, status =   1, q = -1, e =   3.8, theta =  1.49, phi =  2.35, mass =  0.14
+Made Particle :ps12  :10261463972957913100: pdgid =    22, status =   1, q =  0, e =   3.4, theta =  1.40, phi =  1.74, mass =  0.00
+Made Particle :ps13  :10261463152726114317: pdgid =   211, status =   1, q =  1, e =   3.3, theta =  1.32, phi = -1.40, mass =  0.14
+Made Particle :ps14  :10261460346382319630: pdgid =    22, status =   1, q =  0, e =   3.0, theta = -0.92, phi = -2.37, mass =  0.00
+Made Particle :ps15  :10261460216277106703: pdgid =    22, status =   1, q =  0, e =   3.0, theta =  1.30, phi =  0.53, mass =  0.00
+Made Particle :ps16  :10261459511988453392: pdgid =  -211, status =   1, q = -1, e =   2.9, theta =  1.09, phi = -2.71, mass =  0.14
+Made Particle :ps17  :10261458723113271313: pdgid =   321, status =   1, q =  1, e =   2.8, theta = -0.83, phi = -2.24, mass =  0.49
+Made Particle :ps18  :10261458691744071698: pdgid =  -211, status =   1, q = -1, e =   2.8, theta = -0.87, phi =  2.39, mass =  0.14
+Made Particle :ps19  :10261455742479368211: pdgid =    22, status =   1, q =  0, e =   2.5, theta = -0.87, phi = -2.37, mass =  0.00
+Made Particle :ps20  :10261454998147694612: pdgid =   211, status =   1, q =  1, e =   2.4, theta = -0.16, phi =  2.56, mass =  0.14
+Made Particle :ps21  :10261454452642807829: pdgid =  -211, status =   1, q = -1, e =   2.3, theta =  1.23, phi =  0.68, mass =  0.14
+Made Particle :ps22  :10261454322283839510: pdgid =    22, status =   1, q =  0, e =   2.3, theta =  1.43, phi = -0.76, mass =  0.00
+Made Particle :ps23  :10261453696462225431: pdgid =    22, status =   1, q =  0, e =   2.2, theta =  1.25, phi =  0.59, mass =  0.00
+Made Particle :ps24  :10261453100856377368: pdgid =   211, status =   1, q =  1, e =   2.2, theta =  1.19, phi = -0.77, mass =  0.14
+Made Particle :ps25  :10261452892074410009: pdgid =  -211, status =   1, q = -1, e =   2.1, theta =  1.17, phi =  1.29, mass =  0.14
+Made Particle :ps26  :10261451286285123610: pdgid =    22, status =   1, q =  0, e =   2.0, theta =  1.26, phi =  1.26, mass =  0.00
+Made Particle :ps27  :10261451085581385755: pdgid = -2112, status =   1, q =  0, e =   2.0, theta = -0.14, phi = -2.64, mass =  0.94
+Made Particle :ps28  :10261449869111590940: pdgid =  -211, status =   1, q = -1, e =   1.9, theta =  1.29, phi =  1.31, mass =  0.14
+Made Particle :ps29  :10261449446936018973: pdgid =   211, status =   1, q =  1, e =   1.9, theta =  1.46, phi =  2.21, mass =  0.14
+Made Particle :ps30  :10261447817851568158: pdgid =  -321, status =   1, q = -1, e =   1.8, theta = -1.16, phi = -2.33, mass =  0.49
+Made Particle :ps31  :10261447521022771231: pdgid =    22, status =   1, q =  0, e =   1.8, theta =  1.49, phi =  1.03, mass =  0.00
+Made Particle :ps32  :10261445928864972832: pdgid =  -211, status =   1, q = -1, e =   1.7, theta =  1.32, phi =  1.65, mass =  0.14
+Made Particle :ps33  :10261442936648499233: pdgid =    22, status =   1, q =  0, e =   1.5, theta =  1.32, phi =  1.43, mass =  0.00
+Made Particle :ps34  :10261442213154127906: pdgid =  -211, status =   1, q = -1, e =   1.5, theta = -0.85, phi = -1.83, mass =  0.14
+Made Particle :ps35  :10261442090932109347: pdgid =   211, status =   1, q =  1, e =   1.5, theta =  1.45, phi = -2.69, mass =  0.14
+Made Particle :ps36  :10261441457239883812: pdgid =    22, status =   1, q =  0, e =   1.4, theta =  1.39, phi = -1.16, mass =  0.00
+Made Particle :ps37  :10261440844919734309: pdgid =   211, status =   1, q =  1, e =   1.4, theta =  1.19, phi =  2.30, mass =  0.14
+Made Particle :ps38  :10261440636674637862: pdgid =  -211, status =   1, q = -1, e =   1.4, theta = -0.79, phi = -2.42, mass =  0.14
+Made Particle :ps39  :10261438572143837223: pdgid =    22, status =   1, q =  0, e =   1.3, theta = -0.83, phi = -2.31, mass =  0.00
+Made Particle :ps40  :10261437961757261864: pdgid =  2112, status =   1, q =  0, e =   1.2, theta =  0.86, phi =  3.08, mass =  0.94
+Made Particle :ps41  :10261437108270923817: pdgid =   211, status =   1, q =  1, e =   1.2, theta =  1.01, phi =  0.55, mass =  0.14
+Made Particle :ps42  :10261436120266965034: pdgid =    22, status =   1, q =  0, e =   1.1, theta = -0.60, phi = -2.43, mass =  0.00
+Made Particle :ps43  :10261435976469446699: pdgid =    22, status =   1, q =  0, e =   1.1, theta = -0.40, phi =  2.45, mass =  0.00
+Made Particle :ps44  :10261435785196601388: pdgid =   211, status =   1, q =  1, e =   1.1, theta = -0.45, phi =  2.74, mass =  0.14
+Made Particle :ps45  :10261434785238876205: pdgid =  -211, status =   1, q = -1, e =   1.0, theta = -0.27, phi = -2.38, mass =  0.14
+Made Particle :ps46  :10261432755843760174: pdgid =  -211, status =   1, q = -1, e =   1.0, theta =  0.83, phi =  0.95, mass =  0.14
+Made Particle :ps47  :10261432440704729135: pdgid =    22, status =   1, q =  0, e =   1.0, theta =  1.04, phi = -0.15, mass =  0.00
+Made Particle :ps48  :10261428587766743088: pdgid =  -211, status =   1, q = -1, e =   0.8, theta =  1.08, phi = -0.43, mass =  0.14
+Made Particle :ps49  :10261427288048402481: pdgid =   211, status =   1, q =  1, e =   0.8, theta = -0.06, phi =  1.80, mass =  0.14
+Made Particle :ps50  :10261426841455689778: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  1.46, phi =  2.21, mass =  0.00
+Made Particle :ps51  :10261426143456395315: pdgid =  -211, status =   1, q = -1, e =   0.8, theta = -0.11, phi =  2.41, mass =  0.14
+Made Particle :ps52  :10261426045873815604: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  1.08, phi =  0.57, mass =  0.00
+Made Particle :ps53  :10261425511303479349: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  1.04, phi = -0.72, mass =  0.00
+Made Particle :ps54  :10261423930153631798: pdgid =  -211, status =   1, q = -1, e =   0.7, theta =  0.80, phi =  2.73, mass =  0.14
+Made Particle :ps55  :10261422289329324087: pdgid =    22, status =   1, q =  0, e =   0.7, theta = -1.04, phi = -1.58, mass =  0.00
+Made Particle :ps56  :10261421971816316984: pdgid =    22, status =   1, q =  0, e =   0.7, theta = -0.96, phi = -2.21, mass =  0.00
+Made Particle :ps57  :10261421579770527801: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.68, phi =  3.13, mass =  0.00
+Made Particle :ps58  :10261421500984721466: pdgid =   211, status =   1, q =  1, e =   0.6, theta =  1.41, phi =  2.22, mass =  0.14
+Made Particle :ps59  :10261421370860634171: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  1.31, phi =  1.47, mass =  0.00
+Made Particle :ps60  :10261418557860479036: pdgid =  -211, status =   1, q = -1, e =   0.6, theta = -0.94, phi = -2.69, mass =  0.14
+Made Particle :ps61  :10261416676278927421: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.71, phi = -2.70, mass =  0.00
+Made Particle :ps62  :10261416527947366462: pdgid =   211, status =   1, q =  1, e =   0.5, theta = -0.98, phi = -1.58, mass =  0.14
+Made Particle :ps63  :10261414079086198847: pdgid =  -211, status =   1, q = -1, e =   0.5, theta =  1.13, phi =  2.22, mass =  0.14
+Made Particle :ps64  :10261407963547697216: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  1.00, phi = -2.55, mass =  0.00
+Made Particle :ps65  :10261407403486478401: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.84, phi = -2.73, mass =  0.00
+Made Particle :ps66  :10261406165676064834: pdgid =   211, status =   1, q =  1, e =   0.4, theta = -0.80, phi =  2.51, mass =  0.14
+Made Particle :ps67  :10261405986038218819: pdgid =   211, status =   1, q =  1, e =   0.3, theta =  0.80, phi =  1.38, mass =  0.14
+Made Particle :ps68  :10261404403191775300: pdgid =  -211, status =   1, q = -1, e =   0.3, theta =  1.16, phi =  2.17, mass =  0.14
+Made Particle :ps69  :10261403526473187397: pdgid =   211, status =   1, q =  1, e =   0.3, theta =  0.79, phi = -0.12, mass =  0.14
+Made Particle :ps70  :10261402653223288902: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  1.02, phi =  0.45, mass =  0.00
+Made Particle :ps71  :10261400283678507079: pdgid =   211, status =   1, q =  1, e =   0.3, theta =  1.29, phi =  1.41, mass =  0.14
+Made Particle :ps72  :10261398704598548552: pdgid =   211, status =   1, q =  1, e =   0.2, theta =  0.28, phi = -1.84, mass =  0.14
+Made Particle :ps73  :10261393745123475529: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.39, phi =  1.95, mass =  0.00
+Made Particle :ps74  :10261392462136213578: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -1.43, phi =  0.55, mass =  0.00
+Made Particle :ps75  :10261391856755540043: pdgid =  -211, status =   1, q = -1, e =   0.2, theta =  0.46, phi = -0.41, mass =  0.14
+Made Particle :ps76  :10261391234369060940: pdgid =  -211, status =   1, q = -1, e =   0.2, theta = -0.01, phi =  3.00, mass =  0.14
+Made Particle :ps77  :10261387147990794317: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  1.32, phi = -1.45, mass =  0.00
+Made Particle :ps78  :10261386307139797070: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.32, phi =  2.87, mass =  0.00
+Made Particle :ps79  :10261386076255944783: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.30, phi =  2.12, mass =  0.00
+Made Particle :ps80  :10261386001312120912: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  1.20, phi =  1.95, mass =  0.00
+Made Particle :ps81  :10261384688941662289: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.80, phi =  2.28, mass =  0.00
+Made Particle :ps82  :10261383352734974034: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  1.52, phi = -1.53, mass =  0.00
+Made Particle :ps83  :10261371623546290259: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -1.12, phi =  0.85, mass =  0.00
+Made Particle :ps84  :10261363711392350292: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.87, phi = -0.39, mass =  0.00
+Made Particle :ps85  :10261356002274181205: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.03, phi = -3.02, mass =  0.00
+Made Particle :ps86  :10261331047044087894: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  0.38, phi =  2.71, mass =  0.00
+Made Particle :ps87  :10261319379469729879: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.15, phi = -1.09, mass =  0.00
+Made Particle :ps88  :10261296670635458648: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  0.55, phi =  1.54, mass =  0.00
+Simulating Particle :ps0   :10261534607033761792: pdgid =    13, status =   1, q = -1, e =  54.7, theta = -1.25, phi =  1.40, mass =  0.11
+Simulating Muon
+Made Track: tt0   :7964698797018185728:   54.71   17.20 -1.25  1.40
+Made SmearedTrack: ts0   :7955691134374641664:   53.87   16.93 -1.25  1.40
+Simulating Particle :ps1   :10261526215483457537: pdgid =   -13, status =   1, q =  1, e =  39.5, theta =  0.96, phi = -0.32, mass =  0.11
+Simulating Muon
+Made Track: tt1   :7964690405444812801:   39.45   22.52  0.96 -0.32
+Made SmearedTrack: ts1   :7955683815574208513:   40.56   23.16  0.96 -0.32
+Simulating Particle :ps2   :10261499699649314818: pdgid =    22, status =   1, q =  0, e =  13.8, theta = -1.57, phi = -2.91, mass =  0.00
+Simulating Photon
+Made Cluster: et0   :3352977871262973952:   13.80 -1.57 -2.91 sub(et0, )
+Made SmearedCluster: es0   :3343971112584216576:   14.00 -1.57 -2.91 sub(es0, )
+Rejected SmearedCluster: es0   :3343971112584216576:   14.00 -1.57 -2.91 sub(es0, )
+Simulating Particle :ps3   :10261488267782258691: pdgid =   211, status =   1, q =  1, e =   8.6, theta = -0.92, phi = -2.18, mass =  0.14
+Simulating Hadron
+Made Track: tt2   :7964652455336083458:    8.60    5.24 -0.92 -2.18
+Made SmearedTrack: ts2   :7955645796639047682:    8.85    5.39 -0.92 -2.18
+Made Cluster: et1   :3352948765725032449:    4.28 -0.92 -2.32 sub(et1, )
+Made SmearedCluster: es0   :3343946759576485888:    5.47 -0.92 -2.32 sub(es0, )
+Made Cluster: ht0   :5658791937908408320:    4.32 -0.92 -2.38 sub(ht0, )
+Made SmearedCluster: hs0   :5647513932722601984:   -4.01 -0.92 -2.38 sub(hs0, )
+Rejected SmearedCluster: hs0   :5647513932722601984:   -4.01 -0.92 -2.38 sub(hs0, )
+Simulating Particle :ps4   :10261480000825851908: pdgid =  -211, status =   1, q = -1, e =   6.4, theta = -0.78, phi = -2.24, mass =  0.14
+Simulating Hadron
+Made Track: tt3   :7964644184197955587:    6.42    4.56 -0.78 -2.24
+Made SmearedTrack: ts3   :7955636894434328579:    6.40    4.55 -0.78 -2.24
+Made Cluster: et2   :3352947956113211394:    4.10 -0.78 -2.08 sub(et2, )
+Made SmearedCluster: es1   :3343946747004059649:    5.46 -0.78 -2.08 sub(es1, )
+Made Cluster: ht1   :5658775772259680257:    2.32 -0.79 -2.00 sub(ht1, )
+Made SmearedCluster: hs0   :5649732941987708928:    0.57 -0.79 -2.00 sub(hs0, )
+Rejected SmearedCluster: hs0   :5649732941987708928:    0.57 -0.79 -2.00 sub(hs0, )
+Simulating Particle :ps5   :10261479734659514373: pdgid =   211, status =   1, q =  1, e =   6.4, theta =  1.45, phi =  2.79, mass =  0.14
+Simulating Hadron
+Made Track: tt4   :7964643917966606340:    6.36    0.77  1.45  2.79
+Made SmearedTrack: ts4   :7955636785921392644:    6.38    0.77  1.45  2.79
+Rejected SmearedTrack: ts4   :7955636785921392644:    6.38    0.77  1.45  2.79
+Made Cluster: et3   :3352948755946012675:    4.28  1.45  2.61 sub(et3, )
+Made SmearedCluster: es2   :3343924251544518658:    2.17  1.45  2.61 sub(es2, )
+Made Cluster: ht2   :5658773640259305474:    2.08  1.45  2.56 sub(ht2, )
+Made SmearedCluster: hs0   :5647513932722601984:   -1.92  1.45  2.56 sub(hs0, )
+Rejected SmearedCluster: hs0   :5647513932722601984:   -1.92  1.45  2.56 sub(hs0, )
+Simulating Particle :ps6   :10261476669904650246: pdgid =    22, status =   1, q =  0, e =   5.7, theta =  1.42, phi =  1.87, mass =  0.00
+Simulating Photon
+Made Cluster: et4   :3352954841518309380:    5.67  1.42  1.87 sub(et4, )
+Made SmearedCluster: es3   :3343950493442375683:    6.31  1.42  1.87 sub(es3, )
+Simulating Particle :ps7   :10261475226749501447: pdgid =   211, status =   1, q =  1, e =   5.3, theta = -0.87, phi = -2.17, mass =  0.14
+Simulating Hadron
+Made Track: tt5   :7964639408764747781:    5.34    3.44 -0.87 -2.17
+Made SmearedTrack: ts4   :7955632388090888196:    5.38    3.47 -0.87 -2.17
+Made Cluster: ht3   :5658796407576854531:    5.34 -0.88 -2.49 sub(ht3, )
+Made SmearedCluster: hs0   :5649787664375742464:    4.99 -0.88 -2.49 sub(hs0, )
+Simulating Particle :ps8   :10261469065990111240: pdgid =   211, status =   1, q =  1, e =   4.0, theta =  1.33, phi =  1.94, mass =  0.14
+Simulating Hadron
+Made Track: tt6   :7964633234436784134:    3.97    0.95  1.33  1.94
+Made SmearedTrack: ts5   :7955626156928008197:    3.98    0.95  1.33  1.94
+Made Cluster: ht4   :5658790246817464324:    3.97  1.34  1.55 sub(ht4, )
+Made SmearedCluster: hs1   :5649803627743674369:    9.23  1.34  1.55 sub(hs1, )
+Simulating Particle :ps9   :10261468950617391113: pdgid =    22, status =   1, q =  0, e =   4.0, theta =  1.46, phi =  0.58, mass =  0.00
+Simulating Photon
+Made Cluster: et5   :3352947122231050245:    3.96  1.46  0.58 sub(et5, )
+Made SmearedCluster: es4   :3343941037180583940:    4.16  1.46  0.58 sub(es4, )
+Simulating Particle :ps10  :10261468590318288906: pdgid =    22, status =   1, q =  0, e =   3.9, theta = -0.92, phi = -2.61, mass =  0.00
+Simulating Photon
+Made Cluster: et6   :3352946761931948038:    3.91 -0.92 -2.61 sub(et6, )
+Made SmearedCluster: es5   :3343937442469117957:    3.67 -0.92 -2.61 sub(es5, )
+Simulating Particle :ps11  :10261467841907654667: pdgid =  -211, status =   1, q = -1, e =   3.8, theta =  1.49, phi =  2.35, mass =  0.14
+Simulating Hadron
+Made Track: tt7   :7964632009567895559:    3.83    0.29  1.49  2.35
+Made SmearedTrack: ts6   :7955624817437179910:    3.83    0.29  1.49  2.35
+Rejected SmearedTrack: ts6   :7955624817437179910:    3.83    0.29  1.49  2.35
+Made Cluster: ht5   :5658789022735007749:    3.83  1.50  2.74 sub(ht5, )
+Made SmearedCluster: hs2   :5647513932722601986:   -0.83  1.50  2.74 sub(hs2, )
+Rejected SmearedCluster: hs2   :5647513932722601986:   -0.83  1.50  2.74 sub(hs2, )
+Simulating Particle :ps12  :10261463972957913100: pdgid =    22, status =   1, q =  0, e =   3.4, theta =  1.40, phi =  1.74, mass =  0.00
+Simulating Photon
+Made Cluster: et7   :3352942144571572231:    3.39  1.40  1.74 sub(et7, )
+Made SmearedCluster: es6   :3343934196392394758:    3.30  1.40  1.74 sub(es6, )
+Simulating Particle :ps13  :10261463152726114317: pdgid =   211, status =   1, q =  1, e =   3.3, theta =  1.32, phi = -1.40, mass =  0.14
+Simulating Hadron
+Made Track: tt8   :7964627316764573704:    3.29    0.80  1.32 -1.40
+Made SmearedTrack: ts6   :7955619885831159814:    3.27    0.80  1.32 -1.40
+Made Cluster: ht6   :5658784333553467398:    3.30  1.33 -1.86 sub(ht6, )
+Made SmearedCluster: hs2   :5649782633542975490:    3.92  1.33 -1.86 sub(hs2, )
+Simulating Particle :ps14  :10261460346382319630: pdgid =    22, status =   1, q =  0, e =   3.0, theta = -0.92, phi = -2.37, mass =  0.00
+Simulating Photon
+Made Cluster: et8   :3352938517995978760:    2.98 -0.92 -2.37 sub(et8, )
+Made SmearedCluster: es7   :3343930550470574087:    2.89 -0.92 -2.37 sub(es7, )
+Simulating Particle :ps15  :10261460216277106703: pdgid =    22, status =   1, q =  0, e =   3.0, theta =  1.30, phi =  0.53, mass =  0.00
+Simulating Photon
+Made Cluster: et9   :3352938387890765833:    2.96  1.30  0.53 sub(et9, )
+Made SmearedCluster: es8   :3343920054400974856:    1.85  1.30  0.53 sub(es8, )
+Simulating Particle :ps16  :10261459511988453392: pdgid =  -211, status =   1, q = -1, e =   2.9, theta =  1.09, phi = -2.71, mass =  0.14
+Simulating Hadron
+Made Track: tt9   :7964623672289787913:    2.88    1.33  1.09 -2.71
+Made SmearedTrack: ts7   :7955616040881225735:    2.83    1.31  1.09 -2.71
+Made Cluster: ht7   :5658780692815806471:    2.88  1.11 -2.13 sub(ht7, )
+Made SmearedCluster: hs3   :5647513932722601987:   -5.04  1.11 -2.13 sub(hs3, )
+Rejected SmearedCluster: hs3   :5647513932722601987:   -5.04  1.11 -2.13 sub(hs3, )
+Simulating Particle :ps17  :10261458723113271313: pdgid =   321, status =   1, q =  1, e =   2.8, theta = -0.83, phi = -2.24, mass =  0.49
+Simulating Hadron
+Made Track: tt10  :7964622526280105994:    2.75    1.86 -0.83 -2.24
+Made SmearedTrack: ts8   :7955615123677118472:    2.73    1.85 -0.83 -2.24
+Made Cluster: et10  :3352913578970578954:    1.07 -0.84 -2.65 sub(et10, )
+Made SmearedCluster: es9   :3341670923508908041:   -0.17 -0.84 -2.65 sub(es9, )
+Rejected SmearedCluster: es9   :3341670923508908041:   -0.17 -0.84 -2.65 sub(es9, )
+Made Cluster: ht8   :5658768035324887048:    1.72 -0.86 -2.86 sub(ht8, )
+Made SmearedCluster: hs3   :5647513932722601987:   -0.65 -0.86 -2.86 sub(hs3, )
+Rejected SmearedCluster: hs3   :5647513932722601987:   -0.65 -0.86 -2.86 sub(hs3, )
+Simulating Particle :ps18  :10261458691744071698: pdgid =  -211, status =   1, q = -1, e =   2.8, theta = -0.87, phi =  2.39, mass =  0.14
+Simulating Hadron
+Made Track: tt11  :7964622851049259019:    2.79    1.80 -0.87  2.39
+Made SmearedTrack: ts9   :7955615371906514953:    2.75    1.78 -0.87  2.39
+Made Cluster: et11  :3352895630084145163:    0.53 -0.88  2.82 sub(et11, )
+Made SmearedCluster: es9   :3341670923508908041:   -1.77 -0.88  2.82 sub(es9, )
+Rejected SmearedCluster: es9   :3341670923508908041:   -1.77 -0.88  2.82 sub(es9, )
+Made Cluster: ht9   :5658775251555713033:    2.26 -0.90  3.04 sub(ht9, )
+Made SmearedCluster: hs3   :5647513932722601987:   -1.53 -0.90  3.04 sub(hs3, )
+Rejected SmearedCluster: hs3   :5647513932722601987:   -1.53 -0.90  3.04 sub(hs3, )
+Simulating Particle :ps19  :10261455742479368211: pdgid =    22, status =   1, q =  0, e =   2.5, theta = -0.87, phi = -2.37, mass =  0.00
+Simulating Photon
+Made Cluster: et12  :3352933914093027340:    2.45 -0.87 -2.37 sub(et12, )
+Made SmearedCluster: es9   :3343926260895055881:    2.40 -0.87 -2.37 sub(es9, )
+Simulating Particle :ps20  :10261454998147694612: pdgid =   211, status =   1, q =  1, e =   2.4, theta = -0.16, phi =  2.56, mass =  0.14
+Simulating Hadron
+Made Track: tt12  :7964619151993995276:    2.37    2.33 -0.16  2.56
+Made SmearedTrack: ts10  :7955612158461476874:    2.39    2.36 -0.16  2.56
+Made Cluster: et13  :3352919952595091469:    1.43 -0.17  2.24 sub(et13, )
+Made SmearedCluster: es10  :3343910516228620298:    1.31 -0.17  2.24 sub(es10, )
+Made Cluster: ht10  :5658753083929264138:    0.94 -0.17  2.08 sub(ht10, )
+Made SmearedCluster: hs3   :5647513932722601987:   -0.49 -0.17  2.08 sub(hs3, )
+Rejected SmearedCluster: hs3   :5647513932722601987:   -0.49 -0.17  2.08 sub(hs3, )
+Simulating Particle :ps21  :10261454452642807829: pdgid =  -211, status =   1, q = -1, e =   2.3, theta =  1.23, phi =  0.68, mass =  0.14
+Simulating Hadron
+Made Track: tt13  :7964618605516029965:    2.30    0.77  1.23  0.68
+Made SmearedTrack: ts11  :7955611617352220683:    2.33    0.78  1.23  0.68
+Made Cluster: ht11  :5658775633470160907:    2.31  1.25  1.36 sub(ht11, )
+Made SmearedCluster: hs3   :5649778739519684611:    3.48  1.25  1.36 sub(hs3, )
+Simulating Particle :ps22  :10261454322283839510: pdgid =    22, status =   1, q =  0, e =   2.3, theta =  1.43, phi = -0.76, mass =  0.00
+Simulating Photon
+Made Cluster: et14  :3352932493897498638:    2.29  1.43 -0.76 sub(et14, )
+Made SmearedCluster: es11  :3343921966466727947:    1.96  1.43 -0.76 sub(es11, )
+Simulating Particle :ps23  :10261453696462225431: pdgid =    22, status =   1, q =  0, e =   2.2, theta =  1.25, phi =  0.59, mass =  0.00
+Simulating Photon
+Made Cluster: et15  :3352931868075884559:    2.22  1.25  0.59 sub(et15, )
+Made SmearedCluster: es12  :3343928628506263564:    2.67  1.25  0.59 sub(es12, )
+Simulating Particle :ps24  :10261453100856377368: pdgid =   211, status =   1, q =  1, e =   2.2, theta =  1.19, phi = -0.77, mass =  0.14
+Simulating Hadron
+Made Track: tt14  :7964617251070410766:    2.15    0.80  1.19 -0.77
+Made SmearedTrack: ts12  :7955610226653134860:    2.17    0.81  1.19 -0.77
+Made Cluster: ht12  :5658774281683730444:    2.15  1.22 -1.51 sub(ht12, )
+Made SmearedCluster: hs4   :5647513932722601988:   -3.23  1.22 -1.51 sub(hs4, )
+Rejected SmearedCluster: hs4   :5647513932722601988:   -3.23  1.22 -1.51 sub(hs4, )
+Simulating Particle :ps25  :10261452892074410009: pdgid =  -211, status =   1, q = -1, e =   2.1, theta =  1.17, phi =  1.29, mass =  0.14
+Simulating Hadron
+Made Track: tt15  :7964617041843847183:    2.13    0.84  1.17  1.29
+Made SmearedTrack: ts13  :7955609805706493965:    2.12    0.83  1.17  1.29
+Made Cluster: ht13  :5658774072901763085:    2.13  1.20  2.05 sub(ht13, )
+Made SmearedCluster: hs4   :5649811727282339844:   12.92  1.20  2.05 sub(hs4, )
+Rejected SmearedCluster: hs4   :5649811727282339844:   12.92  1.20  2.05 sub(hs4, )
+Simulating Particle :ps26  :10261451286285123610: pdgid =    22, status =   1, q =  0, e =   2.0, theta =  1.26, phi =  1.26, mass =  0.00
+Simulating Photon
+Made Cluster: et16  :3352929457898782736:    1.97  1.26  1.26 sub(et16, )
+Made SmearedCluster: es13  :3343922261800255501:    1.97  1.26  1.26 sub(es13, )
+Simulating Particle :ps27  :10261451085581385755: pdgid = -2112, status =   1, q =  0, e =   2.0, theta = -0.14, phi = -2.64, mass =  0.94
+Simulating Hadron
+Made Cluster: et17  :3352904588102467601:    0.78 -0.14 -2.64 sub(et17, )
+Made SmearedCluster: es14  :3341670923508908046:   -4.16 -0.14 -2.64 sub(es14, )
+Rejected SmearedCluster: es14  :3341670923508908046:   -4.16 -0.14 -2.64 sub(es14, )
+Made Cluster: ht14  :5658758545368154126:    1.18 -0.14 -2.64 sub(ht14, )
+Made SmearedCluster: hs4   :5649769100679839748:    2.38 -0.14 -2.64 sub(hs4, )
+Simulating Particle :ps28  :10261449869111590940: pdgid =  -211, status =   1, q = -1, e =   1.9, theta =  1.29, phi =  1.31, mass =  0.14
+Simulating Hadron
+Made Track: tt16  :7964613968513728528:    1.89    0.53  1.29  1.31
+Made SmearedTrack: ts14  :7955607716605460494:    1.94    0.55  1.29  1.31
+Made Cluster: et18  :3352906543692513298:    0.84  1.30  1.94 sub(et18, )
+Made SmearedCluster: es14  :3343924749972537358:    2.23  1.30  1.94 sub(es14, )
+Made Cluster: ht15  :5658756351101239311:    1.06  1.31  2.13 sub(ht15, )
+Made SmearedCluster: hs5   :5647513932722601989:   -4.45  1.31  2.13 sub(hs5, )
+Rejected SmearedCluster: hs5   :5647513932722601989:   -4.45  1.31  2.13 sub(hs5, )
+Simulating Particle :ps29  :10261449446936018973: pdgid =   211, status =   1, q =  1, e =   1.9, theta =  1.46, phi =  2.21, mass =  0.14
+Simulating Hadron
+Made Track: tt17  :7964613545174237201:    1.86    0.21  1.46  2.21
+Made SmearedTrack: ts15  :7955606362296156175:    1.86    0.21  1.46  2.21
+Rejected SmearedTrack: ts15  :7955606362296156175:    1.86    0.21  1.46  2.21
+Made Cluster: ht16  :5658770627763372048:    1.87  1.47  1.41 sub(ht16, )
+Made SmearedCluster: hs5   :5649762361544802309:    1.81  1.47  1.41 sub(hs5, )
+Rejected SmearedCluster: hs5   :5649762361544802309:    1.81  1.47  1.41 sub(hs5, )
+Simulating Particle :ps30  :10261447817851568158: pdgid =  -321, status =   1, q = -1, e =   1.8, theta = -1.16, phi = -2.33, mass =  0.49
+Simulating Hadron
+Made Track: tt18  :7964610776851808274:    1.71    0.68 -1.16 -2.33
+Made SmearedTrack: ts15  :7955603763956285455:    1.72    0.69 -1.16 -2.33
+Made Cluster: ht17  :5658768998678921233:    1.78 -1.21 -1.38 sub(ht17, )
+Made SmearedCluster: hs5   :5649784493892960261:    4.27 -1.21 -1.38 sub(hs5, )
+Rejected SmearedCluster: hs5   :5649784493892960261:    4.27 -1.21 -1.38 sub(hs5, )
+Simulating Particle :ps31  :10261447521022771231: pdgid =    22, status =   1, q =  0, e =   1.8, theta =  1.49, phi =  1.03, mass =  0.00
+Simulating Photon
+Made Cluster: et19  :3352925692636430355:    1.76  1.49  1.03 sub(et19, )
+Made SmearedCluster: es15  :3343912979138609167:    1.45  1.49  1.03 sub(es15, )
+Rejected SmearedCluster: es15  :3343912979138609167:    1.45  1.49  1.03 sub(es15, )
+Simulating Particle :ps32  :10261445928864972832: pdgid =  -211, status =   1, q = -1, e =   1.7, theta =  1.32, phi =  1.65, mass =  0.14
+Simulating Hadron
+Made Track: tt19  :7964610016065880083:    1.66    0.41  1.32  1.65
+Made SmearedTrack: ts16  :7955602874480721936:    1.67    0.41  1.32  1.65
+Rejected SmearedTrack: ts16  :7955602874480721936:    1.67    0.41  1.32  1.65
+Made Cluster: et20  :3352828744317272084:    0.04  1.34  2.36 sub(et20, )
+Made SmearedCluster: es15  :3341670923508908047:  -11.54  1.34  2.36 sub(es15, )
+Rejected SmearedCluster: es15  :3341670923508908047:  -11.54  1.34  2.36 sub(es15, )
+Made Cluster: ht18  :5658766423223173138:    1.63  1.35  2.57 sub(ht18, )
+Made SmearedCluster: hs5   :5647513932722601989:   -2.82  1.35  2.57 sub(hs5, )
+Rejected SmearedCluster: hs5   :5647513932722601989:   -2.82  1.35  2.57 sub(hs5, )
+Simulating Particle :ps33  :10261442936648499233: pdgid =    22, status =   1, q =  0, e =   1.5, theta =  1.32, phi =  1.43, mass =  0.00
+Simulating Photon
+Made Cluster: et21  :3352921108262158357:    1.50  1.32  1.41 sub(et21, )
+Made SmearedCluster: es15  :3343922605160661007:    1.99  1.32  1.41 sub(es15, )
+Simulating Particle :ps34  :10261442213154127906: pdgid =  -211, status =   1, q = -1, e =   1.5, theta = -0.85, phi = -1.83, mass =  0.14
+Simulating Hadron
+Made Track: tt20  :7964606285389758484:    1.45    0.95 -0.85 -1.83
+Made SmearedTrack: ts16  :7955598739289145360:    1.43    0.94 -0.85 -1.83
+Made Cluster: et22  :3352895906161623062:    0.53 -0.92 -0.94 sub(et22, )
+Made SmearedCluster: es16  :3343840368452960272:    0.08 -0.92 -0.94 sub(es16, )
+Rejected SmearedCluster: es16  :3343840368452960272:    0.08 -0.92 -0.94 sub(es16, )
+Made Cluster: ht19  :5658752688215556115:    0.92 -1.01 -0.48 sub(ht19, )
+Made SmearedCluster: hs5   :5647513932722601989:   -1.13 -1.01 -0.48 sub(hs5, )
+Rejected SmearedCluster: hs5   :5647513932722601989:   -1.13 -1.01 -0.48 sub(hs5, )
+Simulating Particle :ps36  :10261441457239883812: pdgid =    22, status =   1, q =  0, e =   1.4, theta =  1.39, phi = -1.16, mass =  0.00
+Simulating Photon
+Made Cluster: et23  :3352919628853542935:    1.41  1.39 -1.16 sub(et23, )
+Made SmearedCluster: es16  :3343914394024149008:    1.53  1.39 -1.16 sub(es16, )
+Simulating Particle :ps37  :10261440844919734309: pdgid =   211, status =   1, q =  1, e =   1.4, theta =  1.19, phi =  2.30, mass =  0.14
+Simulating Hadron
+Made Track: tt21  :7964604910484324373:    1.37    0.52  1.19  2.30
+Made SmearedTrack: ts17  :7955597944516771857:    1.39    0.52  1.19  2.30
+Made Cluster: ht20  :5658762025747087380:    1.38  1.26  1.13 sub(ht20, )
+Made SmearedCluster: hs5   :5647513932722601989:  -10.57  1.26  1.13 sub(hs5, )
+Rejected SmearedCluster: hs5   :5647513932722601989:  -10.57  1.26  1.13 sub(hs5, )
+Simulating Particle :ps38  :10261440636674637862: pdgid =  -211, status =   1, q = -1, e =   1.4, theta = -0.79, phi = -2.42, mass =  0.14
+Simulating Hadron
+Made Track: tt22  :7964604701157097494:    1.36    0.95 -0.79 -2.42
+Made SmearedTrack: ts18  :7955597355181408274:    1.35    0.95 -0.79 -2.42
+Made Cluster: et24  :3352897374700699672:    0.57 -0.86 -1.53 sub(et24, )
+Made SmearedCluster: es17  :3341670923508908049:   -1.47 -0.86 -1.53 sub(es17, )
+Rejected SmearedCluster: es17  :3341670923508908049:   -1.47 -0.86 -1.53 sub(es17, )
+Made Cluster: ht21  :5658748066719596565:    0.79 -1.00 -0.89 sub(ht21, )
+Made SmearedCluster: hs5   :5647513932722601989:   -0.85 -1.00 -0.89 sub(hs5, )
+Rejected SmearedCluster: hs5   :5647513932722601989:   -0.85 -1.00 -0.89 sub(hs5, )
+Simulating Particle :ps39  :10261438572143837223: pdgid =    22, status =   1, q =  0, e =   1.3, theta = -0.83, phi = -2.31, mass =  0.00
+Simulating Photon
+Made Cluster: et25  :3352916743757496345:    1.25 -0.83 -2.31 sub(et25, )
+Made SmearedCluster: es17  :3343908885051211793:    1.21 -0.83 -2.31 sub(es17, )
+Simulating Particle :ps40  :10261437961757261864: pdgid =  2112, status =   1, q =  0, e =   1.2, theta =  0.86, phi =  3.08, mass =  0.94
+Simulating Hadron
+Made Cluster: et26  :3352898723645489178:    0.61  0.86  3.08 sub(et26, )
+Made SmearedCluster: es18  :3343849058117615634:    0.11  0.86  3.08 sub(es18, )
+Rejected SmearedCluster: es18  :3343849058117615634:    0.11  0.86  3.08 sub(es18, )
+Made Cluster: ht22  :5658741367940055062:    0.60  0.86  3.08 sub(ht22, )
+Made SmearedCluster: hs5   :5647513932722601989:   -3.28  0.86  3.08 sub(hs5, )
+Rejected SmearedCluster: hs5   :5647513932722601989:   -3.28  0.86  3.08 sub(hs5, )
+Simulating Particle :ps41  :10261437108270923817: pdgid =   211, status =   1, q =  1, e =   1.2, theta =  1.01, phi =  0.55, mass =  0.14
+Simulating Hadron
+Made Track: tt23  :7964601151041568791:    1.16    0.62  1.01  0.55
+Made SmearedTrack: ts19  :7955594205905027091:    1.17    0.63  1.01  0.55
+Made Cluster: ht23  :5658758289098276887:    1.17  1.17 -0.96 sub(ht23, )
+Made SmearedCluster: hs5   :5649793377892302853:    6.29  1.17 -0.96 sub(hs5, )
+Rejected SmearedCluster: hs5   :5649793377892302853:    6.29  1.17 -0.96 sub(hs5, )
+Simulating Particle :ps42  :10261436120266965034: pdgid =    22, status =   1, q =  0, e =   1.1, theta = -0.60, phi = -2.43, mass =  0.00
+Simulating Photon
+Made Cluster: et27  :3352914291880624155:    1.11 -0.60 -2.43 sub(et27, )
+Made SmearedCluster: es18  :3343913414257803282:    1.47 -0.60 -2.43 sub(es18, )
+Simulating Particle :ps43  :10261435976469446699: pdgid =    22, status =   1, q =  0, e =   1.1, theta = -0.40, phi =  2.45, mass =  0.00
+Simulating Photon
+Made Cluster: et28  :3352914148083105820:    1.10 -0.40  2.45 sub(et28, )
+Made SmearedCluster: es19  :3343901526113386515:    0.90 -0.40  2.45 sub(es19, )
+Simulating Particle :ps44  :10261435785196601388: pdgid =   211, status =   1, q =  1, e =   1.1, theta = -0.45, phi =  2.74, mass =  0.14
+Simulating Hadron
+Made Track: tt24  :7964599817747824664:    1.08    0.98 -0.45  2.74
+Made SmearedTrack: ts20  :7955592724145504276:    1.09    0.98 -0.45  2.74
+Made Cluster: et29  :3352901438033362973:    0.69 -0.50  1.87 sub(et29, )
+Made SmearedCluster: es20  :3343942377608839188:    4.47 -0.50  1.87 sub(es20, )
+Made Cluster: ht24  :5658730853442781208:    0.40 -1.57 -0.39 sub(ht24, )
+Made SmearedCluster: hs5   :5647513932722601989:   -5.51 -1.57 -0.39 sub(hs5, )
+Rejected SmearedCluster: hs5   :5647513932722601989:   -5.51 -1.57 -0.39 sub(hs5, )
+Simulating Particle :ps45  :10261434785238876205: pdgid =  -211, status =   1, q = -1, e =   1.0, theta = -0.27, phi = -2.38, mass =  0.14
+Simulating Hadron
+Made Track: tt25  :7964598809068044313:    1.03    0.99 -0.27 -2.38
+Made SmearedTrack: ts21  :7955591590410453013:    1.03    0.99 -0.27 -2.38
+Made Cluster: ht25  :5658755966066229273:    1.04 -1.11 -0.08 sub(ht25, )
+Made SmearedCluster: hs5   :5647513932722601989:   -3.43 -1.11 -0.08 sub(hs5, )
+Rejected SmearedCluster: hs5   :5647513932722601989:   -3.43 -1.11 -0.08 sub(hs5, )
+Simulating Particle :ps46  :10261432755843760174: pdgid =  -211, status =   1, q = -1, e =   1.0, theta =  0.83, phi =  0.95, mass =  0.14
+Simulating Hadron
+Made Track: tt26  :7964596587053711386:    0.95    0.64  0.83  0.95
+Made SmearedTrack: ts22  :7955589719528570902:    0.96    0.65  0.83  0.95
+Made Cluster: et30  :3352888327463239710:    0.41  1.06  2.57 sub(et30, )
+Made SmearedCluster: es21  :3343894271836028949:    0.69  1.06  2.57 sub(es21, )
+Made Cluster: ht26  :5658739549856071706:    0.55  1.22  3.06 sub(ht26, )
+Made SmearedCluster: hs5   :5649807068983459845:   10.80  1.22  3.06 sub(hs5, )
+Rejected SmearedCluster: hs5   :5649807068983459845:   10.80  1.22  3.06 sub(hs5, )
+Simulating Particle :ps47  :10261432440704729135: pdgid =    22, status =   1, q =  0, e =   1.0, theta =  1.04, phi = -0.15, mass =  0.00
+Simulating Photon
+Made Cluster: et31  :3352910612318388255:    0.95  1.04 -0.15 sub(et31, )
+Made SmearedCluster: es22  :3343905224868757526:    1.01  1.04 -0.15 sub(es22, )
+Simulating Particle :ps48  :10261428587766743088: pdgid =  -211, status =   1, q = -1, e =   0.8, theta =  1.08, phi = -0.43, mass =  0.14
+Simulating Hadron
+Made Track: tt27  :7964592367808282651:    0.83    0.39  1.08 -0.43
+Made SmearedTrack: ts23  :7955584816525606935:    0.82    0.39  1.08 -0.43
+Rejected SmearedTrack: ts23  :7955584816525606935:    0.82    0.39  1.08 -0.43
+Made Cluster: ht27  :5658749768594096155:    0.84  1.34  1.60 sub(ht27, )
+Made SmearedCluster: hs5   :5649782794646192133:    3.94  1.34  1.60 sub(hs5, )
+Rejected SmearedCluster: hs5   :5649782794646192133:    3.94  1.34  1.60 sub(hs5, )
+Simulating Particle :ps49  :10261427288048402481: pdgid =   211, status =   1, q =  1, e =   0.8, theta = -0.06, phi =  1.80, mass =  0.14
+Simulating Hadron
+Made Track: tt28  :7964591048986984476:    0.79    0.79 -0.06  1.80
+Made SmearedTrack: ts23  :7955584121741246487:    0.80    0.80 -0.06  1.80
+Made Cluster: et32  :3352879996031991840:    0.29 -0.08  0.59 sub(et32, )
+Made SmearedCluster: es23  :3343919844201332759:    1.84 -0.08  0.59 sub(es23, )
+Made Cluster: ht28  :5658738247776337948:    0.51 -1.17 -0.41 sub(ht28, )
+Made SmearedCluster: hs5   :5647513932722601989:   -4.24 -1.17 -0.41 sub(hs5, )
+Rejected SmearedCluster: hs5   :5647513932722601989:   -4.24 -1.17 -0.41 sub(hs5, )
+Simulating Particle :ps50  :10261426841455689778: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  1.46, phi =  2.21, mass =  0.00
+Simulating Photon
+Made Cluster: et33  :3352905013069348897:    0.79  1.46  2.21 sub(et33, )
+Made SmearedCluster: es24  :3343901471314804760:    0.90  1.46  2.21 sub(es24, )
+Rejected SmearedCluster: es24  :3343901471314804760:    0.90  1.46  2.21 sub(es24, )
+Simulating Particle :ps51  :10261426143456395315: pdgid =  -211, status =   1, q = -1, e =   0.8, theta = -0.11, phi =  2.41, mass =  0.14
+Simulating Hadron
+Made Track: tt29  :7964589886021828637:    0.76    0.76 -0.11  2.41
+Made SmearedTrack: ts24  :7955582705140236312:    0.76    0.76 -0.11  2.41
+Made Cluster: et34  :3352889460365721634:    0.42 -0.15 -2.50 sub(et34, )
+Made SmearedCluster: es24  :3343920515950575640:    1.87 -0.15 -2.50 sub(es24, )
+Made Cluster: ht29  :5658726994618089501:    0.35 -1.41 -1.05 sub(ht29, )
+Made SmearedCluster: hs5   :5647513932722601989:   -6.04 -1.41 -1.05 sub(hs5, )
+Rejected SmearedCluster: hs5   :5647513932722601989:   -6.04 -1.41 -1.05 sub(hs5, )
+Simulating Particle :ps52  :10261426045873815604: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  1.08, phi =  0.57, mass =  0.00
+Simulating Photon
+Made Cluster: et35  :3352904217487474723:    0.77  1.08  0.57 sub(et35, )
+Made SmearedCluster: es25  :3343899450230702105:    0.84  1.08  0.57 sub(es25, )
+Simulating Particle :ps53  :10261425511303479349: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  1.04, phi = -0.72, mass =  0.00
+Simulating Photon
+Made Cluster: et36  :3352903682917138468:    0.75  1.04 -0.72 sub(et36, )
+Made SmearedCluster: es26  :3343897710924136474:    0.79  1.04 -0.72 sub(es26, )
+Simulating Particle :ps54  :10261423930153631798: pdgid =  -211, status =   1, q = -1, e =   0.7, theta =  0.80, phi =  2.73, mass =  0.14
+Simulating Hadron
+Made Track: tt30  :7964587632273391646:    0.70    0.49  0.80  2.73
+Made SmearedTrack: ts25  :7955580282707378201:    0.69    0.48  0.80  2.73
+Rejected SmearedTrack: ts25  :7955580282707378201:    0.69    0.48  0.80  2.73
+Made Cluster: ht30  :5658745110980984862:    0.71  1.52 -0.58 sub(ht30, )
+Made SmearedCluster: hs5   :5649754989174718469:    1.39  1.52 -0.58 sub(hs5, )
+Rejected SmearedCluster: hs5   :5649754989174718469:    1.39  1.52 -0.58 sub(hs5, )
+Simulating Particle :ps55  :10261422289329324087: pdgid =    22, status =   1, q =  0, e =   0.7, theta = -1.04, phi = -1.58, mass =  0.00
+Simulating Photon
+Made Cluster: et37  :3352900460942983205:    0.66 -1.04 -1.58 sub(et37, )
+Made SmearedCluster: es27  :3343898510754840603:    0.81 -1.04 -1.58 sub(es27, )
+Simulating Particle :ps56  :10261421971816316984: pdgid =    22, status =   1, q =  0, e =   0.7, theta = -0.96, phi = -2.21, mass =  0.00
+Simulating Photon
+Made Cluster: et38  :3352900143429976102:    0.65 -0.96 -2.21 sub(et38, )
+Made SmearedCluster: es28  :3343874512012705820:    0.31 -0.96 -2.21 sub(es28, )
+Simulating Particle :ps57  :10261421579770527801: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.68, phi =  3.13, mass =  0.00
+Simulating Photon
+Made Cluster: et39  :3352899751384186919:    0.64 -0.68  3.13 sub(et39, )
+Made SmearedCluster: es29  :3343896508964536349:    0.75 -0.68  3.13 sub(es29, )
+Simulating Particle :ps59  :10261421370860634171: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  1.31, phi =  1.47, mass =  0.00
+Simulating Photon
+Made Cluster: et40  :3352899542474293288:    0.64  1.31  1.47 sub(et40, )
+Made SmearedCluster: es30  :3343878294171811870:    0.37  1.31  1.47 sub(es30, )
+Rejected SmearedCluster: es30  :3343878294171811870:    0.37  1.31  1.47 sub(es30, )
+Simulating Particle :ps60  :10261418557860479036: pdgid =  -211, status =   1, q = -1, e =   0.6, theta = -0.94, phi = -2.69, mass =  0.14
+Simulating Hadron
+Made Track: tt31  :7964582122212032543:    0.54    0.32 -0.94 -2.69
+Made SmearedTrack: ts25  :7955574895574777881:    0.54    0.32 -0.94 -2.69
+Rejected SmearedTrack: ts25  :7955574895574777881:    0.54    0.32 -0.94 -2.69
+Made Cluster: et41  :3352878879342592041:    0.27 -1.43 -0.07 sub(et41, )
+Made SmearedCluster: es30  :3343938907090714654:    3.84 -1.43 -0.07 sub(es30, )
+Made Cluster: ht31  :5658722404447289375:    0.28 -1.51 -2.43 sub(ht31, )
+Made SmearedCluster: hs5   :5647513932722601989:   -5.16 -1.51 -2.43 sub(hs5, )
+Rejected SmearedCluster: hs5   :5647513932722601989:   -5.16 -1.51 -2.43 sub(hs5, )
+Simulating Particle :ps61  :10261416676278927421: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.71, phi = -2.70, mass =  0.00
+Simulating Photon
+Made Cluster: et42  :3352894847892586538:    0.50  0.71 -2.70 sub(et42, )
+Made SmearedCluster: es31  :3343893977140035615:    0.68  0.71 -2.70 sub(es31, )
+Simulating Particle :ps62  :10261416527947366462: pdgid =   211, status =   1, q =  1, e =   0.5, theta = -0.98, phi = -1.58, mass =  0.14
+Simulating Hadron
+Made Track: tt32  :7964579317822783520:    0.48    0.27 -0.98 -1.58
+Made SmearedTrack: ts25  :7955572789688139801:    0.49    0.27 -0.98 -1.58
+Rejected SmearedTrack: ts25  :7955572789688139801:    0.49    0.27 -0.98 -1.58
+Made Cluster: ht32  :5658737708774719520:    0.50 -1.47 -2.16 sub(ht32, )
+Made SmearedCluster: hs5   :5649803773032267781:    9.30 -1.47 -2.16 sub(hs5, )
+Simulating Particle :ps64  :10261407963547697216: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  1.00, phi = -2.55, mass =  0.00
+Simulating Photon
+Made Cluster: et43  :3352886135161356331:    0.38  1.00 -2.55 sub(et43, )
+Made SmearedCluster: es32  :3343864515201597472:    0.21  1.00 -2.55 sub(es32, )
+Rejected SmearedCluster: es32  :3343864515201597472:    0.21  1.00 -2.55 sub(es32, )
+Simulating Particle :ps65  :10261407403486478401: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.84, phi = -2.73, mass =  0.00
+Simulating Photon
+Made Cluster: et44  :3352885575100137516:    0.37 -0.84 -2.73 sub(et44, )
+Made SmearedCluster: es32  :3343877443340468256:    0.36 -0.84 -2.73 sub(es32, )
+Simulating Particle :ps66  :10261406165676064834: pdgid =   211, status =   1, q =  1, e =   0.4, theta = -0.80, phi =  2.51, mass =  0.14
+Simulating Hadron
+Made Track: tt33  :7964568326611402785:    0.32    0.23 -0.80  2.51
+Made SmearedTrack: ts25  :7955561071656304665:    0.32    0.23 -0.80  2.51
+Rejected SmearedTrack: ts25  :7955561071656304665:    0.32    0.23 -0.80  2.51
+Made Cluster: et45  :3352813270357508141:    0.02 -1.38  0.73 sub(et45, )
+Made SmearedCluster: es33  :3341670923508908065:   -2.61 -1.38  0.73 sub(es33, )
+Rejected SmearedCluster: es33  :3341670923508908065:   -2.61 -1.38  0.73 sub(es33, )
+Made Cluster: ht33  :5658725841174003745:    0.33 -1.55  2.40 sub(ht33, )
+Made SmearedCluster: hs6   :5649767092432404486:    2.15 -1.55  2.40 sub(hs6, )
+Rejected SmearedCluster: hs6   :5649767092432404486:    2.15 -1.55  2.40 sub(hs6, )
+Simulating Particle :ps67  :10261405986038218819: pdgid =   211, status =   1, q =  1, e =   0.3, theta =  0.80, phi =  1.38, mass =  0.14
+Simulating Hadron
+Made Track: tt34  :7964568130821292066:    0.32    0.22  0.80  1.38
+Made SmearedTrack: ts25  :7955560828898377753:    0.32    0.22  0.80  1.38
+Rejected SmearedTrack: ts25  :7955560828898377753:    0.32    0.22  0.80  1.38
+Made Cluster: et46  :3352839324178579502:    0.06  1.38 -0.44 sub(et46, )
+Made SmearedCluster: es33  :3341670923508908065:   -2.45  1.38 -0.44 sub(es33, )
+Rejected SmearedCluster: es33  :3341670923508908065:   -2.45  1.38 -0.44 sub(es33, )
+Made Cluster: ht34  :5658723098501840930:    0.29  1.54  1.21 sub(ht34, )
+Made SmearedCluster: hs6   :5649756991281692678:    1.50  1.54  1.21 sub(hs6, )
+Rejected SmearedCluster: hs6   :5649756991281692678:    1.50  1.54  1.21 sub(hs6, )
+Simulating Particle :ps70  :10261402653223288902: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  1.02, phi =  0.45, mass =  0.00
+Simulating Photon
+Made Cluster: et47  :3352880824836948015:    0.30  1.05  0.49 sub(et47, )
+Made SmearedCluster: es33  :3343851961890897953:    0.12  1.05  0.49 sub(es33, )
+Rejected SmearedCluster: es33  :3343851961890897953:    0.12  1.05  0.49 sub(es33, )
+Simulating Particle :ps73  :10261393745123475529: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.39, phi =  1.95, mass =  0.00
+Simulating Photon
+Made Cluster: et48  :3352871916737134640:    0.21 -0.39  1.95 sub(et48, )
+Made SmearedCluster: es33  :3341670923508908065:   -0.03 -0.39  1.95 sub(es33, )
+Rejected SmearedCluster: es33  :3341670923508908065:   -0.03 -0.39  1.95 sub(es33, )
+Simulating Particle :ps74  :10261392462136213578: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -1.43, phi =  0.55, mass =  0.00
+Simulating Photon
+Made Cluster: et49  :3352870633749872689:    0.20 -1.43  0.55 sub(et49, )
+Made SmearedCluster: es33  :3343888337403379745:    0.52 -1.43  0.55 sub(es33, )
+Rejected SmearedCluster: es33  :3343888337403379745:    0.52 -1.43  0.55 sub(es33, )
+Simulating Particle :ps77  :10261387147990794317: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  1.32, phi = -1.45, mass =  0.00
+Simulating Photon
+Made Cluster: et50  :3352865319604453426:    0.17  1.32 -1.45 sub(et50, )
+Made SmearedCluster: es33  :3341670923508908065:   -0.21  1.32 -1.45 sub(es33, )
+Rejected SmearedCluster: es33  :3341670923508908065:   -0.21  1.32 -1.45 sub(es33, )
+Simulating Particle :ps78  :10261386307139797070: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.32, phi =  2.87, mass =  0.00
+Simulating Photon
+Made Cluster: et51  :3352864478753456179:    0.16 -0.32  2.87 sub(et51, )
+Made SmearedCluster: es33  :3341670923508908065:   -0.10 -0.32  2.87 sub(es33, )
+Rejected SmearedCluster: es33  :3341670923508908065:   -0.10 -0.32  2.87 sub(es33, )
+Simulating Particle :ps79  :10261386076255944783: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.30, phi =  2.12, mass =  0.00
+Simulating Photon
+Made Cluster: et52  :3352864247869603892:    0.16 -0.30  2.12 sub(et52, )
+Made SmearedCluster: es33  :3343875228919922721:    0.33 -0.30  2.12 sub(es33, )
+Simulating Particle :ps80  :10261386001312120912: pdgid =    22, status =   1, q =  0, e =   0.2, theta =  1.20, phi =  1.95, mass =  0.00
+Simulating Photon
+Made Cluster: et53  :3352864172925780021:    0.16  1.22  1.89 sub(et53, )
+Made SmearedCluster: es34  :3343878039854383138:    0.37  1.22  1.89 sub(es34, )
+Rejected SmearedCluster: es34  :3343878039854383138:    0.37  1.22  1.89 sub(es34, )
+Simulating Particle :ps81  :10261384688941662289: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.80, phi =  2.28, mass =  0.00
+Simulating Photon
+Made Cluster: et54  :3352862860555321398:    0.15 -0.80  2.28 sub(et54, )
+Made SmearedCluster: es34  :3343876887349821474:    0.35 -0.80  2.28 sub(es34, )
+Simulating Particle :ps82  :10261383352734974034: pdgid =    22, status =   1, q =  0, e =   0.1, theta =  1.52, phi = -1.53, mass =  0.00
+Simulating Photon
+Made Cluster: et55  :3352861524348633143:    0.14  1.52 -1.53 sub(et55, )
+Made SmearedCluster: es35  :3343857253949112355:    0.16  1.52 -1.53 sub(es35, )
+Rejected SmearedCluster: es35  :3343857253949112355:    0.16  1.52 -1.53 sub(es35, )
+Simulating Particle :ps83  :10261371623546290259: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -1.12, phi =  0.85, mass =  0.00
+Simulating Photon
+Made Cluster: et56  :3352849795159949368:    0.09 -1.12  0.85 sub(et56, )
+Made SmearedCluster: es35  :3341670923508908067:   -0.31 -1.12  0.85 sub(es35, )
+Rejected SmearedCluster: es35  :3341670923508908067:   -0.31 -1.12  0.85 sub(es35, )
+Simulating Particle :ps84  :10261363711392350292: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.87, phi = -0.39, mass =  0.00
+Simulating Photon
+Made Cluster: et57  :3352841883006009401:    0.06 -0.87 -0.39 sub(et57, )
+Made SmearedCluster: es35  :3343824183535599651:    0.04 -0.87 -0.39 sub(es35, )
+Rejected SmearedCluster: es35  :3343824183535599651:    0.04 -0.87 -0.39 sub(es35, )
+Simulating Particle :ps85  :10261356002274181205: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.03, phi = -3.02, mass =  0.00
+Simulating Photon
+Made Cluster: et58  :3352834173887840314:    0.05 -0.03 -3.02 sub(et58, )
+Made SmearedCluster: es35  :3343836947050135587:    0.07 -0.03 -3.02 sub(es35, )
+Rejected SmearedCluster: es35  :3343836947050135587:    0.07 -0.03 -3.02 sub(es35, )
+Simulating Particle :ps86  :10261331047044087894: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  0.38, phi =  2.71, mass =  0.00
+Simulating Photon
+Made Cluster: et59  :3352809218657747003:    0.02  0.38  2.71 sub(et59, )
+Made SmearedCluster: es35  :3341670923508908067:   -0.00  0.38  2.71 sub(es35, )
+Rejected SmearedCluster: es35  :3341670923508908067:   -0.00  0.38  2.71 sub(es35, )
+Simulating Particle :ps87  :10261319379469729879: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.15, phi = -1.09, mass =  0.00
+Simulating Photon
+Made Cluster: et60  :3352797551083388988:    0.01 -0.15 -1.09 sub(et60, )
+Made SmearedCluster: es35  :3341670923508908067:   -0.00 -0.15 -1.09 sub(es35, )
+Rejected SmearedCluster: es35  :3341670923508908067:   -0.00 -0.15 -1.09 sub(es35, )
+Simulating Particle :ps88  :10261296670635458648: pdgid =    22, status =   1, q =  0, e =   0.0, theta =  0.55, phi =  1.54, mass =  0.00
+Simulating Photon
+Made Cluster: et61  :3352774842249117757:    0.00  0.55  1.54 sub(et61, )
+Made SmearedCluster: es35  :3343788045596885027:    0.01  0.55  1.54 sub(es35, )
+Rejected SmearedCluster: es35  :3343788045596885027:    0.01  0.55  1.54 sub(es35, )
+Made MergedCluster: em0   :3289831316484259840:    0.31 -0.96 -2.21 sub(es28, )
+Made MergedCluster: em1   :3289832033391476737:    0.33 -0.30  2.12 sub(es33, )
+Made MergedCluster: em2   :3289833691821375490:    0.35 -0.80  2.28 sub(es34, )
+Made MergedCluster: em3   :3289834247812022275:    0.36 -0.84 -2.73 sub(es32, )
+Made MergedCluster: em4   :3289850781611589636:    0.68  0.71 -2.70 sub(es31, )
+Made MergedCluster: em5   :3289851076307582981:    0.69  1.06  2.57 sub(es21, )
+Made MergedCluster: em6   :3289853313436090374:    0.75 -0.68  3.13 sub(es29, )
+Made MergedCluster: em7   :3289854515395690503:    0.79  1.04 -0.72 sub(es26, )
+Made MergedCluster: em8   :3289855315226394632:    0.81 -1.04 -1.58 sub(es27, )
+Made MergedCluster: em9   :3289856254702256137:    0.84  1.08  0.57 sub(es25, )
+Made MergedCluster: em10  :3289858330584940554:    0.90 -0.40  2.45 sub(es19, )
+Made MergedCluster: em11  :3289862029340311563:    1.01  1.04 -0.15 sub(es22, )
+Made MergedCluster: em12  :3289865689522765836:    1.21 -0.83 -2.31 sub(es17, )
+Made MergedCluster: em13  :3289867320700174349:    1.31 -0.17  2.24 sub(es10, )
+Made MergedCluster: em14  :3289870218729357326:    1.47 -0.60 -2.43 sub(es18, )
+Made MergedCluster: em15  :3289871198495703055:    1.53  1.39 -1.16 sub(es16, )
+Made MergedCluster: em16  :3289876648672886800:    1.84 -0.08  0.59 sub(es23, )
+Made MergedCluster: em17  :3289876858872528913:    1.85  1.30  0.53 sub(es8, )
+Made MergedCluster: em18  :3289877320422129682:    1.87 -0.15 -2.50 sub(es24, )
+Made MergedCluster: em19  :3289878770938282003:    1.96  1.43 -0.76 sub(es11, )
+Made MergedCluster: em20  :3289879066271809556:    1.97  1.26  1.26 sub(es13, )
+Made MergedCluster: em21  :3289879409632215061:    1.99  1.32  1.41 sub(es15, )
+Made MergedCluster: em22  :3289881056016072726:    2.17  1.45  2.61 sub(es2, )
+Made MergedCluster: em23  :3289881554444091415:    2.23  1.30  1.94 sub(es14, )
+Made MergedCluster: em24  :3289883065366609944:    2.40 -0.87 -2.37 sub(es9, )
+Made MergedCluster: em25  :3289885432977817625:    2.67  1.25  0.59 sub(es12, )
+Made MergedCluster: em26  :3289915492940120090:    8.36 -0.92 -2.33 sub(es0, es7, )
+Made MergedCluster: em27  :3289891000863948827:    3.30  1.40  1.74 sub(es6, )
+Made MergedCluster: em28  :3289894246940672028:    3.67 -0.92 -2.61 sub(es5, )
+Made MergedCluster: em29  :3289895711562268701:    3.84 -1.43 -0.07 sub(es30, )
+Made MergedCluster: em30  :3289897841652138014:    4.16  1.46  0.58 sub(es4, )
+Made MergedCluster: em31  :3289899182080393247:    4.47 -0.50  1.87 sub(es20, )
+Made MergedCluster: em32  :3289903551475613728:    5.46 -0.78 -2.08 sub(es1, )
+Made MergedCluster: em33  :3289907297913929761:    6.31  1.42  1.87 sub(es3, )
+Made MergedCluster: hm0   :5595725905151393792:    2.38 -0.14 -2.64 sub(hs4, )
+Made MergedCluster: hm1   :5595735543991238657:    3.48  1.25  1.36 sub(hs3, )
+Made MergedCluster: hm2   :5595739438014529538:    3.92  1.33 -1.86 sub(hs2, )
+Made MergedCluster: hm3   :5595744468847296515:    4.99 -0.88 -2.49 sub(hs0, )
+Made MergedCluster: hm4   :5595760432215228420:    9.23  1.34  1.55 sub(hs1, )
+Made MergedCluster: hm5   :5595760577503821829:    9.30 -1.47 -2.16 sub(hs5, )
+Made block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289831316484259840)
+
+Made block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.3 (3289832033391476737)
+
+Made block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.3 (3289833691821375490)
+
+Made block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.4 (3289834247812022275)
+
+Made block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.7 (3289850781611589636)
+
+Made block:E1T1     :br5   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts22      value=  1.0 (7955589719528570902)
+      e1 = em5       value=  0.7 (3289851076307582981)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br6   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.8 (3289853313436090374)
+
+Made block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.8 (3289854515395690503)
+
+Made block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.8 (3289855315226394632)
+
+Made block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  0.8 (3289856254702256137)
+
+Made block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  0.9 (3289858330584940554)
+
+Made block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.0 (3289862029340311563)
+
+Made block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  1.2 (3289865689522765836)
+
+Made block:E1T1     :br13  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  2.4 (7955612158461476874)
+      e1 = em13      value=  1.3 (3289867320700174349)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  1.5 (3289870218729357326)
+
+Made block:E1       :br15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  1.5 (3289871198495703055)
+
+Made block:E1T1     :br16  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts23      value=  0.8 (7955584121741246487)
+      e1 = em16      value=  1.8 (3289876648672886800)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  1.8 (3289876858872528913)
+
+Made block:E1T1     :br18  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts24      value=  0.8 (7955582705140236312)
+      e1 = em18      value=  1.9 (3289877320422129682)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  2.0 (3289878770938282003)
+
+Made block:E1       :br20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em20      value=  2.0 (3289879066271809556)
+
+Made block:E1       :br21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  2.0 (3289879409632215061)
+
+Made block:E1       :br22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  2.2 (3289881056016072726)
+
+Made block:E1T1     :br23  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.9 (7955607716605460494)
+      e1 = em23      value=  2.2 (3289881554444091415)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1H1T1   :br24  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  5.4 (7955632388090888196)
+      h1 = hm3       value=  5.0 (5595744468847296515)
+      e2 = em24      value=  2.4 (3289883065366609944)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0184     ---       .
+
+Made block:E1       :br25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em25      value=  2.7 (3289885432977817625)
+
+Made block:E1       :br26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em27      value=  3.3 (3289891000863948827)
+
+Made block:E1       :br27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em28      value=  3.7 (3289894246940672028)
+
+Made block:E1       :br28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em29      value=  3.8 (3289895711562268701)
+
+Made block:E1       :br29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em30      value=  4.2 (3289897841652138014)
+
+Made block:E1T1     :br30  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts20      value=  1.1 (7955592724145504276)
+      e1 = em31      value=  4.5 (3289899182080393247)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :br31  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts3       value=  6.4 (7955636894434328579)
+      e1 = em32      value=  5.5 (3289903551475613728)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em33      value=  6.3 (3289907297913929761)
+
+Made block:E1T1     :br33  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts2       value=  8.9 (7955645796639047682)
+      e1 = em26      value=  8.4 (3289915492940120090)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:H1       :br34  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm0       value=  2.4 (5595725905151393792)
+
+Made block:H1T2     :br35  : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts11      value=  2.3 (7955611617352220683)
+      t1 = ts17      value=  1.4 (7955597944516771857)
+      h2 = hm1       value=  3.5 (5595735543991238657)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.1910       .
+
+Made block:H1T1     :br36  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  3.3 (7955619885831159814)
+      h1 = hm2       value=  3.9 (5595739438014529538)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br37  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  4.0 (7955626156928008197)
+      h1 = hm4       value=  9.2 (5595760432215228420)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1       :br38  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  9.3 (5595760577503821829)
+
+Made block:T1       :br39  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts21      value=  1.0 (7955591590410453013)
+
+Made block:T1       :br40  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts19      value=  1.2 (7955594205905027091)
+
+Made block:T1       :br41  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts18      value=  1.4 (7955597355181408274)
+
+Made block:T1       :br42  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  1.4 (7955598739289145360)
+
+Made block:T1       :br43  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  1.7 (7955603763956285455)
+
+Made block:T1       :br44  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  2.1 (7955609805706493965)
+
+Made block:T1       :br45  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  2.2 (7955610226653134860)
+
+Made block:T1       :br46  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  2.7 (7955615123677118472)
+
+Made block:T1       :br47  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  2.8 (7955615371906514953)
+
+Made block:T1       :br48  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts7       value=  2.8 (7955616040881225735)
+
+Made block:T1       :br49  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 40.6 (7955683815574208513)
+
+Made block:T1       :br50  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 53.9 (7955691134374641664)
+
+Splitting block:H1T2     :br35  : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts11      value=  2.3 (7955611617352220683)
+      t1 = ts17      value=  1.4 (7955597944516771857)
+      h2 = hm1       value=  3.5 (5595735543991238657)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.1910       .
+
+Made block:H1T2     :bs0   : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts11      value=  2.3 (7955611617352220683)
+      t1 = ts17      value=  1.4 (7955597944516771857)
+      h2 = hm1       value=  3.5 (5595735543991238657)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.1910       .
+
+Splitting block:E1H1T1   :br24  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  5.4 (7955632388090888196)
+      h1 = hm3       value=  5.0 (5595744468847296515)
+      e2 = em24      value=  2.4 (3289883065366609944)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0184     ---       .
+
+Made block:E1H1T1   :bs1   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  5.4 (7955632388090888196)
+      h1 = hm3       value=  5.0 (5595744468847296515)
+      e2 = em24      value=  2.4 (3289883065366609944)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0184     ---       .
+
+Splitting block:H1T1     :br37  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  4.0 (7955626156928008197)
+      h1 = hm4       value=  9.2 (5595760432215228420)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs2   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  4.0 (7955626156928008197)
+      h1 = hm4       value=  9.2 (5595760432215228420)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br36  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  3.3 (7955619885831159814)
+      h1 = hm2       value=  3.9 (5595739438014529538)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs3   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  3.3 (7955619885831159814)
+      h1 = hm2       value=  3.9 (5595739438014529538)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:E1T1     :br33  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts2       value=  8.9 (7955645796639047682)
+      e1 = em26      value=  8.4 (3289915492940120090)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs4   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts2       value=  8.9 (7955645796639047682)
+      e1 = em26      value=  8.4 (3289915492940120090)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br31  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts3       value=  6.4 (7955636894434328579)
+      e1 = em32      value=  5.5 (3289903551475613728)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs5   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts3       value=  6.4 (7955636894434328579)
+      e1 = em32      value=  5.5 (3289903551475613728)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br30  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts20      value=  1.1 (7955592724145504276)
+      e1 = em31      value=  4.5 (3289899182080393247)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs6   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts20      value=  1.1 (7955592724145504276)
+      e1 = em31      value=  4.5 (3289899182080393247)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br23  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.9 (7955607716605460494)
+      e1 = em23      value=  2.2 (3289881554444091415)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs7   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.9 (7955607716605460494)
+      e1 = em23      value=  2.2 (3289881554444091415)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br18  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts24      value=  0.8 (7955582705140236312)
+      e1 = em18      value=  1.9 (3289877320422129682)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs8   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts24      value=  0.8 (7955582705140236312)
+      e1 = em18      value=  1.9 (3289877320422129682)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br16  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts23      value=  0.8 (7955584121741246487)
+      e1 = em16      value=  1.8 (3289876648672886800)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs9   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts23      value=  0.8 (7955584121741246487)
+      e1 = em16      value=  1.8 (3289876648672886800)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br13  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  2.4 (7955612158461476874)
+      e1 = em13      value=  1.3 (3289867320700174349)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs10  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  2.4 (7955612158461476874)
+      e1 = em13      value=  1.3 (3289867320700174349)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br5   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts22      value=  1.0 (7955589719528570902)
+      e1 = em5       value=  0.7 (3289851076307582981)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs11  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts22      value=  1.0 (7955589719528570902)
+      e1 = em5       value=  0.7 (3289851076307582981)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:T1       :br50  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 53.9 (7955691134374641664)
+
+Made block:T1       :bs12  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 53.9 (7955691134374641664)
+
+Splitting block:T1       :br49  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 40.6 (7955683815574208513)
+
+Made block:T1       :bs13  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 40.6 (7955683815574208513)
+
+Splitting block:T1       :br48  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts7       value=  2.8 (7955616040881225735)
+
+Made block:T1       :bs14  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts7       value=  2.8 (7955616040881225735)
+
+Splitting block:T1       :br47  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  2.8 (7955615371906514953)
+
+Made block:T1       :bs15  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  2.8 (7955615371906514953)
+
+Splitting block:T1       :br46  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  2.7 (7955615123677118472)
+
+Made block:T1       :bs16  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  2.7 (7955615123677118472)
+
+Splitting block:T1       :br45  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  2.2 (7955610226653134860)
+
+Made block:T1       :bs17  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  2.2 (7955610226653134860)
+
+Splitting block:T1       :br44  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  2.1 (7955609805706493965)
+
+Made block:T1       :bs18  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  2.1 (7955609805706493965)
+
+Splitting block:T1       :br43  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  1.7 (7955603763956285455)
+
+Made block:T1       :bs19  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  1.7 (7955603763956285455)
+
+Splitting block:T1       :br42  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  1.4 (7955598739289145360)
+
+Made block:T1       :bs20  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  1.4 (7955598739289145360)
+
+Splitting block:T1       :br41  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts18      value=  1.4 (7955597355181408274)
+
+Made block:T1       :bs21  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts18      value=  1.4 (7955597355181408274)
+
+Splitting block:T1       :br40  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts19      value=  1.2 (7955594205905027091)
+
+Made block:T1       :bs22  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts19      value=  1.2 (7955594205905027091)
+
+Splitting block:T1       :br39  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts21      value=  1.0 (7955591590410453013)
+
+Made block:T1       :bs23  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts21      value=  1.0 (7955591590410453013)
+
+Splitting block:H1       :br38  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  9.3 (5595760577503821829)
+
+Made block:H1       :bs24  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  9.3 (5595760577503821829)
+
+Splitting block:H1       :br34  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm0       value=  2.4 (5595725905151393792)
+
+Made block:H1       :bs25  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm0       value=  2.4 (5595725905151393792)
+
+Splitting block:E1       :br32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em33      value=  6.3 (3289907297913929761)
+
+Made block:E1       :bs26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em33      value=  6.3 (3289907297913929761)
+
+Splitting block:E1       :br29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em30      value=  4.2 (3289897841652138014)
+
+Made block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em30      value=  4.2 (3289897841652138014)
+
+Splitting block:E1       :br28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em29      value=  3.8 (3289895711562268701)
+
+Made block:E1       :bs28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em29      value=  3.8 (3289895711562268701)
+
+Splitting block:E1       :br27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em28      value=  3.7 (3289894246940672028)
+
+Made block:E1       :bs29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em28      value=  3.7 (3289894246940672028)
+
+Splitting block:E1       :br26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em27      value=  3.3 (3289891000863948827)
+
+Made block:E1       :bs30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em27      value=  3.3 (3289891000863948827)
+
+Splitting block:E1       :br25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em25      value=  2.7 (3289885432977817625)
+
+Made block:E1       :bs31  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em25      value=  2.7 (3289885432977817625)
+
+Splitting block:E1       :br22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  2.2 (3289881056016072726)
+
+Made block:E1       :bs32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  2.2 (3289881056016072726)
+
+Splitting block:E1       :br21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  2.0 (3289879409632215061)
+
+Made block:E1       :bs33  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  2.0 (3289879409632215061)
+
+Splitting block:E1       :br20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em20      value=  2.0 (3289879066271809556)
+
+Made block:E1       :bs34  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em20      value=  2.0 (3289879066271809556)
+
+Splitting block:E1       :br19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  2.0 (3289878770938282003)
+
+Made block:E1       :bs35  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  2.0 (3289878770938282003)
+
+Splitting block:E1       :br17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  1.8 (3289876858872528913)
+
+Made block:E1       :bs36  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  1.8 (3289876858872528913)
+
+Splitting block:E1       :br15  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  1.5 (3289871198495703055)
+
+Made block:E1       :bs37  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  1.5 (3289871198495703055)
+
+Splitting block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  1.5 (3289870218729357326)
+
+Made block:E1       :bs38  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  1.5 (3289870218729357326)
+
+Splitting block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  1.2 (3289865689522765836)
+
+Made block:E1       :bs39  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  1.2 (3289865689522765836)
+
+Splitting block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.0 (3289862029340311563)
+
+Made block:E1       :bs40  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.0 (3289862029340311563)
+
+Splitting block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  0.9 (3289858330584940554)
+
+Made block:E1       :bs41  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  0.9 (3289858330584940554)
+
+Splitting block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  0.8 (3289856254702256137)
+
+Made block:E1       :bs42  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  0.8 (3289856254702256137)
+
+Splitting block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.8 (3289855315226394632)
+
+Made block:E1       :bs43  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.8 (3289855315226394632)
+
+Splitting block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.8 (3289854515395690503)
+
+Made block:E1       :bs44  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.8 (3289854515395690503)
+
+Splitting block:E1       :br6   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.8 (3289853313436090374)
+
+Made block:E1       :bs45  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.8 (3289853313436090374)
+
+Splitting block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.7 (3289850781611589636)
+
+Made block:E1       :bs46  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.7 (3289850781611589636)
+
+Splitting block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.4 (3289834247812022275)
+
+Made block:E1       :bs47  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.4 (3289834247812022275)
+
+Splitting block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.3 (3289833691821375490)
+
+Made block:E1       :bs48  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.3 (3289833691821375490)
+
+Splitting block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.3 (3289832033391476737)
+
+Made block:E1       :bs49  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.3 (3289832033391476737)
+
+Splitting block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289831316484259840)
+
+Made block:E1       :bs50  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289831316484259840)
+
+Processing block:E1H1T1   :bs1   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  5.4 (7955632388090888196)
+      h1 = hm3       value=  5.0 (5595744468847296515)
+      e2 = em24      value=  2.4 (3289883065366609944)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0184     ---       .
+
+Made Particle :pr0   :10252468205951909888: pdgid =   211, status =   1, q =  1, e =   5.4, theta = -0.87, phi = -2.17, mass =  0.14 from SmearedTrack: ts4   :7955632388090888196:    5.38    3.47 -0.87 -2.17
+Finished block
+Processing block:H1T2     :bs0   : ecals = 0 hcals = 1 tracks = 2
+    elements:
+      t0 = ts11      value=  2.3 (7955611617352220683)
+      t1 = ts17      value=  1.4 (7955597944516771857)
+      h2 = hm1       value=  3.5 (5595735543991238657)
+    distances:
+              t0      t1      h2
+      t0       .
+      t1     ---       .
+      h2  0.0000  0.1910       .
+
+Made Particle :pr1   :10252447463797424129: pdgid =  -211, status =   1, q = -1, e =   2.3, theta =  1.23, phi =  0.68, mass =  0.14 from SmearedTrack: ts11  :7955611617352220683:    2.33    0.78  1.23  0.68
+Made Particle :pr2   :10252433876764852226: pdgid =   211, status =   1, q =  1, e =   1.4, theta =  1.19, phi =  2.30, mass =  0.14 from SmearedTrack: ts17  :7955597944516771857:    1.39    0.52  1.19  2.30
+Finished block
+Processing block:E1T1     :bs11  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts22      value=  1.0 (7955589719528570902)
+      e1 = em5       value=  0.7 (3289851076307582981)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr3   :10252425881945374723: pdgid =  -211, status =   1, q = -1, e =   1.0, theta =  0.83, phi =  0.95, mass =  0.14 from SmearedTrack: ts22  :7955589719528570902:    0.96    0.65  0.83  0.95
+Finished block
+Processing block:E1T1     :bs10  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  2.4 (7955612158461476874)
+      e1 = em13      value=  1.3 (3289867320700174349)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr4   :10252448003967156228: pdgid =   211, status =   1, q =  1, e =   2.4, theta = -0.16, phi =  2.56, mass =  0.14 from SmearedTrack: ts10  :7955612158461476874:    2.39    2.36 -0.16  2.56
+Finished block
+Processing block:E1T1     :bs9   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts23      value=  0.8 (7955584121741246487)
+      e1 = em16      value=  1.8 (3289876648672886800)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr5   :10252420353282277381: pdgid =   211, status =   1, q =  1, e =   0.8, theta = -0.06, phi =  1.80, mass =  0.14 from SmearedTrack: ts23  :7955584121741246487:    0.80    0.80 -0.06  1.80
+Finished block
+Processing block:E1T1     :bs8   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts24      value=  0.8 (7955582705140236312)
+      e1 = em18      value=  1.9 (3289877320422129682)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr6   :10252418958659420166: pdgid =  -211, status =   1, q = -1, e =   0.8, theta = -0.11, phi =  2.41, mass =  0.14 from SmearedTrack: ts24  :7955582705140236312:    0.76    0.76 -0.11  2.41
+Finished block
+Processing block:E1T1     :bs7   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  1.9 (7955607716605460494)
+      e1 = em23      value=  2.2 (3289881554444091415)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr7   :10252443613975805959: pdgid =  -211, status =   1, q = -1, e =   1.9, theta =  1.29, phi =  1.31, mass =  0.14 from SmearedTrack: ts14  :7955607716605460494:    1.94    0.55  1.29  1.31
+Finished block
+Processing block:E1T1     :bs6   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts20      value=  1.1 (7955592724145504276)
+      e1 = em31      value=  4.5 (3289899182080393247)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr8   :10252428689463574536: pdgid =   211, status =   1, q =  1, e =   1.1, theta = -0.45, phi =  2.74, mass =  0.14 from SmearedTrack: ts20  :7955592724145504276:    1.09    0.98 -0.45  2.74
+Finished block
+Processing block:E1T1     :bs5   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts3       value=  6.4 (7955636894434328579)
+      e1 = em32      value=  5.5 (3289903551475613728)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr9   :10252472711030767625: pdgid =  -211, status =   1, q = -1, e =   6.4, theta = -0.78, phi = -2.24, mass =  0.14 from SmearedTrack: ts3   :7955636894434328579:    6.40    4.55 -0.78 -2.24
+Finished block
+Processing block:E1T1     :bs4   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts2       value=  8.9 (7955645796639047682)
+      e1 = em26      value=  8.4 (3289915492940120090)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr10  :10252481608999239690: pdgid =   211, status =   1, q =  1, e =   8.9, theta = -0.92, phi = -2.18, mass =  0.14 from SmearedTrack: ts2   :7955645796639047682:    8.85    5.39 -0.92 -2.18
+Finished block
+Processing block:H1T1     :bs3   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts6       value=  3.3 (7955619885831159814)
+      h1 = hm2       value=  3.9 (5595739438014529538)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr11  :10252455721788506123: pdgid =   211, status =   1, q =  1, e =   3.3, theta =  1.32, phi = -1.40, mass =  0.14 from SmearedTrack: ts6   :7955619885831159814:    3.27    0.80  1.32 -1.40
+Finished block
+Processing block:H1T1     :bs2   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts5       value=  4.0 (7955626156928008197)
+      h1 = hm4       value=  9.2 (5595760432215228420)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr12  :10252461988231774220: pdgid =   211, status =   1, q =  1, e =   4.0, theta =  1.33, phi =  1.94, mass =  0.14 from SmearedTrack: ts5   :7955626156928008197:    3.98    0.95  1.33  1.94
+Finished block
+Processing block:E1       :bs50  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289831316484259840)
+
+Made Particle :pr13  :10252396340399046669: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.96, phi = -2.21, mass =  0.00 from MergedCluster: em0   :3289831316484259840:    0.31 -0.96 -2.21 sub(es28, )
+Finished block
+Processing block:E1       :bs49  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.3 (3289832033391476737)
+
+Made Particle :pr14  :10252397057306263566: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.30, phi =  2.12, mass =  0.00 from MergedCluster: em1   :3289832033391476737:    0.33 -0.30  2.12 sub(es33, )
+Finished block
+Processing block:E1       :bs48  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.3 (3289833691821375490)
+
+Made Particle :pr15  :10252398715736162319: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.80, phi =  2.28, mass =  0.00 from MergedCluster: em2   :3289833691821375490:    0.35 -0.80  2.28 sub(es34, )
+Finished block
+Processing block:E1       :bs47  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.4 (3289834247812022275)
+
+Made Particle :pr16  :10252399271726809104: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.84, phi = -2.73, mass =  0.00 from MergedCluster: em3   :3289834247812022275:    0.36 -0.84 -2.73 sub(es32, )
+Finished block
+Processing block:E1       :bs46  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.7 (3289850781611589636)
+
+Made Particle :pr17  :10252415805526376465: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.71, phi = -2.70, mass =  0.00 from MergedCluster: em4   :3289850781611589636:    0.68  0.71 -2.70 sub(es31, )
+Finished block
+Processing block:E1       :bs45  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  0.8 (3289853313436090374)
+
+Made Particle :pr18  :10252418337350877202: pdgid =    22, status =   1, q =  0, e =   0.8, theta = -0.68, phi =  3.13, mass =  0.00 from MergedCluster: em6   :3289853313436090374:    0.75 -0.68  3.13 sub(es29, )
+Finished block
+Processing block:E1       :bs44  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.8 (3289854515395690503)
+
+Made Particle :pr19  :10252419539310477331: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  1.04, phi = -0.72, mass =  0.00 from MergedCluster: em7   :3289854515395690503:    0.79  1.04 -0.72 sub(es26, )
+Finished block
+Processing block:E1       :bs43  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.8 (3289855315226394632)
+
+Made Particle :pr20  :10252420339141181460: pdgid =    22, status =   1, q =  0, e =   0.8, theta = -1.04, phi = -1.58, mass =  0.00 from MergedCluster: em8   :3289855315226394632:    0.81 -1.04 -1.58 sub(es27, )
+Finished block
+Processing block:E1       :bs42  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  0.8 (3289856254702256137)
+
+Made Particle :pr21  :10252421278617042965: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  1.08, phi =  0.57, mass =  0.00 from MergedCluster: em9   :3289856254702256137:    0.84  1.08  0.57 sub(es25, )
+Finished block
+Processing block:E1       :bs41  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em10      value=  0.9 (3289858330584940554)
+
+Made Particle :pr22  :10252423354499727382: pdgid =    22, status =   1, q =  0, e =   0.9, theta = -0.40, phi =  2.45, mass =  0.00 from MergedCluster: em10  :3289858330584940554:    0.90 -0.40  2.45 sub(es19, )
+Finished block
+Processing block:E1       :bs40  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  1.0 (3289862029340311563)
+
+Made Particle :pr23  :10252427053255098391: pdgid =    22, status =   1, q =  0, e =   1.0, theta =  1.04, phi = -0.15, mass =  0.00 from MergedCluster: em11  :3289862029340311563:    1.01  1.04 -0.15 sub(es22, )
+Finished block
+Processing block:E1       :bs39  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  1.2 (3289865689522765836)
+
+Made Particle :pr24  :10252430713437552664: pdgid =    22, status =   1, q =  0, e =   1.2, theta = -0.83, phi = -2.31, mass =  0.00 from MergedCluster: em12  :3289865689522765836:    1.21 -0.83 -2.31 sub(es17, )
+Finished block
+Processing block:E1       :bs38  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  1.5 (3289870218729357326)
+
+Made Particle :pr25  :10252435242644144153: pdgid =    22, status =   1, q =  0, e =   1.5, theta = -0.60, phi = -2.43, mass =  0.00 from MergedCluster: em14  :3289870218729357326:    1.47 -0.60 -2.43 sub(es18, )
+Finished block
+Processing block:E1       :bs37  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  1.5 (3289871198495703055)
+
+Made Particle :pr26  :10252436222410489882: pdgid =    22, status =   1, q =  0, e =   1.5, theta =  1.39, phi = -1.16, mass =  0.00 from MergedCluster: em15  :3289871198495703055:    1.53  1.39 -1.16 sub(es16, )
+Finished block
+Processing block:E1       :bs36  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  1.8 (3289876858872528913)
+
+Made Particle :pr27  :10252441882787315739: pdgid =    22, status =   1, q =  0, e =   1.8, theta =  1.30, phi =  0.53, mass =  0.00 from MergedCluster: em17  :3289876858872528913:    1.85  1.30  0.53 sub(es8, )
+Finished block
+Processing block:E1       :bs35  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  2.0 (3289878770938282003)
+
+Made Particle :pr28  :10252443794853068828: pdgid =    22, status =   1, q =  0, e =   2.0, theta =  1.43, phi = -0.76, mass =  0.00 from MergedCluster: em19  :3289878770938282003:    1.96  1.43 -0.76 sub(es11, )
+Finished block
+Processing block:E1       :bs34  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em20      value=  2.0 (3289879066271809556)
+
+Made Particle :pr29  :10252444090186596381: pdgid =    22, status =   1, q =  0, e =   2.0, theta =  1.26, phi =  1.26, mass =  0.00 from MergedCluster: em20  :3289879066271809556:    1.97  1.26  1.26 sub(es13, )
+Finished block
+Processing block:E1       :bs33  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  2.0 (3289879409632215061)
+
+Made Particle :pr30  :10252444433547001886: pdgid =    22, status =   1, q =  0, e =   2.0, theta =  1.32, phi =  1.41, mass =  0.00 from MergedCluster: em21  :3289879409632215061:    1.99  1.32  1.41 sub(es15, )
+Finished block
+Processing block:E1       :bs32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  2.2 (3289881056016072726)
+
+Made Particle :pr31  :10252446079930859551: pdgid =    22, status =   1, q =  0, e =   2.2, theta =  1.45, phi =  2.61, mass =  0.00 from MergedCluster: em22  :3289881056016072726:    2.17  1.45  2.61 sub(es2, )
+Finished block
+Processing block:E1       :bs31  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em25      value=  2.7 (3289885432977817625)
+
+Made Particle :pr32  :10252450456892604448: pdgid =    22, status =   1, q =  0, e =   2.7, theta =  1.25, phi =  0.59, mass =  0.00 from MergedCluster: em25  :3289885432977817625:    2.67  1.25  0.59 sub(es12, )
+Finished block
+Processing block:E1       :bs30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em27      value=  3.3 (3289891000863948827)
+
+Made Particle :pr33  :10252456024778735649: pdgid =    22, status =   1, q =  0, e =   3.3, theta =  1.40, phi =  1.74, mass =  0.00 from MergedCluster: em27  :3289891000863948827:    3.30  1.40  1.74 sub(es6, )
+Finished block
+Processing block:E1       :bs29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em28      value=  3.7 (3289894246940672028)
+
+Made Particle :pr34  :10252459270855458850: pdgid =    22, status =   1, q =  0, e =   3.7, theta = -0.92, phi = -2.61, mass =  0.00 from MergedCluster: em28  :3289894246940672028:    3.67 -0.92 -2.61 sub(es5, )
+Finished block
+Processing block:E1       :bs28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em29      value=  3.8 (3289895711562268701)
+
+Made Particle :pr35  :10252460735477055523: pdgid =    22, status =   1, q =  0, e =   3.8, theta = -1.43, phi = -0.07, mass =  0.00 from MergedCluster: em29  :3289895711562268701:    3.84 -1.43 -0.07 sub(es30, )
+Finished block
+Processing block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em30      value=  4.2 (3289897841652138014)
+
+Made Particle :pr36  :10252462865566924836: pdgid =    22, status =   1, q =  0, e =   4.2, theta =  1.46, phi =  0.58, mass =  0.00 from MergedCluster: em30  :3289897841652138014:    4.16  1.46  0.58 sub(es4, )
+Finished block
+Processing block:E1       :bs26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em33      value=  6.3 (3289907297913929761)
+
+Made Particle :pr37  :10252472321828716581: pdgid =    22, status =   1, q =  0, e =   6.3, theta =  1.42, phi =  1.87, mass =  0.00 from MergedCluster: em33  :3289907297913929761:    6.31  1.42  1.87 sub(es3, )
+Finished block
+Processing block:H1       :bs25  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm0       value=  2.4 (5595725905151393792)
+
+Made Particle :pr38  :10252447919852486694: pdgid =   130, status =   1, q =  0, e =   2.4, theta = -0.14, phi = -2.64, mass =  0.50 from MergedCluster: hm0   :5595725905151393792:    2.38 -0.14 -2.64 sub(hs4, )
+Finished block
+Processing block:H1       :bs24  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value=  9.3 (5595760577503821829)
+
+Made Particle :pr39  :10252482592204914727: pdgid =   130, status =   1, q =  0, e =   9.3, theta = -1.47, phi = -2.16, mass =  0.50 from MergedCluster: hm5   :5595760577503821829:    9.30 -1.47 -2.16 sub(hs5, )
+Finished block
+Processing block:T1       :bs23  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts21      value=  1.0 (7955591590410453013)
+
+Made Particle :pr40  :10252427565408976936: pdgid =  -211, status =   1, q = -1, e =   1.0, theta = -0.27, phi = -2.38, mass =  0.14 from SmearedTrack: ts21  :7955591590410453013:    1.03    0.99 -0.27 -2.38
+Finished block
+Processing block:T1       :bs22  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts19      value=  1.2 (7955594205905027091)
+
+Made Particle :pr41  :10252430160154329129: pdgid =   211, status =   1, q =  1, e =   1.2, theta =  1.01, phi =  0.55, mass =  0.14 from SmearedTrack: ts19  :7955594205905027091:    1.17    0.63  1.01  0.55
+Finished block
+Processing block:T1       :bs21  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts18      value=  1.4 (7955597355181408274)
+
+Made Particle :pr42  :10252433290443096106: pdgid =  -211, status =   1, q = -1, e =   1.4, theta = -0.79, phi = -2.42, mass =  0.14 from SmearedTrack: ts18  :7955597355181408274:    1.35    0.95 -0.79 -2.42
+Finished block
+Processing block:T1       :bs20  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts16      value=  1.4 (7955598739289145360)
+
+Made Particle :pr43  :10252434667695243307: pdgid =  -211, status =   1, q = -1, e =   1.4, theta = -0.85, phi = -1.83, mass =  0.14 from SmearedTrack: ts16  :7955598739289145360:    1.43    0.94 -0.85 -1.83
+Finished block
+Processing block:T1       :bs19  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts15      value=  1.7 (7955603763956285455)
+
+Made Particle :pr44  :10252439672733040684: pdgid =  -211, status =   1, q = -1, e =   1.7, theta = -1.16, phi = -2.33, mass =  0.14 from SmearedTrack: ts15  :7955603763956285455:    1.72    0.69 -1.16 -2.33
+Finished block
+Processing block:T1       :bs18  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  2.1 (7955609805706493965)
+
+Made Particle :pr45  :10252445655687495725: pdgid =  -211, status =   1, q = -1, e =   2.1, theta =  1.17, phi =  1.29, mass =  0.14 from SmearedTrack: ts13  :7955609805706493965:    2.12    0.83  1.17  1.29
+Finished block
+Processing block:T1       :bs17  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts12      value=  2.2 (7955610226653134860)
+
+Made Particle :pr46  :10252446075753332782: pdgid =   211, status =   1, q =  1, e =   2.2, theta =  1.19, phi = -0.77, mass =  0.14 from SmearedTrack: ts12  :7955610226653134860:    2.17    0.81  1.19 -0.77
+Finished block
+Processing block:T1       :bs16  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  2.7 (7955615123677118472)
+
+Made Particle :pr47  :10252450964793458735: pdgid =   211, status =   1, q =  1, e =   2.7, theta = -0.83, phi = -2.24, mass =  0.14 from SmearedTrack: ts8   :7955615123677118472:    2.73    1.85 -0.83 -2.24
+Finished block
+Processing block:T1       :bs15  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts9       value=  2.8 (7955615371906514953)
+
+Made Particle :pr48  :10252451212704088112: pdgid =  -211, status =   1, q = -1, e =   2.8, theta = -0.87, phi =  2.39, mass =  0.14 from SmearedTrack: ts9   :7955615371906514953:    2.75    1.78 -0.87  2.39
+Finished block
+Processing block:T1       :bs14  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts7       value=  2.8 (7955616040881225735)
+
+Made Particle :pr49  :10252451880850423857: pdgid =  -211, status =   1, q = -1, e =   2.8, theta =  1.09, phi = -2.71, mass =  0.14 from SmearedTrack: ts7   :7955616040881225735:    2.83    1.31  1.09 -2.71
+Finished block
+Processing block:T1       :bs13  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 40.6 (7955683815574208513)
+
+Made Particle :pr50  :10252519625608658994: pdgid =    13, status =   1, q =  1, e =  40.6, theta =  0.96, phi = -0.32, mass =  0.11 from SmearedTrack: ts1   :7955683815574208513:   40.56   23.16  0.96 -0.32
+Finished block
+Processing block:T1       :bs12  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 53.9 (7955691134374641664)
+
+Made Particle :pr51  :10252526944390217779: pdgid =   -13, status =   1, q = -1, e =  53.9, theta = -1.25, phi =  1.40, mass =  0.10 from SmearedTrack: ts0   :7955691134374641664:   53.87   16.93 -1.25  1.40
+Finished block
+Finished reconstruction
+Event: 9
+Made Particle :ps0   :10261540265344892928: pdgid =   -13, status =   1, q =  1, e =  66.0, theta = -0.06, phi = -1.33, mass =  0.11
+Made Particle :ps1   :10261525717919465473: pdgid =    13, status =   1, q = -1, e =  38.5, theta =  0.97, phi =  1.66, mass =  0.11
+Made Particle :ps2   :10261520120385896450: pdgid =   321, status =   1, q =  1, e =  30.2, theta = -0.79, phi =  0.41, mass =  0.49
+Made Particle :ps3   :10261499173966708739: pdgid =  -211, status =   1, q = -1, e =  13.6, theta =  0.21, phi =  2.89, mass =  0.14
+Made Particle :ps4   :10261491230032527364: pdgid =   130, status =   1, q =  0, e =  10.0, theta =  0.29, phi =  2.94, mass =  0.50
+Made Particle :ps5   :10261478647768547333: pdgid =   211, status =   1, q =  1, e =   6.1, theta = -0.75, phi =  0.31, mass =  0.14
+Made Particle :ps6   :10261477879596449798: pdgid =    22, status =   1, q =  0, e =   5.9, theta =  0.35, phi =  2.92, mass =  0.00
+Made Particle :ps7   :10261477443785195527: pdgid =   130, status =   1, q =  0, e =   5.8, theta =  0.28, phi =  2.89, mass =  0.50
+Made Particle :ps8   :10261474518511910920: pdgid =    22, status =   1, q =  0, e =   5.2, theta = -0.86, phi =  0.37, mass =  0.00
+Made Particle :ps9   :10261472966749454345: pdgid =    22, status =   1, q =  0, e =   4.8, theta = -0.65, phi =  0.56, mass =  0.00
+Made Particle :ps10  :10261470647595040778: pdgid =    22, status =   1, q =  0, e =   4.3, theta =  0.24, phi =  2.92, mass =  0.00
+Made Particle :ps11  :10261468773693259787: pdgid =   211, status =   1, q =  1, e =   3.9, theta =  0.37, phi =  2.81, mass =  0.14
+Made Particle :ps12  :10261460482690908172: pdgid =  -211, status =   1, q = -1, e =   3.0, theta = -0.80, phi =  0.41, mass =  0.14
+Made Particle :ps13  :10261458889176252429: pdgid =   130, status =   1, q =  0, e =   2.8, theta =  0.26, phi =  2.57, mass =  0.50
+Made Particle :ps14  :10261458781028220942: pdgid =    22, status =   1, q =  0, e =   2.8, theta =  0.32, phi =  2.81, mass =  0.00
+Made Particle :ps15  :10261455646821974031: pdgid =    22, status =   1, q =  0, e =   2.4, theta =  0.37, phi =  2.72, mass =  0.00
+Made Particle :ps16  :10261452737633845264: pdgid =  -211, status =   1, q = -1, e =   2.1, theta = -0.68, phi =  0.12, mass =  0.14
+Made Particle :ps17  :10261449342829199377: pdgid =   211, status =   1, q =  1, e =   1.9, theta = -0.21, phi =  0.60, mass =  0.14
+Made Particle :ps18  :10261449132098977810: pdgid =   321, status =   1, q =  1, e =   1.9, theta =  0.29, phi =  2.61, mass =  0.49
+Made Particle :ps19  :10261448394358652947: pdgid =    22, status =   1, q =  0, e =   1.8, theta =  0.25, phi =  2.87, mass =  0.00
+Made Particle :ps20  :10261442712557322260: pdgid =   211, status =   1, q =  1, e =   1.5, theta = -0.73, phi =  0.55, mass =  0.14
+Made Particle :ps21  :10261441994010132501: pdgid =  -211, status =   1, q = -1, e =   1.4, theta = -0.59, phi =  0.61, mass =  0.14
+Made Particle :ps22  :10261441612802424854: pdgid =    22, status =   1, q =  0, e =   1.4, theta =  0.13, phi =  2.59, mass =  0.00
+Made Particle :ps23  :10261440106883710999: pdgid =    22, status =   1, q =  0, e =   1.3, theta = -0.84, phi =  0.30, mass =  0.00
+Made Particle :ps24  :10261439488473432088: pdgid =  -211, status =   1, q = -1, e =   1.3, theta = -0.54, phi =  2.18, mass =  0.14
+Made Particle :ps25  :10261439097719488537: pdgid =  -321, status =   1, q = -1, e =   1.3, theta = -0.33, phi =  0.88, mass =  0.49
+Made Particle :ps26  :10261436488640102426: pdgid =    22, status =   1, q =  0, e =   1.1, theta = -0.71, phi =  0.57, mass =  0.00
+Made Particle :ps27  :10261436320104579099: pdgid =   321, status =   1, q =  1, e =   1.1, theta = -0.21, phi =  1.70, mass =  0.49
+Made Particle :ps28  :10261436218717765660: pdgid =    22, status =   1, q =  0, e =   1.1, theta = -0.43, phi =  0.98, mass =  0.00
+Made Particle :ps29  :10261436005185749021: pdgid =    22, status =   1, q =  0, e =   1.1, theta =  0.04, phi =  0.62, mass =  0.00
+Made Particle :ps30  :10261435951014215710: pdgid =    22, status =   1, q =  0, e =   1.1, theta =  0.05, phi =  2.82, mass =  0.00
+Made Particle :ps31  :10261435443968999455: pdgid =    22, status =   1, q =  0, e =   1.1, theta =  0.16, phi =  2.67, mass =  0.00
+Made Particle :ps32  :10261433665537966112: pdgid =    22, status =   1, q =  0, e =   1.0, theta = -1.15, phi =  0.30, mass =  0.00
+Made Particle :ps33  :10261429927163199521: pdgid =  -211, status =   1, q = -1, e =   0.9, theta = -0.49, phi =  0.35, mass =  0.14
+Made Particle :ps34  :10261426135210393634: pdgid =   211, status =   1, q =  1, e =   0.8, theta =  0.06, phi =  1.69, mass =  0.14
+Made Particle :ps35  :10261425737049309219: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.43, phi =  3.12, mass =  0.00
+Made Particle :ps36  :10261423313685315620: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.05, phi =  2.78, mass =  0.00
+Made Particle :ps37  :10261420878646476837: pdgid =  -211, status =   1, q = -1, e =   0.6, theta = -1.24, phi =  0.65, mass =  0.14
+Made Particle :ps38  :10261419917720944678: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.82, phi =  0.55, mass =  0.00
+Made Particle :ps39  :10261417455251357735: pdgid =   211, status =   1, q =  1, e =   0.5, theta =  0.46, phi = -0.64, mass =  0.14
+Made Particle :ps40  :10261417209983139880: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.29, phi =  0.97, mass =  0.00
+Made Particle :ps41  :10261416524319293481: pdgid =  -211, status =   1, q = -1, e =   0.5, theta =  0.24, phi =  1.78, mass =  0.14
+Made Particle :ps42  :10261416229623300138: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.34, phi =  2.94, mass =  0.00
+Made Particle :ps43  :10261416006685556779: pdgid =  -211, status =   1, q = -1, e =   0.5, theta =  0.84, phi =  2.42, mass =  0.14
+Made Particle :ps44  :10261415510759440428: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.52, phi =  1.61, mass =  0.00
+Made Particle :ps45  :10261415203440689197: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.11, phi =  1.83, mass =  0.00
+Made Particle :ps46  :10261413357967900718: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.28, phi =  1.10, mass =  0.00
+Made Particle :ps47  :10261411697306632239: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.05, phi =  2.74, mass =  0.00
+Made Particle :ps48  :10261408681581084720: pdgid =   211, status =   1, q =  1, e =   0.4, theta =  0.16, phi =  0.37, mass =  0.14
+Made Particle :ps49  :10261404017798152241: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.36, phi =  3.02, mass =  0.00
+Made Particle :ps50  :10261400284217475122: pdgid =  -211, status =   1, q = -1, e =   0.3, theta = -0.59, phi =  0.78, mass =  0.14
+Made Particle :ps51  :10261399579433893939: pdgid =   211, status =   1, q =  1, e =   0.3, theta = -0.86, phi =  0.69, mass =  0.14
+Made Particle :ps52  :10261399412376862772: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.08, phi = -2.85, mass =  0.00
+Made Particle :ps53  :10261385841601413173: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.53, phi =  0.52, mass =  0.00
+Made Particle :ps54  :10261384192656932918: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.75, phi =  0.73, mass =  0.00
+Made Particle :ps55  :10261384103410532407: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.12, phi =  0.92, mass =  0.00
+Made Particle :ps56  :10261381992106950712: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.87, phi = -0.20, mass =  0.00
+Made Particle :ps57  :10261380011911020601: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.44, phi =  1.99, mass =  0.00
+Made Particle :ps58  :10261369911198613562: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.22, phi =  0.41, mass =  0.00
+Made Particle :ps59  :10261349540049190971: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.24, phi = -2.66, mass =  0.00
+Simulating Particle :ps0   :10261540265344892928: pdgid =   -13, status =   1, q =  1, e =  66.0, theta = -0.06, phi = -1.33, mass =  0.11
+Simulating Muon
+Made Track: tt0   :7964704455362871296:   66.01   65.88 -0.06 -1.33
+Made SmearedTrack: ts0   :7955697051258322944:   65.27   65.14 -0.06 -1.33
+Simulating Particle :ps1   :10261525717919465473: pdgid =    13, status =   1, q = -1, e =  38.5, theta =  0.97, phi =  1.66, mass =  0.11
+Simulating Muon
+Made Track: tt1   :7964689907880820737:   38.54   21.93  0.97  1.66
+Made SmearedTrack: ts1   :7955682910005100545:   38.91   22.14  0.97  1.66
+Simulating Particle :ps2   :10261520120385896450: pdgid =   321, status =   1, q =  1, e =  30.2, theta = -0.79, phi =  0.41, mass =  0.49
+Simulating Hadron
+Made Track: tt2   :7964684305987272706:   30.18   21.14 -0.79  0.41
+Made SmearedTrack: ts2   :7955676761769902082:   29.86   20.92 -0.79  0.41
+Made Cluster: et0   :3352972189616832512:   11.22 -0.79  0.37 sub(et0, )
+Made SmearedCluster: es0   :3343978090312237056:   18.36 -0.79  0.37 sub(es0, )
+Made Cluster: ht0   :5658828963785474048:   18.96 -0.79  0.36 sub(ht0, )
+Made SmearedCluster: hs0   :5649822337839661056:   19.48 -0.79  0.36 sub(hs0, )
+Simulating Particle :ps3   :10261499173966708739: pdgid =  -211, status =   1, q = -1, e =  13.6, theta =  0.21, phi =  2.89, mass =  0.14
+Simulating Hadron
+Made Track: tt3   :7964663362428600323:   13.56   13.27  0.21  2.89
+Made SmearedTrack: ts3   :7955656569889226755:   13.75   13.45  0.21  2.89
+Made Cluster: et1   :3352955151101984769:    5.74  0.21  2.94 sub(et1, )
+Made SmearedCluster: es1   :3341670923508908033:   -0.19  0.21  2.94 sub(es1, )
+Rejected SmearedCluster: es1   :3341670923508908033:   -0.19  0.21  2.94 sub(es1, )
+Made Cluster: ht1   :5658807364900356097:    7.83  0.21  2.97 sub(ht1, )
+Made SmearedCluster: hs1   :5649791672970641409:    5.90  0.21  2.97 sub(hs1, )
+Rejected SmearedCluster: hs1   :5649791672970641409:    5.90  0.21  2.97 sub(hs1, )
+Simulating Particle :ps4   :10261491230032527364: pdgid =   130, status =   1, q =  0, e =  10.0, theta =  0.29, phi =  2.94, mass =  0.50
+Simulating Hadron
+Made Cluster: ht2   :5658812410859880450:    9.95  0.29  2.94 sub(ht2, )
+Made SmearedCluster: hs1   :5649814745153273857:   14.29  0.29  2.94 sub(hs1, )
+Simulating Particle :ps5   :10261478647768547333: pdgid =   211, status =   1, q =  1, e =   6.1, theta = -0.75, phi =  0.31, mass =  0.14
+Simulating Hadron
+Made Track: tt4   :7964642830805106692:    6.11    4.49 -0.75  0.31
+Made SmearedTrack: ts4   :7955636111770910724:    6.22    4.57 -0.75  0.31
+Made Cluster: et2   :3352942730991894530:    3.46 -0.75  0.15 sub(et2, )
+Made SmearedCluster: es1   :3341670923508908033:   -0.63 -0.75  0.15 sub(es1, )
+Rejected SmearedCluster: es1   :3341670923508908033:   -0.63 -0.75  0.15 sub(es1, )
+Made Cluster: ht3   :5658778732616220675:    2.66 -0.75  0.07 sub(ht3, )
+Made SmearedCluster: hs2   :5649791128059248642:    5.77 -0.75  0.07 sub(hs2, )
+Simulating Particle :ps6   :10261477879596449798: pdgid =    22, status =   1, q =  0, e =   5.9, theta =  0.35, phi =  2.92, mass =  0.00
+Simulating Photon
+Made Cluster: et3   :3352956051210108931:    5.94  0.35  2.92 sub(et3, )
+Made SmearedCluster: es1   :3343947934407327745:    5.73  0.35  2.92 sub(es1, )
+Simulating Particle :ps7   :10261477443785195527: pdgid =   130, status =   1, q =  0, e =   5.8, theta =  0.28, phi =  2.89, mass =  0.50
+Simulating Hadron
+Made Cluster: et4   :3352915414920200196:    1.18  0.28  2.89 sub(et4, )
+Made SmearedCluster: es2   :3343951045486182402:    6.44  0.28  2.89 sub(es2, )
+Made Cluster: ht4   :5658793455432761348:    4.67  0.28  2.89 sub(ht4, )
+Made SmearedCluster: hs3   :5649714722952445955:    0.28  0.28  2.89 sub(hs3, )
+Rejected SmearedCluster: hs3   :5649714722952445955:    0.28  0.28  2.89 sub(hs3, )
+Simulating Particle :ps8   :10261474518511910920: pdgid =    22, status =   1, q =  0, e =   5.2, theta = -0.86, phi =  0.37, mass =  0.00
+Simulating Photon
+Made Cluster: et5   :3352952690125570053:    5.18 -0.86  0.37 sub(et5, )
+Made SmearedCluster: es3   :3343943579117551619:    4.74 -0.86  0.37 sub(es3, )
+Simulating Particle :ps9   :10261472966749454345: pdgid =    22, status =   1, q =  0, e =   4.8, theta = -0.65, phi =  0.56, mass =  0.00
+Simulating Photon
+Made Cluster: et6   :3352951138363113478:    4.82 -0.65  0.56 sub(et6, )
+Made SmearedCluster: es4   :3343943909737758724:    4.82 -0.65  0.56 sub(es4, )
+Simulating Particle :ps10  :10261470647595040778: pdgid =    22, status =   1, q =  0, e =   4.3, theta =  0.24, phi =  2.92, mass =  0.00
+Simulating Photon
+Made Cluster: et7   :3352948819208699911:    4.30  0.24  2.92 sub(et7, )
+Made SmearedCluster: es5   :3343941323492163589:    4.23  0.24  2.92 sub(es5, )
+Simulating Particle :ps11  :10261468773693259787: pdgid =   211, status =   1, q =  1, e =   3.9, theta =  0.37, phi =  2.81, mass =  0.14
+Simulating Hadron
+Made Track: tt5   :7964632941955383301:    3.93    3.67  0.37  2.81
+Made SmearedTrack: ts5   :7955626301392420869:    4.00    3.73  0.37  2.81
+Made Cluster: et8   :3352912622503591944:    1.02  0.37  2.61 sub(et8, )
+Made SmearedCluster: es6   :3343913743510667270:    1.49  0.37  2.61 sub(es6, )
+Made Cluster: ht5   :5658781012369342469:    2.92  0.37  2.51 sub(ht5, )
+Made SmearedCluster: hs3   :5649785700227219459:    4.54  0.37  2.51 sub(hs3, )
+Rejected SmearedCluster: hs3   :5649785700227219459:    4.54  0.37  2.51 sub(hs3, )
+Simulating Particle :ps12  :10261460482690908172: pdgid =  -211, status =   1, q = -1, e =   3.0, theta = -0.80, phi =  0.41, mass =  0.14
+Simulating Hadron
+Made Track: tt6   :7964624644089053190:    2.99    2.08 -0.80  0.41
+Made SmearedTrack: ts6   :7955617412905172998:    2.99    2.08 -0.80  0.41
+Made Cluster: et9   :3352916842573201417:    1.26 -0.81  0.77 sub(et9, )
+Made SmearedCluster: es7   :3343919220095188999:    1.80 -0.81  0.77 sub(es7, )
+Made Cluster: ht6   :5658768290875441158:    1.74 -0.82  0.95 sub(ht6, )
+Made SmearedCluster: hs3   :5649777213363453955:    3.31 -0.82  0.95 sub(hs3, )
+Rejected SmearedCluster: hs3   :5649777213363453955:    3.31 -0.82  0.95 sub(hs3, )
+Simulating Particle :ps13  :10261458889176252429: pdgid =   130, status =   1, q =  0, e =   2.8, theta =  0.26, phi =  2.57, mass =  0.50
+Simulating Hadron
+Made Cluster: ht7   :5658780070003605511:    2.81  0.26  2.57 sub(ht7, )
+Made SmearedCluster: hs3   :5647513932722601987:   -2.54  0.26  2.57 sub(hs3, )
+Rejected SmearedCluster: hs3   :5647513932722601987:   -2.54  0.26  2.57 sub(hs3, )
+Simulating Particle :ps14  :10261458781028220942: pdgid =    22, status =   1, q =  0, e =   2.8, theta =  0.32, phi =  2.81, mass =  0.00
+Simulating Photon
+Made Cluster: et10  :3352936952641880074:    2.80  0.32  2.81 sub(et10, )
+Made SmearedCluster: es8   :3343930238577934344:    2.85  0.32  2.81 sub(es8, )
+Simulating Particle :ps15  :10261455646821974031: pdgid =    22, status =   1, q =  0, e =   2.4, theta =  0.37, phi =  2.72, mass =  0.00
+Simulating Photon
+Made Cluster: et11  :3352933818435633163:    2.44  0.37  2.72 sub(et11, )
+Made SmearedCluster: es9   :3343925986184921097:    2.37  0.37  2.72 sub(es9, )
+Simulating Particle :ps16  :10261452737633845264: pdgid =  -211, status =   1, q = -1, e =   2.1, theta = -0.68, phi =  0.12, mass =  0.14
+Simulating Hadron
+Made Track: tt7   :7964616887067738119:    2.11    1.64 -0.68  0.12
+Made SmearedTrack: ts7   :7955609945672515591:    2.14    1.66 -0.68  0.12
+Made Cluster: et12  :3352898020397023244:    0.59 -0.70  0.59 sub(et12, )
+Made SmearedCluster: es10  :3343891915778031626:    0.62 -0.70  0.59 sub(es10, )
+Made Cluster: ht8   :5658764467939311624:    1.52 -0.72  0.84 sub(ht8, )
+Made SmearedCluster: hs3   :5649772896535445507:    2.81 -0.72  0.84 sub(hs3, )
+Simulating Particle :ps17  :10261449342829199377: pdgid =   211, status =   1, q =  1, e =   1.9, theta = -0.21, phi =  0.60, mass =  0.14
+Simulating Hadron
+Made Track: tt8   :7964613440773816328:    1.86    1.82 -0.21  0.60
+Made SmearedTrack: ts8   :7955606062491500552:    1.85    1.81 -0.21  0.60
+Made Cluster: et13  :3352917055660621837:    1.27 -0.21  0.18 sub(et13, )
+Made SmearedCluster: es11  :3341670923508908043:   -4.72 -0.21  0.18 sub(es11, )
+Rejected SmearedCluster: es11  :3341670923508908043:   -4.72 -0.21  0.18 sub(es11, )
+Made Cluster: ht9   :5658741072799465481:    0.59 -0.22 -0.04 sub(ht9, )
+Made SmearedCluster: hs4   :5647513932722601988:   -0.49 -0.22 -0.04 sub(hs4, )
+Rejected SmearedCluster: hs4   :5647513932722601988:   -0.49 -0.22 -0.04 sub(hs4, )
+Simulating Particle :ps18  :10261449132098977810: pdgid =   321, status =   1, q =  1, e =   1.9, theta =  0.29, phi =  2.61, mass =  0.49
+Simulating Hadron
+Made Track: tt9   :7964612142689157129:    1.78    1.71  0.29  2.61
+Made SmearedTrack: ts9   :7955604872257077257:    1.78    1.71  0.29  2.61
+Made Cluster: ht10  :5658770312926330890:    1.85  0.31  1.93 sub(ht10, )
+Made SmearedCluster: hs4   :5649767792036020228:    2.23  0.31  1.93 sub(hs4, )
+Simulating Particle :ps19  :10261448394358652947: pdgid =    22, status =   1, q =  0, e =   1.8, theta =  0.25, phi =  2.87, mass =  0.00
+Simulating Photon
+Made Cluster: et14  :3352926565972312078:    1.81  0.25  2.87 sub(et14, )
+Made SmearedCluster: es11  :3343917188175101963:    1.69  0.25  2.87 sub(es11, )
+Simulating Particle :ps20  :10261442712557322260: pdgid =   211, status =   1, q =  1, e =   1.5, theta = -0.73, phi =  0.55, mass =  0.14
+Simulating Hadron
+Made Track: tt10  :7964606787053682698:    1.48    1.10 -0.73  0.55
+Made SmearedTrack: ts10  :7955599696097968138:    1.49    1.11 -0.73  0.55
+Made Cluster: ht11  :5658763893384675339:    1.49 -0.90 -0.82 sub(ht11, )
+Made SmearedCluster: hs5   :5647513932722601989:   -1.51 -0.90 -0.82 sub(hs5, )
+Rejected SmearedCluster: hs5   :5647513932722601989:   -1.51 -0.90 -0.82 sub(hs5, )
+Simulating Particle :ps21  :10261441994010132501: pdgid =  -211, status =   1, q = -1, e =   1.4, theta = -0.59, phi =  0.61, mass =  0.14
+Simulating Hadron
+Made Track: tt11  :7964606065226547211:    1.44    1.19 -0.59  0.61
+Made SmearedTrack: ts11  :7955598784398884875:    1.43    1.19 -0.59  0.61
+Made Cluster: et15  :3352852602642497551:    0.10 -0.63  1.27 sub(et15, )
+Made SmearedCluster: es12  :3341670923508908044:   -0.51 -0.63  1.27 sub(es12, )
+Rejected SmearedCluster: es12  :3341670923508908044:   -0.51 -0.63  1.27 sub(es12, )
+Made Cluster: ht12  :5658761410264432652:    1.35 -0.70  1.74 sub(ht12, )
+Made SmearedCluster: hs5   :5647513932722601989:   -6.07 -0.70  1.74 sub(hs5, )
+Rejected SmearedCluster: hs5   :5647513932722601989:   -6.07 -0.70  1.74 sub(hs5, )
+Simulating Particle :ps22  :10261441612802424854: pdgid =    22, status =   1, q =  0, e =   1.4, theta =  0.13, phi =  2.59, mass =  0.00
+Simulating Photon
+Made Cluster: et16  :3352919784416083984:    1.42  0.13  2.59 sub(et16, )
+Made SmearedCluster: es12  :3343916612160847884:    1.65  0.13  2.59 sub(es12, )
+Simulating Particle :ps23  :10261440106883710999: pdgid =    22, status =   1, q =  0, e =   1.3, theta = -0.84, phi =  0.30, mass =  0.00
+Simulating Photon
+Made Cluster: et17  :3352918278497370129:    1.34 -0.84  0.30 sub(et17, )
+Made SmearedCluster: es13  :3343912141536100365:    1.40 -0.84  0.30 sub(es13, )
+Simulating Particle :ps24  :10261439488473432088: pdgid =  -211, status =   1, q = -1, e =   1.3, theta = -0.54, phi =  2.18, mass =  0.14
+Simulating Hadron
+Made Track: tt12  :7964603546628784140:    1.30    1.11 -0.54  2.18
+Made SmearedTrack: ts12  :7955596401440718860:    1.30    1.11 -0.54  2.18
+Rejected SmearedTrack: ts12  :7955596401440718860:    1.30    1.11 -0.54  2.18
+Made Cluster: et18  :3352882254041841682:    0.32 -0.58  2.91 sub(et18, )
+Made SmearedCluster: es14  :3341670923508908046:   -2.28 -0.58  2.91 sub(es14, )
+Rejected SmearedCluster: es14  :3341670923508908046:   -2.28 -0.58  2.91 sub(es14, )
+Made Cluster: ht13  :5658754648891195405:    0.98 -0.70 -2.76 sub(ht13, )
+Made SmearedCluster: hs5   :5649764370803064837:    1.92 -0.70 -2.76 sub(hs5, )
+Rejected SmearedCluster: hs5   :5649764370803064837:    1.92 -0.70 -2.76 sub(hs5, )
+Simulating Particle :ps25  :10261439097719488537: pdgid =  -321, status =   1, q = -1, e =   1.3, theta = -0.33, phi =  0.88, mass =  0.49
+Simulating Hadron
+Made Track: tt13  :7964601546631544845:    1.18    1.12 -0.33  0.88
+Made SmearedTrack: ts12  :7955594516111556620:    1.19    1.13 -0.33  0.88
+Made Cluster: et19  :3352900626783666195:    0.67 -0.35  1.60 sub(et19, )
+Made SmearedCluster: es14  :3341670923508908046:   -5.79 -0.35  1.60 sub(es14, )
+Rejected SmearedCluster: es14  :3341670923508908046:   -5.79 -0.35  1.60 sub(es14, )
+Made Cluster: ht14  :5658741736722137102:    0.61 -0.43  2.19 sub(ht14, )
+Made SmearedCluster: hs5   :5649768384666009605:    2.30 -0.43  2.19 sub(hs5, )
+Simulating Particle :ps26  :10261436488640102426: pdgid =    22, status =   1, q =  0, e =   1.1, theta = -0.71, phi =  0.57, mass =  0.00
+Simulating Photon
+Made Cluster: et20  :3352914660253761556:    1.13 -0.71  0.56 sub(et20, )
+Made SmearedCluster: es14  :3343901184799801358:    0.89 -0.71  0.56 sub(es14, )
+Simulating Particle :ps27  :10261436320104579099: pdgid =   321, status =   1, q =  1, e =   1.1, theta = -0.21, phi =  1.70, mass =  0.49
+Simulating Hadron
+Made Track: tt14  :7964598498492416014:    1.01    0.99 -0.21  1.70
+Made SmearedTrack: ts13  :7955591568686055437:    1.02    1.00 -0.21  1.70
+Made Cluster: et21  :3352896679578697749:    0.56 -0.24  0.85 sub(et21, )
+Made SmearedCluster: es15  :3343939075320053775:    3.86 -0.24  0.85 sub(es15, )
+Made Cluster: ht15  :5658740128697286671:    0.57 -1.21  1.10 sub(ht15, )
+Made SmearedCluster: hs6   :5649807328856244230:   10.92 -1.21  1.10 sub(hs6, )
+Rejected SmearedCluster: hs6   :5649807328856244230:   10.92 -1.21  1.10 sub(hs6, )
+Simulating Particle :ps28  :10261436218717765660: pdgid =    22, status =   1, q =  0, e =   1.1, theta = -0.43, phi =  0.98, mass =  0.00
+Simulating Photon
+Made Cluster: et22  :3352914390331424790:    1.12 -0.43  0.98 sub(et22, )
+Made SmearedCluster: es16  :3343908561993334800:    1.20 -0.43  0.98 sub(es16, )
+Simulating Particle :ps29  :10261436005185749021: pdgid =    22, status =   1, q =  0, e =   1.1, theta =  0.04, phi =  0.62, mass =  0.00
+Simulating Photon
+Made Cluster: et23  :3352914176799408151:    1.10  0.04  0.62 sub(et23, )
+Made SmearedCluster: es17  :3343908952986353681:    1.22  0.04  0.62 sub(es17, )
+Simulating Particle :ps30  :10261435951014215710: pdgid =    22, status =   1, q =  0, e =   1.1, theta =  0.05, phi =  2.82, mass =  0.00
+Simulating Photon
+Made Cluster: et24  :3352914122627874840:    1.10  0.05  2.82 sub(et24, )
+Made SmearedCluster: es18  :3343903467029659666:    0.95  0.05  2.82 sub(es18, )
+Simulating Particle :ps31  :10261435443968999455: pdgid =    22, status =   1, q =  0, e =   1.1, theta =  0.16, phi =  2.67, mass =  0.00
+Simulating Photon
+Made Cluster: et25  :3352913615582658585:    1.07  0.16  2.67 sub(et25, )
+Made SmearedCluster: es19  :3343904166373228563:    0.97  0.16  2.67 sub(es19, )
+Simulating Particle :ps32  :10261433665537966112: pdgid =    22, status =   1, q =  0, e =   1.0, theta = -1.15, phi =  0.30, mass =  0.00
+Simulating Photon
+Made Cluster: et26  :3352911837151625242:    0.99 -1.15  0.30 sub(et26, )
+Made SmearedCluster: es20  :3343902175731384340:    0.92 -1.15  0.30 sub(es20, )
+Rejected SmearedCluster: es20  :3343902175731384340:    0.92 -1.15  0.30 sub(es20, )
+Simulating Particle :ps33  :10261429927163199521: pdgid =  -211, status =   1, q = -1, e =   0.9, theta = -0.49, phi =  0.35, mass =  0.14
+Simulating Hadron
+Made Track: tt15  :7964593725181526031:    0.87    0.77 -0.49  0.35
+Made SmearedTrack: ts14  :7955586431154389006:    0.87    0.77 -0.49  0.35
+Made Cluster: et27  :3352866388386512923:    0.17 -0.62  1.65 sub(et27, )
+Made SmearedCluster: es20  :3341670923508908052:   -1.73 -0.62  1.65 sub(es20, )
+Rejected SmearedCluster: es20  :3341670923508908052:   -1.73 -0.62  1.65 sub(es20, )
+Made Cluster: ht16  :5658745001306226704:    0.71 -1.32  0.87 sub(ht16, )
+Made SmearedCluster: hs6   :5647513932722601990:   -1.12 -1.32  0.87 sub(hs6, )
+Rejected SmearedCluster: hs6   :5647513932722601990:   -1.12 -1.32  0.87 sub(hs6, )
+Simulating Particle :ps34  :10261426135210393634: pdgid =   211, status =   1, q =  1, e =   0.8, theta =  0.06, phi =  1.69, mass =  0.14
+Simulating Hadron
+Made Track: tt16  :7964589877637414928:    0.76    0.76  0.06  1.69
+Made SmearedTrack: ts15  :7955582373356109839:    0.75    0.75  0.06  1.69
+Made Cluster: et28  :3352894301127311388:    0.49  0.09  0.33 sub(et28, )
+Made SmearedCluster: es20  :3343928062981963796:    2.61  0.09  0.33 sub(es20, )
+Made Cluster: ht17  :5658722137364496401:    0.28  1.30 -0.88 sub(ht17, )
+Made SmearedCluster: hs6   :5649784847187574790:    4.35  1.30 -0.88 sub(hs6, )
+Simulating Particle :ps35  :10261425737049309219: pdgid =    22, status =   1, q =  0, e =   0.8, theta =  0.43, phi =  3.12, mass =  0.00
+Simulating Photon
+Made Cluster: et29  :3352903908662968349:    0.76  0.43  3.12 sub(et29, )
+Made SmearedCluster: es21  :3343894950537330709:    0.71  0.43  3.12 sub(es21, )
+Simulating Particle :ps36  :10261423313685315620: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.05, phi =  2.78, mass =  0.00
+Simulating Photon
+Made Cluster: et30  :3352901485298974750:    0.69  0.05  2.78 sub(et30, )
+Made SmearedCluster: es22  :3343896595356712982:    0.76  0.05  2.78 sub(es22, )
+Simulating Particle :ps38  :10261419917720944678: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.82, phi =  0.55, mass =  0.00
+Simulating Photon
+Made Cluster: et31  :3352898089334603807:    0.60 -0.82  0.55 sub(et31, )
+Made SmearedCluster: es23  :3343883247850356759:    0.44 -0.82  0.55 sub(es23, )
+Simulating Particle :ps39  :10261417455251357735: pdgid =   211, status =   1, q =  1, e =   0.5, theta =  0.46, phi = -0.64, mass =  0.14
+Simulating Hadron
+Made Track: tt17  :7964580980925136913:    0.51    0.45  0.46 -0.64
+Made SmearedTrack: ts16  :7955573667537092624:    0.50    0.45  0.46 -0.64
+Rejected SmearedTrack: ts16  :7955573667537092624:    0.50    0.45  0.46 -0.64
+Made Cluster: et32  :3352869504943128608:    0.20  1.21 -2.53 sub(et32, )
+Made SmearedCluster: es24  :3343970781334863896:   13.85  1.21 -2.53 sub(es24, )
+Made Cluster: ht18  :5658725753091522578:    0.33  1.50 -0.89 sub(ht18, )
+Made SmearedCluster: hs7   :5649793036046041095:    6.21  1.50 -0.89 sub(hs7, )
+Rejected SmearedCluster: hs7   :5649793036046041095:    6.21  1.50 -0.89 sub(hs7, )
+Simulating Particle :ps40  :10261417209983139880: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.29, phi =  0.97, mass =  0.00
+Simulating Photon
+Made Cluster: et33  :3352895381596799009:    0.52 -0.29  0.97 sub(et33, )
+Made SmearedCluster: es25  :3343877162957537305:    0.35 -0.29  0.97 sub(es25, )
+Simulating Particle :ps41  :10261416524319293481: pdgid =  -211, status =   1, q = -1, e =   0.5, theta =  0.24, phi =  1.78, mass =  0.14
+Simulating Hadron
+Made Track: tt18  :7964579314043715602:    0.48    0.47  0.24  1.78
+Made SmearedTrack: ts16  :7955572330271342608:    0.48    0.47  0.24  1.78
+Rejected SmearedTrack: ts16  :7955572330271342608:    0.48    0.47  0.24  1.78
+Made Cluster: et34  :3352879895815389218:    0.29  1.38  2.26 sub(et34, )
+Made SmearedCluster: es26  :3343928717570211866:    2.68  1.38  2.26 sub(es26, )
+Made Cluster: ht19  :5658714571093835795:    0.21  1.47  2.09 sub(ht19, )
+Made SmearedCluster: hs7   :5647513932722601991:  -11.77  1.47  2.09 sub(hs7, )
+Rejected SmearedCluster: hs7   :5647513932722601991:  -11.77  1.47  2.09 sub(hs7, )
+Simulating Particle :ps42  :10261416229623300138: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.34, phi =  2.94, mass =  0.00
+Simulating Photon
+Made Cluster: et35  :3352894401236959267:    0.50  0.34  2.94 sub(et35, )
+Made SmearedCluster: es27  :3343884931754360859:    0.46  0.34  2.94 sub(es27, )
+Simulating Particle :ps43  :10261416006685556779: pdgid =  -211, status =   1, q = -1, e =   0.5, theta =  0.84, phi =  2.42, mass =  0.14
+Simulating Hadron
+Made Track: tt19  :7964578774587015187:    0.47    0.32  0.84  2.42
+Made SmearedTrack: ts16  :7955570512386588688:    0.46    0.31  0.84  2.42
+Rejected SmearedTrack: ts16  :7955570512386588688:    0.46    0.31  0.84  2.42
+Made Cluster: ht20  :5658737187512909844:    0.49  1.38 -2.78 sub(ht20, )
+Made SmearedCluster: hs7   :5647513932722601991:   -5.09  1.38 -2.78 sub(hs7, )
+Rejected SmearedCluster: hs7   :5647513932722601991:   -5.09  1.38 -2.78 sub(hs7, )
+Simulating Particle :ps44  :10261415510759440428: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.52, phi =  1.61, mass =  0.00
+Simulating Photon
+Made Cluster: et36  :3352893682373099556:    0.48  0.52  1.61 sub(et36, )
+Made SmearedCluster: es28  :3343889927472414748:    0.57  0.52  1.61 sub(es28, )
+Simulating Particle :ps45  :10261415203440689197: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.11, phi =  1.83, mass =  0.00
+Simulating Photon
+Made Cluster: et37  :3352893375054348325:    0.48  0.11  1.83 sub(et37, )
+Made SmearedCluster: es29  :3343889033817227293:    0.54  0.11  1.83 sub(es29, )
+Simulating Particle :ps46  :10261413357967900718: pdgid =    22, status =   1, q =  0, e =   0.5, theta = -0.28, phi =  1.10, mass =  0.00
+Simulating Photon
+Made Cluster: et38  :3352891529581559846:    0.45 -0.28  1.10 sub(et38, )
+Made SmearedCluster: es30  :3343890120884355102:    0.57 -0.28  1.10 sub(es30, )
+Simulating Particle :ps47  :10261411697306632239: pdgid =    22, status =   1, q =  0, e =   0.4, theta =  0.05, phi =  2.74, mass =  0.00
+Simulating Photon
+Made Cluster: et39  :3352889868920291367:    0.43  0.05  2.74 sub(et39, )
+Made SmearedCluster: es31  :3343887550726012959:    0.50  0.05  2.74 sub(es31, )
+Simulating Particle :ps48  :10261408681581084720: pdgid =   211, status =   1, q =  1, e =   0.4, theta =  0.16, phi =  0.37, mass =  0.14
+Simulating Hadron
+Made Track: tt20  :7964571043733962772:    0.36    0.36  0.16  0.37
+Made SmearedTrack: ts16  :7955563593680814096:    0.36    0.35  0.16  0.37
+Rejected SmearedTrack: ts16  :7955563593680814096:    0.36    0.35  0.16  0.37
+Made Cluster: et40  :3352862469377753128:    0.15  1.35 -0.44 sub(et40, )
+Made SmearedCluster: es32  :3343934844653535264:    3.38  1.35 -0.44 sub(es32, )
+Made Cluster: ht21  :5658719061855436821:    0.24  1.47 -0.05 sub(ht21, )
+Made SmearedCluster: hs7   :5649814074043662343:   13.98  1.47 -0.05 sub(hs7, )
+Simulating Particle :ps49  :10261404017798152241: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.36, phi =  3.02, mass =  0.00
+Simulating Photon
+Made Cluster: et41  :3352882189411811369:    0.32  0.36  3.02 sub(et41, )
+Made SmearedCluster: es33  :3343846084301553697:    0.10  0.36  3.02 sub(es33, )
+Rejected SmearedCluster: es33  :3343846084301553697:    0.10  0.36  3.02 sub(es33, )
+Simulating Particle :ps52  :10261399412376862772: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.08, phi = -2.85, mass =  0.00
+Simulating Photon
+Made Cluster: et42  :3352877583990521898:    0.26  0.08 -2.85 sub(et42, )
+Made SmearedCluster: es33  :3343873929654566945:    0.31  0.08 -2.85 sub(es33, )
+Simulating Particle :ps53  :10261385841601413173: pdgid =    22, status =   1, q =  0, e =   0.2, theta = -0.53, phi =  0.52, mass =  0.00
+Simulating Photon
+Made Cluster: et43  :3352864013215072299:    0.16 -0.53  0.52 sub(et43, )
+Made SmearedCluster: es34  :3343873623319380002:    0.30 -0.53  0.52 sub(es34, )
+Simulating Particle :ps54  :10261384192656932918: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.75, phi =  0.73, mass =  0.00
+Simulating Photon
+Made Cluster: et44  :3352862364270592044:    0.14 -0.75  0.73 sub(et44, )
+Made SmearedCluster: es35  :3343872605330341923:    0.29 -0.75  0.73 sub(es35, )
+Rejected SmearedCluster: es35  :3343872605330341923:    0.29 -0.75  0.73 sub(es35, )
+Simulating Particle :ps55  :10261384103410532407: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.12, phi =  0.92, mass =  0.00
+Simulating Photon
+Made Cluster: et45  :3352862275024191533:    0.14 -0.12  0.92 sub(et45, )
+Made SmearedCluster: es35  :3343880092758573091:    0.39 -0.12  0.92 sub(es35, )
+Simulating Particle :ps56  :10261381992106950712: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.87, phi = -0.20, mass =  0.00
+Simulating Photon
+Made Cluster: et46  :3352860163720609838:    0.13 -0.87 -0.20 sub(et46, )
+Made SmearedCluster: es36  :3341670923508908068:   -0.04 -0.87 -0.20 sub(es36, )
+Rejected SmearedCluster: es36  :3341670923508908068:   -0.04 -0.87 -0.20 sub(es36, )
+Simulating Particle :ps57  :10261380011911020601: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.44, phi =  1.99, mass =  0.00
+Simulating Photon
+Made Cluster: et47  :3352858183524679727:    0.12 -0.44  1.99 sub(et47, )
+Made SmearedCluster: es36  :3341670923508908068:   -0.15 -0.44  1.99 sub(es36, )
+Rejected SmearedCluster: es36  :3341670923508908068:   -0.15 -0.44  1.99 sub(es36, )
+Simulating Particle :ps58  :10261369911198613562: pdgid =    22, status =   1, q =  0, e =   0.1, theta = -0.22, phi =  0.41, mass =  0.00
+Simulating Photon
+Made Cluster: et48  :3352848082812272688:    0.08 -0.22  0.41 sub(et48, )
+Made SmearedCluster: es36  :3341670923508908068:   -0.04 -0.22  0.41 sub(es36, )
+Rejected SmearedCluster: es36  :3341670923508908068:   -0.04 -0.22  0.41 sub(es36, )
+Simulating Particle :ps59  :10261349540049190971: pdgid =    22, status =   1, q =  0, e =   0.0, theta = -0.24, phi = -2.66, mass =  0.00
+Simulating Photon
+Made Cluster: et49  :3352827711662850097:    0.04 -0.24 -2.66 sub(et49, )
+Made SmearedCluster: es36  :3341670923508908068:   -0.11 -0.24 -2.66 sub(es36, )
+Rejected SmearedCluster: es36  :3341670923508908068:   -0.11 -0.24 -2.66 sub(es36, )
+Made MergedCluster: em0   :3289830427790934016:    0.30 -0.53  0.52 sub(es34, )
+Made MergedCluster: em1   :3289830734126120961:    0.31  0.08 -2.85 sub(es33, )
+Made MergedCluster: em2   :3289833967429091330:    0.35 -0.29  0.97 sub(es25, )
+Made MergedCluster: em3   :3289836897230127107:    0.39 -0.12  0.92 sub(es35, )
+Made MergedCluster: em4   :3289840052321910788:    0.44 -0.82  0.55 sub(es23, )
+Made MergedCluster: em5   :3289935107615358981:   18.55  0.29  2.90 sub(es2, es1, es5, es11, es27, )
+Made MergedCluster: em6   :3289881378813902854:    2.21  0.05  2.79 sub(es18, es22, es31, )
+Made MergedCluster: em7   :3289845838288781319:    0.54  0.11  1.83 sub(es29, )
+Made MergedCluster: em8   :3289846731943968776:    0.57  0.52  1.61 sub(es28, )
+Made MergedCluster: em9   :3289846925355909129:    0.57 -0.28  1.10 sub(es30, )
+Made MergedCluster: em10  :3289907365089902602:    6.33 -0.66  0.56 sub(es4, es14, es10, )
+Made MergedCluster: em11  :3289851755008884747:    0.71  0.43  3.12 sub(es21, )
+Made MergedCluster: em12  :3289860970844782604:    0.97  0.16  2.67 sub(es19, )
+Made MergedCluster: em13  :3289865366464888845:    1.20 -0.43  0.98 sub(es16, )
+Made MergedCluster: em14  :3289865757457907726:    1.22  0.04  0.62 sub(es17, )
+Made MergedCluster: em15  :3289868946007654415:    1.40 -0.84  0.30 sub(es13, )
+Made MergedCluster: em16  :3289870547982221328:    1.49  0.37  2.61 sub(es6, )
+Made MergedCluster: em17  :3289873416632401937:    1.65  0.13  2.59 sub(es12, )
+Made MergedCluster: em18  :3289876024566743058:    1.80 -0.81  0.77 sub(es7, )
+Made MergedCluster: em19  :3289882790656475155:    2.37  0.37  2.72 sub(es9, )
+Made MergedCluster: em20  :3289884867453517844:    2.61  0.09  0.33 sub(es20, )
+Made MergedCluster: em21  :3289885522041765909:    2.68  1.38  2.26 sub(es26, )
+Made MergedCluster: em22  :3289887043049488406:    2.85  0.32  2.81 sub(es8, )
+Made MergedCluster: em23  :3289891649125089303:    3.38  1.35 -0.44 sub(es32, )
+Made MergedCluster: em24  :3289895879791607832:    3.86 -0.24  0.85 sub(es15, )
+Made MergedCluster: em25  :3289900383589105689:    4.74 -0.86  0.37 sub(es3, )
+Made MergedCluster: em26  :3289927585806417946:   13.85  1.21 -2.53 sub(es24, )
+Made MergedCluster: em27  :3289934894783791131:   18.36 -0.79  0.37 sub(es0, )
+Made MergedCluster: hm0   :5595724596507574272:    2.23  0.31  1.93 sub(hs4, )
+Made MergedCluster: hm1   :5595725189137563649:    2.30 -0.43  2.19 sub(hs5, )
+Made MergedCluster: hm2   :5595729701006999554:    2.81 -0.72  0.84 sub(hs3, )
+Made MergedCluster: hm3   :5595741651659128835:    4.35  1.30 -0.88 sub(hs6, )
+Made MergedCluster: hm4   :5595747932530802692:    5.77 -0.75  0.07 sub(hs2, )
+Made MergedCluster: hm5   :5595770878515216389:   13.98  1.47 -0.05 sub(hs7, )
+Made MergedCluster: hm6   :5595771549624827910:   14.29  0.29  2.94 sub(hs1, )
+Made MergedCluster: hm7   :5595779142311215111:   19.48 -0.79  0.36 sub(hs0, )
+Made block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289830427790934016)
+
+Made block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.3 (3289830734126120961)
+
+Made block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.4 (3289833967429091330)
+
+Made block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.4 (3289836897230127107)
+
+Made block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.4 (3289840052321910788)
+
+Made block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.5 (3289845838288781319)
+
+Made block:E1       :br6   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.6 (3289846731943968776)
+
+Made block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  0.6 (3289846925355909129)
+
+Made block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  0.7 (3289851755008884747)
+
+Made block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  1.0 (3289860970844782604)
+
+Made block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  1.2 (3289865366464888845)
+
+Made block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  1.2 (3289865757457907726)
+
+Made block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  1.4 (3289868946007654415)
+
+Made block:E1T1     :br13  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts5       value=  4.0 (7955626301392420869)
+      e1 = em16      value=  1.5 (3289870547982221328)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  1.7 (3289873416632401937)
+
+Made block:E1T1     :br15  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts6       value=  3.0 (7955617412905172998)
+      e1 = em18      value=  1.8 (3289876024566743058)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  2.2 (3289881378813902854)
+
+Made block:E1       :br17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  2.4 (3289882790656475155)
+
+Made block:E1H1T1   :br18  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts15      value=  0.8 (7955582373356109839)
+      h1 = hm3       value=  4.3 (5595741651659128835)
+      e2 = em20      value=  2.6 (3289884867453517844)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1       :br19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  2.7 (3289885522041765909)
+
+Made block:E1       :br20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  2.9 (3289887043049488406)
+
+Made block:E1       :br21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  3.4 (3289891649125089303)
+
+Made block:E1T1     :br22  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.0 (7955591568686055437)
+      e1 = em24      value=  3.9 (3289895879791607832)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1       :br23  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em25      value=  4.7 (3289900383589105689)
+
+Made block:E1H1T1   :br24  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  2.1 (7955609945672515591)
+      h1 = hm2       value=  2.8 (5595729701006999554)
+      e2 = em10      value=  6.3 (3289907365089902602)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1       :br25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em26      value= 13.9 (3289927585806417946)
+
+Made block:E1H1T1   :br26  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts2       value= 29.9 (7955676761769902082)
+      h1 = hm7       value= 19.5 (5595779142311215111)
+      e2 = em27      value= 18.4 (3289934894783791131)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1       :br27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value= 18.5 (3289935107615358981)
+
+Made block:H1T1     :br28  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  1.8 (7955604872257077257)
+      h1 = hm0       value=  2.2 (5595724596507574272)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br29  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts12      value=  1.2 (7955594516111556620)
+      h1 = hm1       value=  2.3 (5595725189137563649)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :br30  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  6.2 (7955636111770910724)
+      h1 = hm4       value=  5.8 (5595747932530802692)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1       :br31  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value= 14.0 (5595770878515216389)
+
+Made block:H1T1     :br32  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value= 13.7 (7955656569889226755)
+      h1 = hm6       value= 14.3 (5595771549624827910)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.1715       .
+
+Made block:T1       :br33  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  0.9 (7955586431154389006)
+
+Made block:T1       :br34  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  1.4 (7955598784398884875)
+
+Made block:T1       :br35  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  1.5 (7955599696097968138)
+
+Made block:T1       :br36  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  1.8 (7955606062491500552)
+
+Made block:T1       :br37  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 38.9 (7955682910005100545)
+
+Made block:T1       :br38  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 65.3 (7955697051258322944)
+
+Splitting block:E1H1T1   :br26  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts2       value= 29.9 (7955676761769902082)
+      h1 = hm7       value= 19.5 (5595779142311215111)
+      e2 = em27      value= 18.4 (3289934894783791131)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs0   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts2       value= 29.9 (7955676761769902082)
+      h1 = hm7       value= 19.5 (5595779142311215111)
+      e2 = em27      value= 18.4 (3289934894783791131)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:E1H1T1   :br24  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  2.1 (7955609945672515591)
+      h1 = hm2       value=  2.8 (5595729701006999554)
+      e2 = em10      value=  6.3 (3289907365089902602)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs1   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  2.1 (7955609945672515591)
+      h1 = hm2       value=  2.8 (5595729701006999554)
+      e2 = em10      value=  6.3 (3289907365089902602)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:E1H1T1   :br18  : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts15      value=  0.8 (7955582373356109839)
+      h1 = hm3       value=  4.3 (5595741651659128835)
+      e2 = em20      value=  2.6 (3289884867453517844)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made block:E1H1T1   :bs2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts15      value=  0.8 (7955582373356109839)
+      h1 = hm3       value=  4.3 (5595741651659128835)
+      e2 = em20      value=  2.6 (3289884867453517844)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Splitting block:H1T1     :br32  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value= 13.7 (7955656569889226755)
+      h1 = hm6       value= 14.3 (5595771549624827910)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.1715       .
+
+Made block:H1T1     :bs3   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value= 13.7 (7955656569889226755)
+      h1 = hm6       value= 14.3 (5595771549624827910)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.1715       .
+
+Splitting block:H1T1     :br30  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  6.2 (7955636111770910724)
+      h1 = hm4       value=  5.8 (5595747932530802692)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs4   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  6.2 (7955636111770910724)
+      h1 = hm4       value=  5.8 (5595747932530802692)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br29  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts12      value=  1.2 (7955594516111556620)
+      h1 = hm1       value=  2.3 (5595725189137563649)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs5   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts12      value=  1.2 (7955594516111556620)
+      h1 = hm1       value=  2.3 (5595725189137563649)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:H1T1     :br28  : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  1.8 (7955604872257077257)
+      h1 = hm0       value=  2.2 (5595724596507574272)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made block:H1T1     :bs6   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  1.8 (7955604872257077257)
+      h1 = hm0       value=  2.2 (5595724596507574272)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Splitting block:E1T1     :br22  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.0 (7955591568686055437)
+      e1 = em24      value=  3.9 (3289895879791607832)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs7   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.0 (7955591568686055437)
+      e1 = em24      value=  3.9 (3289895879791607832)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br15  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts6       value=  3.0 (7955617412905172998)
+      e1 = em18      value=  1.8 (3289876024566743058)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs8   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts6       value=  3.0 (7955617412905172998)
+      e1 = em18      value=  1.8 (3289876024566743058)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:E1T1     :br13  : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts5       value=  4.0 (7955626301392420869)
+      e1 = em16      value=  1.5 (3289870547982221328)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made block:E1T1     :bs9   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts5       value=  4.0 (7955626301392420869)
+      e1 = em16      value=  1.5 (3289870547982221328)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Splitting block:T1       :br38  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 65.3 (7955697051258322944)
+
+Made block:T1       :bs10  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 65.3 (7955697051258322944)
+
+Splitting block:T1       :br37  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 38.9 (7955682910005100545)
+
+Made block:T1       :bs11  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 38.9 (7955682910005100545)
+
+Splitting block:T1       :br36  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  1.8 (7955606062491500552)
+
+Made block:T1       :bs12  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  1.8 (7955606062491500552)
+
+Splitting block:T1       :br35  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  1.5 (7955599696097968138)
+
+Made block:T1       :bs13  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  1.5 (7955599696097968138)
+
+Splitting block:T1       :br34  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  1.4 (7955598784398884875)
+
+Made block:T1       :bs14  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  1.4 (7955598784398884875)
+
+Splitting block:T1       :br33  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  0.9 (7955586431154389006)
+
+Made block:T1       :bs15  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  0.9 (7955586431154389006)
+
+Splitting block:H1       :br31  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value= 14.0 (5595770878515216389)
+
+Made block:H1       :bs16  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value= 14.0 (5595770878515216389)
+
+Splitting block:E1       :br27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value= 18.5 (3289935107615358981)
+
+Made block:E1       :bs17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value= 18.5 (3289935107615358981)
+
+Splitting block:E1       :br25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em26      value= 13.9 (3289927585806417946)
+
+Made block:E1       :bs18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em26      value= 13.9 (3289927585806417946)
+
+Splitting block:E1       :br23  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em25      value=  4.7 (3289900383589105689)
+
+Made block:E1       :bs19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em25      value=  4.7 (3289900383589105689)
+
+Splitting block:E1       :br21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  3.4 (3289891649125089303)
+
+Made block:E1       :bs20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  3.4 (3289891649125089303)
+
+Splitting block:E1       :br20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  2.9 (3289887043049488406)
+
+Made block:E1       :bs21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  2.9 (3289887043049488406)
+
+Splitting block:E1       :br19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  2.7 (3289885522041765909)
+
+Made block:E1       :bs22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  2.7 (3289885522041765909)
+
+Splitting block:E1       :br17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  2.4 (3289882790656475155)
+
+Made block:E1       :bs23  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  2.4 (3289882790656475155)
+
+Splitting block:E1       :br16  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  2.2 (3289881378813902854)
+
+Made block:E1       :bs24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  2.2 (3289881378813902854)
+
+Splitting block:E1       :br14  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  1.7 (3289873416632401937)
+
+Made block:E1       :bs25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  1.7 (3289873416632401937)
+
+Splitting block:E1       :br12  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  1.4 (3289868946007654415)
+
+Made block:E1       :bs26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  1.4 (3289868946007654415)
+
+Splitting block:E1       :br11  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  1.2 (3289865757457907726)
+
+Made block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  1.2 (3289865757457907726)
+
+Splitting block:E1       :br10  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  1.2 (3289865366464888845)
+
+Made block:E1       :bs28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  1.2 (3289865366464888845)
+
+Splitting block:E1       :br9   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  1.0 (3289860970844782604)
+
+Made block:E1       :bs29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  1.0 (3289860970844782604)
+
+Splitting block:E1       :br8   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  0.7 (3289851755008884747)
+
+Made block:E1       :bs30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  0.7 (3289851755008884747)
+
+Splitting block:E1       :br7   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  0.6 (3289846925355909129)
+
+Made block:E1       :bs31  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  0.6 (3289846925355909129)
+
+Splitting block:E1       :br6   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.6 (3289846731943968776)
+
+Made block:E1       :bs32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.6 (3289846731943968776)
+
+Splitting block:E1       :br5   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.5 (3289845838288781319)
+
+Made block:E1       :bs33  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.5 (3289845838288781319)
+
+Splitting block:E1       :br4   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.4 (3289840052321910788)
+
+Made block:E1       :bs34  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.4 (3289840052321910788)
+
+Splitting block:E1       :br3   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.4 (3289836897230127107)
+
+Made block:E1       :bs35  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.4 (3289836897230127107)
+
+Splitting block:E1       :br2   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.4 (3289833967429091330)
+
+Made block:E1       :bs36  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.4 (3289833967429091330)
+
+Splitting block:E1       :br1   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.3 (3289830734126120961)
+
+Made block:E1       :bs37  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.3 (3289830734126120961)
+
+Splitting block:E1       :br0   : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289830427790934016)
+
+Made block:E1       :bs38  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289830427790934016)
+
+Processing block:E1H1T1   :bs2   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts15      value=  0.8 (7955582373356109839)
+      h1 = hm3       value=  4.3 (5595741651659128835)
+      e2 = em20      value=  2.6 (3289884867453517844)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr0   :10252418632353054720: pdgid =   211, status =   1, q =  1, e =   0.8, theta =  0.06, phi =  1.69, mass =  0.14 from SmearedTrack: ts15  :7955582373356109839:    0.75    0.75  0.06  1.69
+Finished block
+Processing block:E1H1T1   :bs1   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts7       value=  2.1 (7955609945672515591)
+      h1 = hm2       value=  2.8 (5595729701006999554)
+      e2 = em10      value=  6.3 (3289907365089902602)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr1   :10252445795355721729: pdgid =  -211, status =   1, q = -1, e =   2.1, theta = -0.68, phi =  0.12, mass =  0.14 from SmearedTrack: ts7   :7955609945672515591:    2.14    1.66 -0.68  0.12
+Made Particle :pr2   :10252415615457296386: pdgid =   130, status =   1, q =  0, e =   0.7, theta = -0.72, phi =  0.84, mass =  0.50 from MergedCluster: hm2   :5595729701006999554:    2.81 -0.72  0.84 sub(hs3, )
+Made Particle :pr3   :10252472389004689411: pdgid =    22, status =   1, q =  0, e =   6.3, theta = -0.72, phi =  0.84, mass =  0.00 from MergedCluster: hm2   :5595729701006999554:    2.81 -0.72  0.84 sub(hs3, )
+Finished block
+Processing block:E1H1T1   :bs0   : ecals = 1 hcals = 1 tracks = 1
+    elements:
+      t0 = ts2       value= 29.9 (7955676761769902082)
+      h1 = hm7       value= 19.5 (5595779142311215111)
+      e2 = em27      value= 18.4 (3289934894783791131)
+    distances:
+              t0      h1      e2
+      t0       .
+      h1  0.0000       .
+      e2  0.0000     ---       .
+
+Made Particle :pr4   :10252512572085370884: pdgid =   211, status =   1, q =  1, e =  29.9, theta = -0.79, phi =  0.41, mass =  0.14 from SmearedTrack: ts2   :7955676761769902082:   29.86   20.92 -0.79  0.41
+Finished block
+Processing block:E1T1     :bs9   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts5       value=  4.0 (7955626301392420869)
+      e1 = em16      value=  1.5 (3289870547982221328)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr5   :10252462132608106501: pdgid =   211, status =   1, q =  1, e =   4.0, theta =  0.37, phi =  2.81, mass =  0.14 from SmearedTrack: ts5   :7955626301392420869:    4.00    3.73  0.37  2.81
+Finished block
+Processing block:E1T1     :bs8   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts6       value=  3.0 (7955617412905172998)
+      e1 = em18      value=  1.8 (3289876024566743058)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr6   :10252453251309895686: pdgid =  -211, status =   1, q = -1, e =   3.0, theta = -0.80, phi =  0.41, mass =  0.14 from SmearedTrack: ts6   :7955617412905172998:    2.99    2.08 -0.80  0.41
+Finished block
+Processing block:E1T1     :bs7   : ecals = 1 hcals = 0 tracks = 1
+    elements:
+      t0 = ts13      value=  1.0 (7955591568686055437)
+      e1 = em24      value=  3.9 (3289895879791607832)
+    distances:
+              t0      e1
+      t0       .
+      e1  0.0000       .
+
+Made Particle :pr7   :10252427543881711623: pdgid =   211, status =   1, q =  1, e =   1.0, theta = -0.21, phi =  1.70, mass =  0.14 from SmearedTrack: ts13  :7955591568686055437:    1.02    1.00 -0.21  1.70
+Finished block
+Processing block:H1T1     :bs6   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts9       value=  1.8 (7955604872257077257)
+      h1 = hm0       value=  2.2 (5595724596507574272)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr8   :10252440777544171528: pdgid =   211, status =   1, q =  1, e =   1.8, theta =  0.29, phi =  2.61, mass =  0.14 from SmearedTrack: ts9   :7955604872257077257:    1.78    1.71  0.29  2.61
+Finished block
+Processing block:H1T1     :bs5   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts12      value=  1.2 (7955594516111556620)
+      h1 = hm1       value=  2.3 (5595725189137563649)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr9   :10252430468238540809: pdgid =  -211, status =   1, q = -1, e =   1.2, theta = -0.33, phi =  0.88, mass =  0.14 from SmearedTrack: ts12  :7955594516111556620:    1.19    1.13 -0.33  0.88
+Finished block
+Processing block:H1T1     :bs4   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts4       value=  6.2 (7955636111770910724)
+      h1 = hm4       value=  5.8 (5595747932530802692)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.0000       .
+
+Made Particle :pr10  :10252471928556093450: pdgid =   211, status =   1, q =  1, e =   6.2, theta = -0.75, phi =  0.31, mass =  0.14 from SmearedTrack: ts4   :7955636111770910724:    6.22    4.57 -0.75  0.31
+Finished block
+Processing block:H1T1     :bs3   : ecals = 0 hcals = 1 tracks = 1
+    elements:
+      t0 = ts3       value= 13.7 (7955656569889226755)
+      h1 = hm6       value= 14.3 (5595771549624827910)
+    distances:
+              t0      h1
+      t0       .
+      h1  0.1715       .
+
+Made Particle :pr11  :10252492381393780747: pdgid =  -211, status =   1, q = -1, e =  13.8, theta =  0.21, phi =  2.89, mass =  0.14 from SmearedTrack: ts3   :7955656569889226755:   13.75   13.45  0.21  2.89
+Finished block
+Processing block:E1       :bs38  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em0       value=  0.3 (3289830427790934016)
+
+Made Particle :pr12  :10252395451705720844: pdgid =    22, status =   1, q =  0, e =   0.3, theta = -0.53, phi =  0.52, mass =  0.00 from MergedCluster: em0   :3289830427790934016:    0.30 -0.53  0.52 sub(es34, )
+Finished block
+Processing block:E1       :bs37  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em1       value=  0.3 (3289830734126120961)
+
+Made Particle :pr13  :10252395758040907789: pdgid =    22, status =   1, q =  0, e =   0.3, theta =  0.08, phi = -2.85, mass =  0.00 from MergedCluster: em1   :3289830734126120961:    0.31  0.08 -2.85 sub(es33, )
+Finished block
+Processing block:E1       :bs36  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em2       value=  0.4 (3289833967429091330)
+
+Made Particle :pr14  :10252398991343878158: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.29, phi =  0.97, mass =  0.00 from MergedCluster: em2   :3289833967429091330:    0.35 -0.29  0.97 sub(es25, )
+Finished block
+Processing block:E1       :bs35  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em3       value=  0.4 (3289836897230127107)
+
+Made Particle :pr15  :10252401921144913935: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.12, phi =  0.92, mass =  0.00 from MergedCluster: em3   :3289836897230127107:    0.39 -0.12  0.92 sub(es35, )
+Finished block
+Processing block:E1       :bs34  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em4       value=  0.4 (3289840052321910788)
+
+Made Particle :pr16  :10252405076236697616: pdgid =    22, status =   1, q =  0, e =   0.4, theta = -0.82, phi =  0.55, mass =  0.00 from MergedCluster: em4   :3289840052321910788:    0.44 -0.82  0.55 sub(es23, )
+Finished block
+Processing block:E1       :bs33  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em7       value=  0.5 (3289845838288781319)
+
+Made Particle :pr17  :10252410862203568145: pdgid =    22, status =   1, q =  0, e =   0.5, theta =  0.11, phi =  1.83, mass =  0.00 from MergedCluster: em7   :3289845838288781319:    0.54  0.11  1.83 sub(es29, )
+Finished block
+Processing block:E1       :bs32  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em8       value=  0.6 (3289846731943968776)
+
+Made Particle :pr18  :10252411755858755602: pdgid =    22, status =   1, q =  0, e =   0.6, theta =  0.52, phi =  1.61, mass =  0.00 from MergedCluster: em8   :3289846731943968776:    0.57  0.52  1.61 sub(es28, )
+Finished block
+Processing block:E1       :bs31  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em9       value=  0.6 (3289846925355909129)
+
+Made Particle :pr19  :10252411949270695955: pdgid =    22, status =   1, q =  0, e =   0.6, theta = -0.28, phi =  1.10, mass =  0.00 from MergedCluster: em9   :3289846925355909129:    0.57 -0.28  1.10 sub(es30, )
+Finished block
+Processing block:E1       :bs30  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em11      value=  0.7 (3289851755008884747)
+
+Made Particle :pr20  :10252416778923671572: pdgid =    22, status =   1, q =  0, e =   0.7, theta =  0.43, phi =  3.12, mass =  0.00 from MergedCluster: em11  :3289851755008884747:    0.71  0.43  3.12 sub(es21, )
+Finished block
+Processing block:E1       :bs29  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em12      value=  1.0 (3289860970844782604)
+
+Made Particle :pr21  :10252425994759569429: pdgid =    22, status =   1, q =  0, e =   1.0, theta =  0.16, phi =  2.67, mass =  0.00 from MergedCluster: em12  :3289860970844782604:    0.97  0.16  2.67 sub(es19, )
+Finished block
+Processing block:E1       :bs28  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em13      value=  1.2 (3289865366464888845)
+
+Made Particle :pr22  :10252430390379675670: pdgid =    22, status =   1, q =  0, e =   1.2, theta = -0.43, phi =  0.98, mass =  0.00 from MergedCluster: em13  :3289865366464888845:    1.20 -0.43  0.98 sub(es16, )
+Finished block
+Processing block:E1       :bs27  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em14      value=  1.2 (3289865757457907726)
+
+Made Particle :pr23  :10252430781372694551: pdgid =    22, status =   1, q =  0, e =   1.2, theta =  0.04, phi =  0.62, mass =  0.00 from MergedCluster: em14  :3289865757457907726:    1.22  0.04  0.62 sub(es17, )
+Finished block
+Processing block:E1       :bs26  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em15      value=  1.4 (3289868946007654415)
+
+Made Particle :pr24  :10252433969922441240: pdgid =    22, status =   1, q =  0, e =   1.4, theta = -0.84, phi =  0.30, mass =  0.00 from MergedCluster: em15  :3289868946007654415:    1.40 -0.84  0.30 sub(es13, )
+Finished block
+Processing block:E1       :bs25  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em17      value=  1.7 (3289873416632401937)
+
+Made Particle :pr25  :10252438440547188761: pdgid =    22, status =   1, q =  0, e =   1.7, theta =  0.13, phi =  2.59, mass =  0.00 from MergedCluster: em17  :3289873416632401937:    1.65  0.13  2.59 sub(es12, )
+Finished block
+Processing block:E1       :bs24  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em6       value=  2.2 (3289881378813902854)
+
+Made Particle :pr26  :10252446402728689690: pdgid =    22, status =   1, q =  0, e =   2.2, theta =  0.05, phi =  2.79, mass =  0.00 from MergedCluster: em6   :3289881378813902854:    2.21  0.05  2.79 sub(es18, es22, es31, )
+Finished block
+Processing block:E1       :bs23  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em19      value=  2.4 (3289882790656475155)
+
+Made Particle :pr27  :10252447814571261979: pdgid =    22, status =   1, q =  0, e =   2.4, theta =  0.37, phi =  2.72, mass =  0.00 from MergedCluster: em19  :3289882790656475155:    2.37  0.37  2.72 sub(es9, )
+Finished block
+Processing block:E1       :bs22  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em21      value=  2.7 (3289885522041765909)
+
+Made Particle :pr28  :10252450545956552732: pdgid =    22, status =   1, q =  0, e =   2.7, theta =  1.38, phi =  2.26, mass =  0.00 from MergedCluster: em21  :3289885522041765909:    2.68  1.38  2.26 sub(es26, )
+Finished block
+Processing block:E1       :bs21  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em22      value=  2.9 (3289887043049488406)
+
+Made Particle :pr29  :10252452066964275229: pdgid =    22, status =   1, q =  0, e =   2.9, theta =  0.32, phi =  2.81, mass =  0.00 from MergedCluster: em22  :3289887043049488406:    2.85  0.32  2.81 sub(es8, )
+Finished block
+Processing block:E1       :bs20  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em23      value=  3.4 (3289891649125089303)
+
+Made Particle :pr30  :10252456673039876126: pdgid =    22, status =   1, q =  0, e =   3.4, theta =  1.35, phi = -0.44, mass =  0.00 from MergedCluster: em23  :3289891649125089303:    3.38  1.35 -0.44 sub(es32, )
+Finished block
+Processing block:E1       :bs19  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em25      value=  4.7 (3289900383589105689)
+
+Made Particle :pr31  :10252465407503892511: pdgid =    22, status =   1, q =  0, e =   4.7, theta = -0.86, phi =  0.37, mass =  0.00 from MergedCluster: em25  :3289900383589105689:    4.74 -0.86  0.37 sub(es3, )
+Finished block
+Processing block:E1       :bs18  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em26      value= 13.9 (3289927585806417946)
+
+Made Particle :pr32  :10252492609721204768: pdgid =    22, status =   1, q =  0, e =  13.9, theta =  1.21, phi = -2.53, mass =  0.00 from MergedCluster: em26  :3289927585806417946:   13.85  1.21 -2.53 sub(es24, )
+Finished block
+Processing block:E1       :bs17  : ecals = 1 hcals = 0 tracks = 0
+    elements:
+      e0 = em5       value= 18.5 (3289935107615358981)
+
+Made Particle :pr33  :10252500131530145825: pdgid =    22, status =   1, q =  0, e =  18.5, theta =  0.29, phi =  2.90, mass =  0.00 from MergedCluster: em5   :3289935107615358981:   18.55  0.29  2.90 sub(es2, es1, es5, es11, es27, )
+Finished block
+Processing block:H1       :bs16  : ecals = 0 hcals = 1 tracks = 0
+    elements:
+      h0 = hm5       value= 14.0 (5595770878515216389)
+
+Made Particle :pr34  :10252492893216309282: pdgid =   130, status =   1, q =  0, e =  14.0, theta =  1.47, phi = -0.05, mass =  0.50 from MergedCluster: hm5   :5595770878515216389:   13.98  1.47 -0.05 sub(hs7, )
+Finished block
+Processing block:T1       :bs15  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts14      value=  0.9 (7955586431154389006)
+
+Made Particle :pr35  :10252422631156351011: pdgid =  -211, status =   1, q = -1, e =   0.9, theta = -0.49, phi =  0.35, mass =  0.14 from SmearedTrack: ts14  :7955586431154389006:    0.87    0.77 -0.49  0.35
+Finished block
+Processing block:T1       :bs14  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts11      value=  1.4 (7955598784398884875)
+
+Made Particle :pr36  :10252434712595267620: pdgid =  -211, status =   1, q = -1, e =   1.4, theta = -0.59, phi =  0.61, mass =  0.14 from SmearedTrack: ts11  :7955598784398884875:    1.43    1.19 -0.59  0.61
+Finished block
+Processing block:T1       :bs13  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts10      value=  1.5 (7955599696097968138)
+
+Made Particle :pr37  :10252435620188127269: pdgid =   211, status =   1, q =  1, e =   1.5, theta = -0.73, phi =  0.55, mass =  0.14 from SmearedTrack: ts10  :7955599696097968138:    1.49    1.11 -0.73  0.55
+Finished block
+Processing block:T1       :bs12  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts8       value=  1.8 (7955606062491500552)
+
+Made Particle :pr38  :10252441964299419686: pdgid =   211, status =   1, q =  1, e =   1.9, theta = -0.21, phi =  0.60, mass =  0.14 from SmearedTrack: ts8   :7955606062491500552:    1.85    1.81 -0.21  0.60
+Finished block
+Processing block:T1       :bs11  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts1       value= 38.9 (7955682910005100545)
+
+Made Particle :pr39  :10252518720041648167: pdgid =   -13, status =   1, q = -1, e =  38.9, theta =  0.97, phi =  1.66, mass =  0.11 from SmearedTrack: ts1   :7955682910005100545:   38.91   22.14  0.97  1.66
+Finished block
+Processing block:T1       :bs10  : ecals = 0 hcals = 0 tracks = 1
+    elements:
+      t0 = ts0       value= 65.3 (7955697051258322944)
+
+Made Particle :pr40  :10252532861240344616: pdgid =    13, status =   1, q =  1, e =  65.3, theta = -0.06, phi = -1.33, mass =  0.10 from SmearedTrack: ts0   :7955697051258322944:   65.27   65.14 -0.06 -1.33
+Finished block
+Finished reconstruction

--- a/test/test_analysis_pdebug_clic.py
+++ b/test/test_analysis_pdebug_clic.py
@@ -10,14 +10,11 @@ import heppy.framework.context as context
 if context.name == 'fcc':
 
     from analysis_ee_Z_cfg import config
-    from heppy.test.plot_ee_Z import plot_ee_mass
     from heppy.framework.looper import Looper
     from ROOT import TFile
 
     import logging
-    #todo check with Colin regarding the logging level which turns off pdebug also
-    #logging.getLogger().setLevel(logging.ERROR)
-    logging.getLogger().setLevel(logging.INFO)
+    logging.getLogger().setLevel(logging.ERROR)
     
     import heppy.statistics.rrandom as random
 
@@ -27,6 +24,7 @@ if context.name == 'fcc':
             random.seed(0xdeadbeef)
             self.outdir = tempfile.mkdtemp()
             import logging
+            #Alice: I turned this off otherwise no pdebug output. Ask Colin why it is on and if this is OK
             #logging.disable(logging.CRITICAL)
 
         def tearDown(self):

--- a/test/test_analysis_pdebug_clic.py
+++ b/test/test_analysis_pdebug_clic.py
@@ -1,0 +1,63 @@
+import unittest
+import tempfile
+import copy
+import os
+import shutil
+import heppy.framework.context as context
+
+#Runs a Clic Z analysis and checks the pdebug output against a master document
+
+if context.name == 'fcc':
+
+    from analysis_ee_Z_cfg import config
+    from heppy.test.plot_ee_Z import plot_ee_mass
+    from heppy.framework.looper import Looper
+    from ROOT import TFile
+
+    import logging
+    #todo check with Colin regarding the logging level which turns off pdebug also
+    #logging.getLogger().setLevel(logging.ERROR)
+    logging.getLogger().setLevel(logging.INFO)
+    
+    import heppy.statistics.rrandom as random
+
+    class TestAnalysis_ee_Z(unittest.TestCase):
+
+        def setUp(self):
+            random.seed(0xdeadbeef)
+            self.outdir = tempfile.mkdtemp()
+            import logging
+            #logging.disable(logging.CRITICAL)
+
+        def tearDown(self):
+            shutil.rmtree(self.outdir)
+            logging.disable(logging.NOTSET)
+
+        
+
+        def test_z_clic(self):
+            '''Check Z mass in ee->Z->ddbar (CLIC).
+            Will fail if physics algorithms are modified,
+            so should probably be removed from test suite,
+            or better: be made optional. 
+            '''
+            random.seed(0xdeadbeef)
+            from heppy.papas.detectors.CLIC import clic
+            fname = '/'.join([os.environ['HEPPY'],
+                                      'test/data/ee_Z_ddbar.root'])
+            config.components[0].files = [fname]
+            for s in config.sequence:
+                if hasattr( s,'detector'):
+                    s.detector = clic
+                if hasattr(s, 'debug_filename'):
+                    s.debug_filename = 'physics_clic.txt'
+            self.looper = Looper( self.outdir, config,
+                                  nEvents=10,
+                                  nPrint=0 )            
+            self.looper.loop()
+            self.looper.write()
+            self.assertEqual(0,os.system("source $HEPPY/test/data/pdebug_python_check.sh  physics_clic.txt $HEPPY/test/data/required_clic_physics_dd.txt"))
+
+if __name__ == '__main__':
+
+    unittest.main()

--- a/test/test_analysis_pdebug_cms_ZZ.py
+++ b/test/test_analysis_pdebug_cms_ZZ.py
@@ -1,0 +1,65 @@
+import unittest
+import tempfile
+import copy
+import os
+import shutil
+
+#Runs a CMS ZZ mumu bbar analysis and checks the pdebug output against a master document
+
+import heppy.framework.context as context
+
+if context.name == 'fcc':
+
+    from analysis_ee_ZH_cfg import config
+    #from heppy.test.plot_ee_ZH import plot
+    from heppy.framework.looper import Looper
+    from ROOT import TFile
+
+    import logging
+    logging.getLogger().setLevel(logging.ERROR)
+
+    import heppy.statistics.rrandom as random
+
+
+
+    class TestAnalysis_ee_ZH_debug(unittest.TestCase):
+
+        def setUp(self):
+            random.seed(0xdeadbeef)
+            self.outdir = tempfile.mkdtemp()
+            import logging
+            #logging.disable(logging.CRITICAL)
+
+        def tearDown(self):
+            shutil.rmtree(self.outdir)
+            logging.disable(logging.NOTSET)
+
+        def test_analysis_ee_ZH_mumubb(self):
+            '''Check for an almost perfect match with reference.
+            Will fail if physics algorithms are modified,
+            so should probably be removed from test suite,
+            or better: be made optional. 
+            '''
+            from heppy.papas.detectors.CMS import cms
+            for s in config.sequence:
+                if hasattr( s,'detector'):
+                    s.detector = cms
+                if hasattr(s, 'debug_filename'):
+                    s.debug_filename = 'physics_cms.txt'                
+            # import pdb; pdb.set_trace()
+            fname = '/'.join([os.environ['HEPPY'],
+                                      'test/data/ee_ZH_Zmumu_Hbb.root'])
+            #fname = os.path.abspath('ee_ZH_Zmumu_Hbb.root')
+            config.components[0].files = [fname]
+            looper = Looper( self.outdir, config,
+                                          nEvents=10,
+                                          nPrint=0 )
+            looper.loop()
+            looper.write()
+            self.assertEqual(0,os.system("source $HEPPY/test/data/pdebug_python_check.sh  physics_cms.txt $HEPPY/test/data/required_cms_physics.txt"))
+            
+
+
+if __name__ == '__main__':
+
+    unittest.main()

--- a/test/test_analysis_pdebug_cms_ZZ.py
+++ b/test/test_analysis_pdebug_cms_ZZ.py
@@ -11,7 +11,6 @@ import heppy.framework.context as context
 if context.name == 'fcc':
 
     from analysis_ee_ZH_cfg import config
-    #from heppy.test.plot_ee_ZH import plot
     from heppy.framework.looper import Looper
     from ROOT import TFile
 
@@ -49,7 +48,6 @@ if context.name == 'fcc':
             # import pdb; pdb.set_trace()
             fname = '/'.join([os.environ['HEPPY'],
                                       'test/data/ee_ZH_Zmumu_Hbb.root'])
-            #fname = os.path.abspath('ee_ZH_Zmumu_Hbb.root')
             config.components[0].files = [fname]
             looper = Looper( self.outdir, config,
                                           nEvents=10,


### PR DESCRIPTION
There are two new tests one for CMS one for CLIC.
The additional data files needed (the expected outputs and the comparison script) are stored in test/data.
If physics processes are changed or if detector parameters are changed these tests will fail and the files against which the checks are made will need to be updated.

I changed the way pdebug starts up slightly, and added pdebug to two configuration files but in such a way so that no pdebug output is made. The configuration can then be edited by the tow new tests to set the pdebug filename and so turn on the physics pdebug outputs.

Note: I removed this line 
logging.disable(logging.CRITICAL), 
as otherwise I got no pdebug output. Need to discuss with Colin what this line does and if it is OK to remove.