### PR TITLE
heppy submission tools : version is tracked

### DIFF
--- a/framework/config.py
+++ b/framework/config.py
@@ -386,12 +386,26 @@ class MCComponent( Component ):
 class Config( object ):
     '''Main configuration object, holds a sequence of analyzers, and
     a list of components.'''
-    def __init__(self, components, sequence, services, events_class,preprocessor=None):
+    def __init__(self, components, sequence, services,
+                 events_class,preprocessor=None, versions=None):
+        '''Create the configuration object for a heppy job.
+        
+        @param components: list of Components to be processed (input)
+        @param sequence: list of Analyzers
+        @param services: list of services
+        @param events_class: class object to be used to extract events
+                            from the input files
+        @param preprocessor: CMS only
+        @param versions: dictionary listing the version of the software that is used.
+        
+        versions is an object of the class heppy.utils.versions.Versions 
+        '''
         self.preprocessor = preprocessor
         self.components = components
         self.sequence = sequence
         self.services = services
         self.events_class = events_class
+        self.versions = versions
 
     def __str__(self):
         comp = '\n'.join(map(str, self.components))

--- a/framework/heppy_loop.py
+++ b/framework/heppy_loop.py
@@ -243,7 +243,7 @@ def create_parser():
     parser.add_option("-t", "--trackversions", 
                       dest="track_versions",
                       help="list of the python packages to track, e.g. heppy,my_package",
-                      default=None)
+                      default='heppy')
     parser.add_option("-I", "--input",
                       dest="input",
                       type="str",

--- a/framework/heppy_loop.py
+++ b/framework/heppy_loop.py
@@ -154,11 +154,10 @@ def main( options, args, parser ):
 
     # track the versions
     versions = None
-    if options.track_versions:
-        to_track = options.track_versions.split(',')
-        to_track.append('heppy')
-        cfg.config.versions = Versions(cfgFileName,
-                                       to_track)
+    to_track = options.track_versions.split(',')
+    to_track.append('heppy')
+    cfg.config.versions = Versions(cfgFileName,
+                                   to_track)
     if len(selComps)>options.ntasks:
         print "WARNING: too many threads {tnum}, will just use a maximum of {jnum}.".format(tnum=len(selComps),jnum=options.ntasks)
     if not createOutputDir(outDir, selComps, options.force):

--- a/framework/heppy_loop.py
+++ b/framework/heppy_loop.py
@@ -22,6 +22,7 @@ if "-i" not in sys.argv:
 
 from heppy.framework.looper import Looper
 from heppy.framework.config import split
+from heppy.utils.versions import Versions
 
 # global, to be used interactively when only one component is processed.
 loop = None
@@ -105,6 +106,7 @@ _heppyGlobalOptions = {}
 def getHeppyOption(name,default=None):
     global _heppyGlobalOptions
     return _heppyGlobalOptions[name] if name in _heppyGlobalOptions else default
+
 def setHeppyOption(name,value=True):
     global _heppyGlobalOptions
     _heppyGlobalOptions[name] = value
@@ -126,7 +128,6 @@ def main( options, args, parser ):
         parser.print_help()
         print 'ERROR: second argument must be an existing file (your input cfg).'
         sys.exit(3)
-
     if options.verbose:
         import logging
         logging.basicConfig(level=logging.INFO)
@@ -141,22 +142,28 @@ def main( options, args, parser ):
             _heppyGlobalOptions[key] = val
         else:
             _heppyGlobalOptions[opt] = True
-
+            
+    # open the cfg, and create the config for each job
     file = open( cfgFileName, 'r' )
     sys.path.append( os.path.dirname(cfgFileName) )
-
     cfg = imp.load_source( 'heppy.__cfg_to_run__', 
                            cfgFileName, file)
 
     selComps = [comp for comp in cfg.config.components if len(comp.files)>0]
     selComps = split(selComps)
-    # for comp in selComps:
-    #    print comp
+
+    # track the versions
+    versions = None
+    if options.track_versions:
+        to_track = options.track_versions.split(',')
+        to_track.append('heppy')
+        cfg.config.versions = Versions(cfgFileName,
+                                       to_track)
     if len(selComps)>options.ntasks:
         print "WARNING: too many threads {tnum}, will just use a maximum of {jnum}.".format(tnum=len(selComps),jnum=options.ntasks)
     if not createOutputDir(outDir, selComps, options.force):
         print 'exiting'
-        sys.exit(0)
+        sys.exit(1)
     if len(selComps)>1:
         shutil.copy( cfgFileName, outDir )
         pool = multiprocessing.Pool(processes=min(len(selComps),options.ntasks))
@@ -172,7 +179,7 @@ def main( options, args, parser ):
         # when running only one loop, do not use multiprocessor module.
         # then, the exceptions are visible -> use only one sample for testing
         global loop
-        loop = runLoop( comp, outDir, cfg.config, options )
+        loop = runLoop( comp, outDir, cfg.config, options)
     return loop
 
 
@@ -233,6 +240,10 @@ def create_parser():
                       action='store_true',
                       help="Activate memory checks per event",
                       default=False)
+    parser.add_option("-t", "--trackversions", 
+                      dest="track_versions",
+                      help="list of the python packages to track, e.g. heppy,my_package",
+                      default=None)
     parser.add_option("-I", "--input",
                       dest="input",
                       type="str",

--- a/framework/looper.py
+++ b/framework/looper.py
@@ -408,7 +408,8 @@ possibly skipping a number of events at the beginning.
 
 
 if __name__ == '__main__':
-
+    """The main section is used by heppy_batch.py"""
+    
     import pickle
     import sys
     import os
@@ -426,23 +427,13 @@ if __name__ == '__main__':
             _heppyGlobalOptions[k]=v
         jfile.close()
 
-    if len(args) == 1 :
-        cfgFileName = args[0]
-        pckfile = open( cfgFileName, 'r' )
-        config = pickle.load( pckfile )
-        comp = config.components[0]
-        events_class = config.events_class
-    elif len(args) == 2 :
-        cfgFileName = args[0]
-        file = open( cfgFileName, 'r' )
-        cfg = imp.load_source( 'cfg', cfgFileName, file)
-        compFileName = args[1]
-        pckfile = open( compFileName, 'r' )
-        comp = pickle.load( pckfile )
-        cfg.config.components=[comp]
-        events_class = cfg.config.events_class
+    cfgFileName = args[0]
+    pckfile = open( cfgFileName, 'r' )
+    config = pickle.load( pckfile )
+    comp = config.components[0]
+    events_class = config.events_class
 
-    looper = Looper( 'Loop', cfg.config,nPrint = 5)
+    looper = Looper( 'Loop', config, nPrint = 5)
     looper.loop()
     looper.write()
 

--- a/scripts/heppy_hadd.py
+++ b/scripts/heppy_hadd.py
@@ -14,54 +14,57 @@ def haddPck(file, odir, idirs):
     All dirs in idirs must have the same subdirectory structure.
     Each pickle file will be opened, and the corresponding objects added to a destination pickle in odir.
     '''
-    sum = None
-    for dir in idirs:
-        fileName = file.replace( idirs[0], dir )
+    objsum = None
+    for dirpath in idirs:
+        fileName = file.replace( idirs[0], dirpath )
         pckfile = open(fileName)
         obj = pickle.load(pckfile)
-        if sum is None:
-            sum = obj
+        if objsum is None:
+            objsum = obj
         else:
             try:
-                sum += obj
+                objsum += obj
             except TypeError:
                 # += not implemented, nevermind
                 pass
                 
     oFileName = file.replace( idirs[0], odir )
     pckfile = open(oFileName, 'w')
-    pickle.dump(sum, pckfile)
+    pickle.dump(objsum, pckfile)
     txtFileName = oFileName.replace('.pck','.txt')
     txtFile = open(txtFileName, 'w')
-    txtFile.write( str(sum) )
+    txtFile.write( str(objsum) )
     txtFile.write( '\n' )
     txtFile.close()
     
 
-def hadd(file, odir, idirs, appx=''):
-    if file.endswith('.pck'):
+def hadd(fname, odir, idirs, appx=''):
+    if fname.endswith('.pck'):
         try:
-            haddPck(file, odir, idirs)
+            haddPck(fname, odir, idirs)
         except ImportError:
             pass
         return
-    elif not file.endswith('.root'):
+    elif fname.endswith('.yaml'):
+        # just copy the yaml file to the output dir
+        shutil.copy(fname, odir)
+    elif not fname.endswith('.root'):
         return
     haddCmd = ['hadd']
-    haddCmd.append( file.replace( idirs[0], odir ).replace('.root', appx+'.root') )
+    haddCmd.append( fname.replace( idirs[0], odir ).replace('.root', appx+'.root') )
     for dir in idirs:
-        haddCmd.append( file.replace( idirs[0], dir ) )
+        haddCmd.append( fname.replace( idirs[0], dir ) )
     # import pdb; pdb.set_trace()
     cmd = ' '.join(haddCmd)
     print cmd
     if len(cmd) > MAX_ARG_STRLEN:
         print 'Command longer than maximum unix string length; dividing into 2'
-        hadd(file, odir, idirs[:len(idirs)/2], '1')
-        hadd(file.replace(idirs[0], idirs[len(idirs)/2]), odir, idirs[len(idirs)/2:], '2')
+        hadd(fname, odir, idirs[:len(idirs)/2], '1')
+        hadd(fname.replace(idirs[0], idirs[len(idirs)/2]), odir, idirs[len(idirs)/2:], '2')
         haddCmd = ['hadd']
-        haddCmd.append( file.replace( idirs[0], odir ).replace('.root', appx+'.root') )
-        haddCmd.append( file.replace( idirs[0], odir ).replace('.root', '1.root') )
-        haddCmd.append( file.replace( idirs[0], odir ).replace('.root', '2.root') )
+        haddCmd.append( fname.replace( idirs[0], odir ).replace('.root', appx+'.root') )
+        haddCmd.append( fname.replace( idirs[0], odir ).replace('.root', '1.root') )
+        haddCmd.append( fname.replace( idirs[0], odir ).replace('.root', '2.root') )
         cmd = ' '.join(haddCmd)
         print 'Running merge cmd:', cmd
         os.system(cmd)
@@ -74,13 +77,16 @@ def haddRec(odir, idirs):
     print 'to', odir 
 
     cmd = ' '.join( ['mkdir', odir])
-    try:
-        os.mkdir( odir )
-    except OSError:
-        print 
-        print 'ERROR: directory in the way. Maybe you ran hadd already in this directory? Remove it and try again'
-        print 
-        raise
+    if os.path.isdir(odir):
+        shutil.rmtree(odir)
+    os.mkdir(odir)
+##    try:
+##        os.mkdir( odir )
+##    except OSError:
+##        print 
+##        print 'ERROR: directory in the way. Maybe you ran hadd already in this directory? Remove it and try again'
+##        print 
+##        raise
     for root,dirs,files in os.walk( idirs[0] ):
         # print root, dirs, files
         for dir in dirs:
@@ -93,11 +99,10 @@ def haddRec(odir, idirs):
         for file in files:
             hadd('/'.join([root, file]), odir, idirs)
 
-def haddChunks(idir, removeDestDir, cleanUp=False, odir_cmd='./'):
+def haddChunks(idir, removeDestDir, cleanUp=False, base_odir='./'):
     chunks = {}
     for file in sorted(os.listdir(idir)):
         filepath = '/'.join( [idir, file] )
-        # print filepath
         if os.path.isdir(filepath):
             compdir = file
             try:
@@ -111,7 +116,8 @@ def haddChunks(idir, removeDestDir, cleanUp=False, odir_cmd='./'):
         print 'warning: no chunk found.'
         return
     for comp, cchunks in chunks.iteritems():
-        odir = odir_cmd+'/'+'/'.join( [idir, comp] )
+        # odir = base_odir+'/'+'/'.join( [idir, comp] )
+        odir = '/'.join( [base_odir, comp] )
         print odir, cchunks
         if removeDestDir:
             if os.path.isdir( odir ):
@@ -155,11 +161,11 @@ if __name__ == '__main__':
         print 'provide at most 2 directory as arguments: first the source, then the destination (optional)'
         sys.exit(1)
 
-    dir = args[0]
+    dirname = args[0]
     if(len(args)>1):
-      odir = args[1]
+        odir = args[1]
     else:
-      odir='./'
+        odir = dirname
 
-    haddChunks(dir, options.remove, options.clean, odir)
+    haddChunks(dirname, options.remove, options.clean, odir)
 

--- a/test/simple_example_cfg.py
+++ b/test/simple_example_cfg.py
@@ -75,4 +75,5 @@ config = cfg.Config( components = selectedComponents,
                      services = services, 
                      events_class = Events )
 
+
 # print config 

--- a/utils/batchmanager.py
+++ b/utils/batchmanager.py
@@ -46,6 +46,10 @@ class BatchManager:
         self.parser_.add_option("-b", "--batch", dest="batch",
                                 help="batch command. default is: 'bsub -q 8nh < batchScript.sh'. You can also use 'nohup < ./batchScript.sh &' to run locally.",
                                 default="bsub -q 8nh < ./batchScript.sh")
+        self.parser_.add_option("-t", "--trackversions", 
+                                dest="track_versions",
+                                help="list of the python packages to track, e.g. heppy,my_package",
+                                default='heppy')        
         self.parser_.add_option( "--option",
                                 dest="extraOptions",
                                 type="string",

--- a/utils/test_versions.py
+++ b/utils/test_versions.py
@@ -28,5 +28,5 @@ class TestVersion(unittest.TestCase):
             self.assertEqual(data['software']['heppy'],
                              self.versions.tracked['heppy']['commitid'])
         
-##if __name__ == '__main__':
-##    unittest.main()
+if __name__ == '__main__':
+    unittest.main()

--- a/utils/versions.py
+++ b/utils/versions.py
@@ -18,11 +18,11 @@ class Versions(object):
         exclude = 'python2'
         path = [p for p in sys.path if 'python2' not in p]
         self.scriptfname = scriptfname
-        self.finder = modulefinder.ModuleFinder(path)
-        self.finder.run_script(scriptfname)
+        finder = modulefinder.ModuleFinder(path)
+        finder.run_script(scriptfname)
         # self.finder.report()
         self.tracked = dict()
-        for key, mod in self.finder.modules.iteritems():
+        for key, mod in finder.modules.iteritems():
             for pattern in to_track:
                 if fnmatch.fnmatch(key, pattern):
                     self._analyze(key, mod)

--- a/utils/versions.py
+++ b/utils/versions.py
@@ -33,7 +33,6 @@ class Versions(object):
         repo = git.Repo(module.__path__[0])
         info['commitid'] = repo.head.commit.hexsha
         self.tracked[key] = info
-        print
 
     #----------------------------------------------------------------------
     def write_yaml(self, path):


### PR DESCRIPTION
This pull request enables the tracking of the version of the software used by the user in heppy jobs. 
When the heppy process runs, the user configuration file is parsed to find imported python modules. 
If, for a given python module, a git repository is found, the HEAD commit id is stored and written to a yaml file in the output directory, called `software.yaml`.

The only package to be always tracked is `heppy`. 

With the `heppy` and `heppy_batch.py`, the user can specify the list of packages to be tracked, like this: 

    heppy OutDir analysis_cfg.py -t my_analysis1,my_analysis2

In addition, we are now making use of the `dill` module, which allows to pickle more complicated objects that might be used in the cfg by the user, such as lambda functions. 

@hegner this pull request might fail due to missing python modules in our python. If that's the case I will contact you to see how they can be installed (no big deal, one just has to run pip)