### PR TITLE
small bug fixes and parametrized b tagging in ZH had example

### DIFF
--- a/analyzers/PapasSim.py
+++ b/analyzers/PapasSim.py
@@ -59,7 +59,7 @@ class PapasSim(Analyzer):
             vertex = ptc.start_vertex().position()
             charge = ptc.q()
             pid = ptc.pdgid()
-            simptc = Particle(tp4, vertex, charge, index, pid)
+            simptc = Particle(tp4, vertex, charge, pid, index)
             pdebugger.info(" ".join(("Made", simptc.__str__())))
             simptc.gen_ptc = ptc
             return simptc

--- a/analyzers/examples/zh/ZHTreeProducer.py
+++ b/analyzers/examples/zh/ZHTreeProducer.py
@@ -21,6 +21,7 @@ class ZHTreeProducer(Analyzer):
         bookJet(self.tree, 'jet2', self.taggers)
         bookHbb(self.tree, 'higgs')
         bookParticle(self.tree, 'misenergy')
+        var(self.tree, 'n_nu')
        
     def process(self, event):
         self.tree.reset()
@@ -45,6 +46,9 @@ class ZHTreeProducer(Analyzer):
             # if higgs.m() < 30:
             #    import pdb; pdb.set_trace()
             fillHbb(self.tree, 'higgs', higgs)
+        neutrinos = getattr(event, 'neutrinos', None)
+        if neutrinos:
+            fill(self.tree, 'n_nu', len(neutrinos))
         self.tree.tree.Fill()
         
     def write(self, setup):

--- a/analyzers/ntuple.py
+++ b/analyzers/ntuple.py
@@ -153,34 +153,38 @@ def bookIsoParticle(tree, pName):
 def fillIsoParticle(tree, pName, ptc, lepton):
     fillParticle(tree, pName, ptc)
     fillLepton(tree, '{pName}_lep'.format(pName=pName), lepton)
-    
-def bookZed(tree, pName):
+
+def bookResonance(pName, tree):
     bookParticle(tree, pName )
+    var(tree, '{pName}_acol'.format(pName=pName))
+    var(tree, '{pName}_acop'.format(pName=pName))
+    var(tree, '{pName}_cross'.format(pName=pName))
+
+def fillResonance(tree, pName, resonance):
+    fillParticle(tree, pName, resonance)
+    fill(tree, '{pName}_acol'.format(pName=pName), resonance.acollinearity() )
+    fill(tree, '{pName}_acop'.format(pName=pName), resonance.acoplanarity() )
+    fill(tree, '{pName}_cross'.format(pName=pName), resonance.cross() )
+   
+def bookZed(tree, pName):
+    bookResonance(pName, tree)
     bookLepton(tree, '{pName}_1'.format(pName=pName)  )
     bookLepton(tree, '{pName}_2'.format(pName=pName)  )
-    var(tree, '{pName}_acol'.format(pName=pName))
-    var(tree, '{pName}_acop'.format(pName=pName))
 
 def fillZed(tree, pName, zed):
-    fillParticle(tree, pName, zed)
+    fillResonance(tree, pName, zed)
     fillLepton(tree, '{pName}_1'.format(pName=pName), zed.leg1() )
     fillLepton(tree, '{pName}_2'.format(pName=pName), zed.leg2() )
-    fill(tree, '{pName}_acol'.format(pName=pName), zed.acollinearity() * 180./math.pi)
-    fill(tree, '{pName}_acop'.format(pName=pName), zed.acoplanarity() * 180./math.pi)
 
 def bookHbb(tree, pName):
-    bookParticle(tree, pName )
+    bookResonance(pName, tree)
     bookParticle(tree, '{pName}_1'.format(pName=pName)  )
     bookParticle(tree, '{pName}_2'.format(pName=pName)  )
-    var(tree, '{pName}_acol'.format(pName=pName))
-    var(tree, '{pName}_acop'.format(pName=pName))
 
 def fillHbb(tree, pName, higgs):
-    fillParticle(tree, pName, higgs)
+    fillResonance(tree, pName, higgs)
     fillParticle(tree, '{pName}_1'.format(pName=pName), higgs.leg1() )
     fillParticle(tree, '{pName}_2'.format(pName=pName), higgs.leg2() )
-    fill(tree, '{pName}_acol'.format(pName=pName), higgs.acollinearity() * 180./math.pi)
-    fill(tree, '{pName}_acop'.format(pName=pName), higgs.acoplanarity() * 180./math.pi)
 
 def bookMet(tree, pName):
     var(tree, '{pName}_pt'.format(pName=pName)  )

--- a/papas/detectors/CLIC.py
+++ b/papas/detectors/CLIC.py
@@ -186,7 +186,9 @@ class CLIC(Detector):
         '''
         if track.p3().Mag() > 5 and \
            abs(track.theta()) < 80. * math.pi / 180.:
-            return random.uniform(0, 1) < 0.95  
+            return random.uniform(0, 1) < 0.95
+        else:
+            return False
 
     def electron_resolution(self, ptc):
         '''returns the relative electron resolution.

--- a/papas/pfalgo/pfreconstructor.py
+++ b/papas/pfalgo/pfreconstructor.py
@@ -386,7 +386,7 @@ class PFReconstructor(object):
             momentum = math.sqrt(energy**2 - mass**2)
         p3 = cluster.position.Unit() * momentum
         p4 = TLorentzVector(p3.Px(), p3.Py(), p3.Pz(), energy) #mass is not accurate here
-        particle = Particle(p4, vertex, charge, len(self.particles), pdg_id, subtype='r')
+        particle = Particle(p4, vertex, charge, pdg_id, len(self.particles), subtype='r')
         # alice: this may be a bit strange because we can make a photon 
         # with a path where the point is actually that of the hcal?
         # nb this only is problem if the cluster and the assigned layer 
@@ -410,7 +410,7 @@ class PFReconstructor(object):
         mass, charge = particle_data[pdgid]
         p4 = TLorentzVector()
         p4.SetVectM(track.p3() , mass)
-        particle = Particle(p4, vertex, charge, len(self.particles), pdgid,  subtype='r')
+        particle = Particle(p4, vertex, charge, pdgid, len(self.particles), subtype='r')
         #todo fix this so it picks up smeared track points (need to propagagte smeared track)
         particle.set_track(track) #refer to existing track rather than make a new one
         self.locked[track.uniqueid] = True

--- a/papas/pfobjects.py
+++ b/papas/pfobjects.py
@@ -292,7 +292,7 @@ class SmearedTrack(Track):
 
 
 class Particle(BaseParticle):
-    def __init__(self, tlv, vertex, charge, index=0, pdgid=None, subtype='s'):
+    def __init__(self, tlv, vertex, charge, pdgid, index=0, subtype='s'):
         self.subtype = subtype
         super(Particle, self).__init__(pdgid, charge, tlv)
         

--- a/papas/test_propagator.py
+++ b/papas/test_propagator.py
@@ -11,7 +11,7 @@ class TestPropagator(unittest.TestCase):
         cyl1 = SurfaceCylinder('cyl1', 1, 2)
         cyl2 = SurfaceCylinder('cyl2', 2, 1)
 
-        particle = Particle( LorentzVector(1, 0, 1, 2.), origin, 0)
+        particle = Particle( LorentzVector(1, 0, 1, 2.), origin, 0, 22)
         straight_line.propagate_one( particle, cyl1 )
         straight_line.propagate_one( particle, cyl2 )
         self.assertEqual( len(particle.points), 3)
@@ -22,7 +22,7 @@ class TestPropagator(unittest.TestCase):
         self.assertAlmostEqual( particle.points['cyl2'].Z(), 1. )
         
         # testing extrapolation to -z 
-        particle = Particle( LorentzVector(1, 0, -1, 2.), origin, 0)
+        particle = Particle( LorentzVector(1, 0, -1, 2.), origin, 0, 22)
         # import pdb; pdb.set_trace()
         straight_line.propagate_one( particle, cyl1 )
         straight_line.propagate_one( particle, cyl2 )
@@ -34,38 +34,38 @@ class TestPropagator(unittest.TestCase):
 
         # extrapolating from a vertex close to +endcap
         particle = Particle( LorentzVector(1, 0, 1, 2.),
-                             Point(0,0,1.5), 0)
+                             Point(0,0,1.5), 0, 22)
         straight_line.propagate_one( particle, cyl1 )
         self.assertAlmostEqual( particle.points['cyl1'].Perp(), 0.5 )
         
         # extrapolating from a vertex close to -endcap
         particle = Particle( LorentzVector(1, 0, -1, 2.),
-                             Point(0,0,-1.5), 0)
+                             Point(0,0,-1.5), 0, 22)
         straight_line.propagate_one( particle, cyl1 )
         self.assertAlmostEqual( particle.points['cyl1'].Perp(), 0.5 )
         
         # extrapolating from a non-zero radius
         particle = Particle( LorentzVector(0, 0.5, 1, 2.),
-                             Point(0,0.5,0), 0)
+                             Point(0,0.5,0), 0, 22)
         straight_line.propagate_one( particle, cyl1 )
         self.assertAlmostEqual( particle.points['cyl1'].Perp(), 1. )
         self.assertAlmostEqual( particle.points['cyl1'].Z(), 1. )
 
         # extrapolating from a z outside the cylinder
         particle = Particle( LorentzVector(0, 0, -1, 2.),
-                             Point(0,0,2.5), 0)
+                             Point(0,0,2.5), 0, 22)
         straight_line.propagate_one( particle, cyl1 )
         self.assertFalse( 'cyl1' in particle.points ) 
         
         # extrapolating from a z outside the cylinder, negative
         particle = Particle( LorentzVector(0, 0, -1, 2.),
-                             Point(0,0,-2.5), 0)
+                             Point(0,0,-2.5), 0, 22)
         straight_line.propagate_one( particle, cyl1 )
         self.assertFalse( 'cyl1' in particle.points ) 
 
         # extrapolating from a rho outside the cylinder
         particle = Particle( LorentzVector(0, 0, -1, 2.),
-                             Point(0,1.1,0), 0)
+                             Point(0,1.1,0), 0, 22)
         straight_line.propagate_one( particle, cyl1 )
         self.assertFalse( 'cyl1' in particle.points ) 
                 
@@ -74,10 +74,10 @@ class TestPropagator(unittest.TestCase):
         cyl2 = SurfaceCylinder('cyl2', 2., 1.)
         field = 3.8
         particle = Particle( LorentzVector(2., 0, 1, 5),
-                             Point(0., 0., 0.), -1)   
+                             Point(0., 0., 0.), -1, -211)   
         debug_info = helix.propagate_one(particle, cyl1, field)
         particle = Particle( LorentzVector(0., 2, 1, 5),
-                             Point(0., 0., 0.), -1)        
+                             Point(0., 0., 0.), -1, -211)        
         debug_info = helix.propagate_one(particle, cyl1, field)
 
         

--- a/particles/tlv/resonance.py
+++ b/particles/tlv/resonance.py
@@ -53,7 +53,7 @@ class Resonance2(Resonance):
 
     def acollinearity(self):
         '''return the angle between the two legs, in radians'''
-        return self.leg1().p3().Angle(self.leg2().p3())
+        return self.leg1().p3().Angle(self.leg2().p3()) * 180 / math.pi
     
     def acoplanarity(self, axis=None):
         '''return the angle between the lepton plane and the provided axis.

--- a/test/analysis_ee_ZH_had_cfg.py
+++ b/test/analysis_ee_ZH_had_cfg.py
@@ -190,7 +190,7 @@ compute_jet_energy = cfg.Analyzer(
 # cms_roc is a numpy array, so one can easily scale
 # the cms performance, help(numpy.array) for more info.
 
-btag_type = 'smeared'
+btag_type = 'parametrized'
 btag = None
 if btag_type == 'parametrized':
     from heppy.analyzers.ParametrizedBTagger import ParametrizedBTagger

--- a/test/analysis_ee_Z_cfg.py
+++ b/test/analysis_ee_Z_cfg.py
@@ -78,9 +78,10 @@ zed_tree = cfg.Analyzer(
 
 
 from heppy.test.papas_cfg import gen_particles_stable, papas_sequence, detector, papas, papasdisplay, papasdisplaycompare
-from heppy.test.papas_cfg import papasdisplaycompare as display 
+from heppy.test.papas_cfg import papasdisplaycompare as display
+display = papasdisplay
 
-do_clic = True
+do_clic = False
 if do_clic:
     from heppy.papas.detectors.CLIC import clic
     papas.detector = clic    

--- a/test/gun_papas_cfg.py
+++ b/test/gun_papas_cfg.py
@@ -78,8 +78,8 @@ source = cfg.Analyzer(
     thetamax = 0.1,
     phimin = math.pi/2.,
     phimax = math.pi/2.,
-    ptmin = 5,
-    ptmax = 10,
+    ptmin = 1,
+    ptmax = 1,
     flat_pt = False,
     papas = True
 )

--- a/test/gun_papas_cfg.py
+++ b/test/gun_papas_cfg.py
@@ -78,8 +78,8 @@ source = cfg.Analyzer(
     thetamax = 0.1,
     phimin = math.pi/2.,
     phimax = math.pi/2.,
-    ptmin = 1,
-    ptmax = 1,
+    ptmin = 0.2,
+    ptmax = 0.2,
     flat_pt = False,
     papas = True
 )


### PR DESCRIPTION
two bugs fixed (did not affect anybody):
* needed to return false in clic tracker acceptance if conditions are not met (was returning None)
* changed particle interface so that particles are properly constructed with a pdgid everywhere (was affecting only the particle gun)

Now using the parametrized b tagging in the ZH had example analysis, as IP smearing b tagging is not understood yet, and as people working on this analysis are using the parametrized tagger. 