### PR TITLE
bug fix on b matching (~no change in physics)

### DIFF
--- a/analyzers/ParametrizedBTagger.py
+++ b/analyzers/ParametrizedBTagger.py
@@ -16,7 +16,7 @@ def is_matched_to_b(jet):
     return is_bjet
 
 
-def is_from_b(jet, event, fraction=0.05):
+def is_from_b(jet, event, fraction=0.01):
     '''returns true if more than a fraction of the jet energy
     is from a b.'''
     history = HistoryHelper(event.papasevent)
@@ -25,9 +25,9 @@ def is_from_b(jet, event, fraction=0.05):
                                       event.gen_vertices)       
     sum_e_from_b = 0
     # charged_ptcs = jet.constituents[211]
-    from_b = False
     for ptc in jet.constituents.particles:
         simids = history.get_linked_collection(ptc.uniqueid, 'ps')
+        from_b = False
         for simid in simids:
             simptc = event.papasevent.get_object(simid)
             if is_ptc_from_b(event, simptc.gen_ptc, event.genbrowser):

--- a/framework/looper.py
+++ b/framework/looper.py
@@ -356,11 +356,13 @@ possibly skipping a number of events at the beginning.
                 #TODO: check that this works fine with non podio inputs, e.g. plain TChains.
                 if hasattr(self.event, 'input') and \
                    hasattr(self.event.input, 'current_filename'):
-                    print 'exception running analyzer {ana} on event {iev} in file\n {fname}'.format(
-                        ana=analyzer.cfg_ana.name,
-                        iev=self.event.iEv, 
-                        fname=self.event.input.current_filename()
-                    )   
+# TODO re-enable analyzer printout when next podio is available
+##                    print 'exception running analyzer {ana} on event {iev} in file\n {fname}'.format(
+##                        ana=analyzer.cfg_ana.name,
+##                        iev=self.event.iEv, 
+##                        fname=self.event.input.current_filename()
+##                    )
+                    pass
                 raise 
             if self.memReportFirstEvent >=0 and iEv >= self.memReportFirstEvent:           
                 memNow=resource.getrusage(resource.RUSAGE_SELF).ru_maxrss

--- a/test/test_analysis_ee_Z_bb.py
+++ b/test/test_analysis_ee_Z_bb.py
@@ -48,7 +48,7 @@ if context.name == 'fcc':
             rootfile = '/'.join([self.outdir,
                                 'heppy.analyzers.JetTreeProducer.JetTreeProducer_1/jet_tree.root '])
             plotter = Plotter(rootfile)
-            self.assertGreater(plotter.bfrac(), 0.95)
+            self.assertAlmostEqual(plotter.bfrac(), 0.83, places=2)
             self.assertAlmostEqual(plotter.beff(), 0.7, places=2)
     
         def test_fake_cms(self):


### PR DESCRIPTION
Thanks @alicerobson for finding this bug! 
The performance of the jet to b matching for the parametrized b tagger is now even better. 
After reoptimization of the matching working point, the b tag efficiency increased by less than 1%, and the background level remains the same. 