### PR TITLE
physics developments 

### DIFF
--- a/analyzers/EventByNumber.py
+++ b/analyzers/EventByNumber.py
@@ -1,0 +1,9 @@
+from heppy.framework.analyzer import Analyzer
+
+class EventByNumber(Analyzer):
+    
+    def process(self, event):
+        if event.iEv not in self.cfg_ana.event_numbers:
+            return False
+        else:
+            return True

--- a/analyzers/EventFilter.py
+++ b/analyzers/EventFilter.py
@@ -53,6 +53,11 @@ class EventFilter  (Analyzer):
             passed = len(input_collection) >= self.cfg_ana.min_number
         if passed:
             self.counters['efficiency'].inc('Selected')
+##        else:
+##            if self.cfg_ana.instance_label != 'gen_taus_acc':
+##                print self.cfg_ana
+##                print event
+##                print   
         return passed
             
 

--- a/analyzers/EventSkipper.py
+++ b/analyzers/EventSkipper.py
@@ -1,0 +1,10 @@
+from heppy.framework.analyzer import Analyzer
+
+class EventSkipper(Analyzer):
+    
+    def process(self, event):
+        if event.iEv < self.cfg_ana.first_event:
+            return False
+        else:
+            return True
+        

--- a/analyzers/IsolationAnalyzer.py
+++ b/analyzers/IsolationAnalyzer.py
@@ -56,9 +56,13 @@ class IsolationAnalyzer(Analyzer):
         super(IsolationAnalyzer, self).beginLoop(setup)
         # now using same isolation definition for all pdgids
         self.iso_computers = dict()
+        off_iso_area = None
+        if hasattr(self.cfg_ana, 'off_iso_area'):
+            off_iso_area = self.cfg_ana.off_iso_area
         for pdgid in pdgids:
             self.iso_computers[pdgid] = IsolationComputer(
                 [self.cfg_ana.iso_area],
+                off_areas=[off_iso_area], 
                 label='iso{pdgid}'.format(pdgid=str(pdgid))
             )
             

--- a/analyzers/IsolationAnalyzer.py
+++ b/analyzers/IsolationAnalyzer.py
@@ -97,7 +97,7 @@ class IsolationAnalyzer(Analyzer):
           - photon -> 22
           - other -> neutral hadron
         '''
-        if ptc.pdgid() in [11,13]:
+        if abs(ptc.pdgid()) in [11,13]:
             return ptc.pdgid() 
         elif ptc.q(): 
             return ptc.q() * 211

--- a/analyzers/IsolationAnalyzer.py
+++ b/analyzers/IsolationAnalyzer.py
@@ -56,13 +56,13 @@ class IsolationAnalyzer(Analyzer):
         super(IsolationAnalyzer, self).beginLoop(setup)
         # now using same isolation definition for all pdgids
         self.iso_computers = dict()
-        off_iso_area = None
+        off_iso_areas = None
         if hasattr(self.cfg_ana, 'off_iso_area'):
-            off_iso_area = self.cfg_ana.off_iso_area
+            off_iso_areas = [self.cfg_ana.off_iso_area]
         for pdgid in pdgids:
             self.iso_computers[pdgid] = IsolationComputer(
                 [self.cfg_ana.iso_area],
-                off_areas=[off_iso_area], 
+                off_areas=off_iso_areas, 
                 label='iso{pdgid}'.format(pdgid=str(pdgid))
             )
             

--- a/analyzers/P4SumBuilder.py
+++ b/analyzers/P4SumBuilder.py
@@ -15,10 +15,10 @@ class P4SumBuilder(Analyzer):
     Example::
     
         from heppy.analyzers.P4SumBuilder import P4SumBuilder
-        recoil = cfg.Analyzer(
+        sum_vis = cfg.Analyzer(
           P4SumBuilder,
+          output = 'sum_vis',
           particles = 'rec_particles',
-          output = 'sum_ptc',
         ) 
 
     @param particles: collection of input particles.

--- a/analyzers/ResonanceBuilder.py
+++ b/analyzers/ResonanceBuilder.py
@@ -6,7 +6,7 @@ from heppy.particles.tlv.resonance import Resonance2 as Resonance
 import pprint 
 import itertools
 
-mass = {23: 91, 25: 125}
+mass = {23: 91, 24: 80.4, 25: 125}
 
 class ResonanceBuilder(Analyzer):
     '''Builds L{resonances<heppy.particles.tlv.resonance>}.

--- a/analyzers/ResonanceBuilder.py
+++ b/analyzers/ResonanceBuilder.py
@@ -51,9 +51,3 @@ class ResonanceBuilder(Analyzer):
         nominal_mass = mass[self.cfg_ana.pdgid]
         resonances.sort(key=lambda x: abs(x.m()-nominal_mass))
         setattr(event, self.cfg_ana.output, resonances)
-        # getting legs of best resonance
-        legs = []
-        if len(resonances):
-            legs = resonances[0].legs
-        setattr(event, '_'.join([self.cfg_ana.output, 'legs']), legs)
-                

--- a/analyzers/ResonanceLegExtractor.py
+++ b/analyzers/ResonanceLegExtractor.py
@@ -1,0 +1,16 @@
+from heppy.framework.analyzer import Analyzer
+
+class ResonanceLegExtractor(Analyzer):
+    
+    def process(self, event):
+        '''extract the legs of the first resonance 
+        '''
+        resonances = getattr(event, self.cfg_ana.resonances)
+        legs = [] 
+        if len(resonances):
+            the_res = resonances[0]
+            legs = [the_res.leg1(), the_res.leg2()]
+        setattr(event,
+                '_'.join([self.cfg_ana.resonances, 'legs']),
+                legs)
+        return True

--- a/analyzers/Tagger.py
+++ b/analyzers/Tagger.py
@@ -1,0 +1,30 @@
+from heppy.framework.analyzer import Analyzer
+
+class Tagger(Analyzer):
+    '''sets entries in the tag dictionary of the input objects.
+    
+    Example::
+
+        from heppy.analyzers.Tagger import Tagger
+        jet_tagger = cfg.Analyzer(
+            Tagger,
+            input_objects='jets',
+            tags = {
+              nptcs10 : lambda x: x.constituents.n_particles()>=10,
+              ncharged10 : lambda x: x.constituents.n_charged_hadrons()>10,
+              is_photon : lambda x: x.constituents[22].e()/x.e()>0.95
+            }
+        )
+
+
+    @param input_jets: input collection of objects. They must have a tags dictionary.
+    @param roc: L{ROC curve<heppy.analyzers.roc.ROC>}
+    '''
+    
+    def process(self, event):
+        objects = getattr(event, self.cfg_ana.input_objects)
+        tags = self.cfg_ana.tags
+        for obj in objects:
+            for tagname, func in tags.iteritems():
+                obj.tags[tagname] = func(obj)
+        

--- a/papas/detectors/CLIC.py
+++ b/papas/detectors/CLIC.py
@@ -120,11 +120,12 @@ class HCAL(DetectorElement):
     
 class Tracker(DetectorElement):
    
+    theta_max = 75. * math.pi / 180.
+    
     def __init__(self):
         super(Tracker, self).__init__('tracker',
                                       VolumeCylinder('tracker', ECAL.min_radius , ECAL.min_z),
                                       material.void)
-        self.theta_max = 75. * math.pi / 180.
         # Emilia Leogrande
         # using our definition of theta (equal to zero at eta=0)
         self.resmap = [(80.0, [0.00064001464571871076, 0.13554521466257508, 1.1091870672607593]),
@@ -148,7 +149,7 @@ class Tracker(DetectorElement):
         rnd = random.uniform(0,1)
         pt = track.p3().Pt()
         theta = abs(track.theta())
-        if theta < self.theta_max:
+        if theta < self.__class__.theta_max:
             if pt < 0.1:
                 return False
             elif pt < 0.3:
@@ -209,7 +210,7 @@ class CLIC(Detector):
         No information, cooking something up.
         '''
         if track.p3().Mag() > 5 and \
-           abs(track.theta()) < 80. * math.pi / 180.:
+           abs(track.theta()) < Tracker.theta_max:
             return random.uniform(0, 1) < 0.95
         else:
             return False
@@ -229,7 +230,7 @@ class CLIC(Detector):
         The CLIC CDR gives 99% for E > 7.5GeV and polar angle > 10 degrees
         '''
         return track.p3().Mag() > 7.5 and \
-               abs(track.theta()) < 80. * math.pi / 180.
+               abs(track.theta()) < Tracker.theta_max
             
     def muon_resolution(self, track):
         '''returns the relative muon resolution.

--- a/papas/detectors/CLIC.py
+++ b/papas/detectors/CLIC.py
@@ -120,7 +120,8 @@ class HCAL(DetectorElement):
     
 class Tracker(DetectorElement):
    
-    theta_max = 75. * math.pi / 180.
+    # acceptance in radians 
+    theta_max = math.pi / 2.
     
     def __init__(self):
         super(Tracker, self).__init__('tracker',

--- a/particles/genbrowser.py
+++ b/particles/genbrowser.py
@@ -80,7 +80,11 @@ class GenBrowser(object):
         Recursive.
         '''
         result = []
-        if len(particle.daughters) == 1:
+        self_decay = False
+        for dau in particle.daughters:
+            if dau.pdgid() == particle.pdgid():
+                self_decay = True
+        if self_decay:
             result.extend(self.decay_daughters(particle.daughters[0]))
         else:
             result.extend(particle.daughters)

--- a/particles/genbrowser.py
+++ b/particles/genbrowser.py
@@ -54,7 +54,9 @@ class GenBrowser(object):
                 
     def ancestors(self, particle):
         """Returns the list of ancestors for a given particle, 
-        that is mothers, grandmothers, etc."""
+        that is mothers, grandmothers, etc.
+        Recursive.
+        """
         result = []
         for mother in particle.mothers:
             result.append(mother)
@@ -63,13 +65,25 @@ class GenBrowser(object):
 
     def descendants(self, particle):
         """Returns the list of descendants for a given particle, 
-        that is daughters, granddaughters, etc."""
+        that is daughters, granddaughters, etc.
+        Recursive.
+        """
         result = []
         for daughter in particle.daughters:
             result.append(daughter)
             result.extend(self.descendants(daughter))
         return result
 
-
+    def decay_daughters(self, particle):
+        '''Returns decay daughters.
+        If particle decays to a single particle (itself), return daughters of daughter.
+        Recursive.
+        '''
+        result = []
+        if len(particle.daughters) == 1:
+            result.extend(self.decay_daughters(particle.daughters[0]))
+        else:
+            result.extend(particle.daughters)
+        return result
 
 

--- a/particles/genbrowser.py
+++ b/particles/genbrowser.py
@@ -80,12 +80,13 @@ class GenBrowser(object):
         Recursive.
         '''
         result = []
-        self_decay = False
+        self_decay = None
         for dau in particle.daughters:
             if dau.pdgid() == particle.pdgid():
-                self_decay = True
+                self_decay = dau
+                break
         if self_decay:
-            result.extend(self.decay_daughters(particle.daughters[0]))
+            result.extend(self.decay_daughters(self_decay))
         else:
             result.extend(particle.daughters)
         return result

--- a/particles/isolation.py
+++ b/particles/isolation.py
@@ -112,15 +112,13 @@ class IsolationComputer(object):
                 continue
             is_on = False
             for area in self.on_areas:
-                if area.is_inside(lepton.eta(), lepton.phi(),
-                                  ptc.eta(), ptc.phi() ):
+                if area.is_inside(lepton, ptc):
                     is_on = True
                     break
             if not is_on:
                 continue        
             for area in self.off_areas:
-                if area.is_inside(lepton.eta(), lepton.phi(),
-                                  ptc.eta(), ptc.phi() ):
+                if area.is_inside(lepton, ptc):
                     is_on = False
                     break
             if is_on:

--- a/particles/isolation.py
+++ b/particles/isolation.py
@@ -51,6 +51,13 @@ class IsolationInfo(object):
         self.sume += ptc.e()
         self.num += 1 
 
+    def rm_particle(self, ptc):
+        '''Remove a particle and update counters (e.g. for FSR recovery)'''
+        self.particles.remove(ptc)
+        self.sumpt -= ptc.pt()
+        self.sume -= ptc.e()
+        self.num -= 1
+
     def __iadd__(self, other):
         self.particles.extend(other.particles)
         self.sumpt += other.sumpt

--- a/particles/jet.py
+++ b/particles/jet.py
@@ -31,6 +31,7 @@ class JetComponent(object):
         self._pt = 0
         self._num = 0
         self._pdgid = pdgid
+        self._q = 0
         self._particles = list()
 
     def pdgid(self):
@@ -49,6 +50,10 @@ class JetComponent(object):
         '''@return: the number of particles with this pdgid'''
         return self._num
     
+    def q(self):
+        '''@return: total charge of the particles with this pdgid'''
+        return self._q
+    
     def particles(self):
         '''@return list of particles'''
         return self._particles
@@ -63,6 +68,7 @@ class JetComponent(object):
         self._particles.append(ptc)
         self._e += ptc.e()
         self._pt += ptc.pt()
+        self._q += ptc.q()
         self._num += 1
 
     def sort(self, *args, **kwargs):
@@ -197,6 +203,7 @@ class Jet(P4):
         super(Jet, self).__init__(*args, **kwargs)
         self.constituents = None
         self.tags = JetTags()
+        self._q = None
 
     def pdgid(self):
         '''needed to behave as a particle.
@@ -206,11 +213,9 @@ class Jet(P4):
         return 0
 
     def q(self):
-        '''Needed to behave as a particle.
-        
-        @return 0
-        '''
-        return 0
+        if self._q is None:
+            self._q = sum(const.q() for const in self.constituents.values())
+        return self._q
     
     def __str__(self):
         tmp = '{className} : {p4}, tags={tags}'

--- a/particles/jet.py
+++ b/particles/jet.py
@@ -81,11 +81,13 @@ class JetComponent(object):
             e = self.e(),
             pt = self.pt()
         )
-        ptcs = []
-        for ptc in self._particles:
-            ptcs.append('\t\t\t{particle}'.format(particle=str(ptc)))
         result = [header]
-        result.extend(ptcs)
+        if hasattr(self, '_particles'):
+            # not there if the component was deepcopied, see below
+            ptcs = []
+            for ptc in self._particles:
+                ptcs.append('\t\t\t{particle}'.format(particle=str(ptc)))
+            result.extend(ptcs)
         return '\n'.join(result)
     
     def __deepcopy__(self, memodict={}):

--- a/particles/jet.py
+++ b/particles/jet.py
@@ -1,4 +1,5 @@
 import math
+import copy
 from p4 import P4
 
 def group_pdgid(ptc):
@@ -16,7 +17,7 @@ def group_pdgid(ptc):
     else:
         return pdgid
 
-class JetComponent(list):
+class JetComponent(object):
     '''L{Jet} constituent particle information.
     
     In addition to the values returned by the various methods of this class,
@@ -30,6 +31,7 @@ class JetComponent(list):
         self._pt = 0
         self._num = 0
         self._pdgid = pdgid
+        self._particles = list()
 
     def pdgid(self):
         '''@return: the pdgid'''
@@ -47,6 +49,10 @@ class JetComponent(list):
         '''@return: the number of particles with this pdgid'''
         return self._num
     
+    def particles(self):
+        '''@return list of particles'''
+        return self._particles
+    
     def append(self, ptc):
         '''Append a new particle, incrementing all quantities'''
         pdgid = group_pdgid(ptc)
@@ -54,10 +60,13 @@ class JetComponent(list):
             self._pdgid = pdgid
         elif pdgid!=self._pdgid:
             raise ValueError('cannot add particles of different type to a component')
-        super(JetComponent, self).append(ptc)
+        self._particles.append(ptc)
         self._e += ptc.e()
         self._pt += ptc.pt()
         self._num += 1
+
+    def sort(self, *args, **kwargs):
+        self._particles.sort(*args, **kwargs)
 
     def __str__(self):
         header = '\t\tpdgid={pdgid}, n={num:d}, e={e:3.1f}, pt={pt:3.1f}'.format(
@@ -67,14 +76,21 @@ class JetComponent(list):
             pt = self.pt()
         )
         ptcs = []
-        for ptc in self:
+        for ptc in self._particles:
             ptcs.append('\t\t\t{particle}'.format(particle=str(ptc)))
         result = [header]
         result.extend(ptcs)
         return '\n'.join(result)
+    
+    def __deepcopy__(self, memodict={}):
+        newone = type(self).__new__(type(self))
+        for attr, val in self.__dict__.iteritems():
+            if attr not in ['_particles']:
+                setattr(newone, attr, copy.deepcopy(val, memodict))
+        return newone
         
  
-class JetConstituents(dict):
+class JetConstituents(object):
     '''Dictionary of constituents.
     
     The dictionary is indexed by the following integer keys:
@@ -92,13 +108,14 @@ class JetConstituents(dict):
         all_pdgids = [211, 22, 130, 11, 13, 
                       1, 2 #HF had and em 
                       ]
+        self._components = dict()
         for pdgid in all_pdgids:
-            self[pdgid] = JetComponent(pdgid)
+            self._components[pdgid] = JetComponent(pdgid)
         self.particles = []
 
     def validate(self, jet_energy, tolerance = 1e-2):
         '''Calls pdb if total component energy != jet energy'''
-        tote = sum([comp.e() for comp in self.values()]) 
+        tote = sum([comp.e() for comp in self._components.values()]) 
         if abs(jet_energy-tote)>tolerance: 
             import pdb; pdb.set_trace()
     
@@ -106,7 +123,7 @@ class JetConstituents(dict):
         '''Appends a particle to the list of constituents.'''
         pdgid = group_pdgid(ptc)
         try:
-            self[pdgid].append(ptc)
+            self._components[pdgid].append(ptc)
         except KeyError:
             msg = '''Particle
             {ptc}
@@ -118,14 +135,26 @@ class JetConstituents(dict):
             raise ValueError(msg)
         self.particles.append(ptc)
             
+    def __getattr__(self, attr):
+        return getattr(self._components, attr)
+    
+    def __getitem__(self, item):
+        return self._components[item]
+            
     def sort(self):
         '''Sort constituent particles by decreasing energy.'''
-        for ptcs in self.values():
+        for ptcs in self._components.values():
             ptcs.sort(key = lambda ptc: ptc.e(), reverse=True)
 
     def __str__(self):
-        return '\n'.join(map(str, self.values()))
+        return '\n'.join(map(str, self._components.values()))
 
+    def __deepcopy__(self, memodict={}):
+        newone = type(self).__new__(type(self))
+        for attr, val in self.__dict__.iteritems():
+            if attr not in ['particles']:
+                setattr(newone, attr, copy.deepcopy(val, memodict))
+        return newone
 
 class JetTags(dict):
     '''Dictionary of tags attached to a jet.

--- a/particles/jet.py
+++ b/particles/jet.py
@@ -143,6 +143,12 @@ class JetConstituents(object):
             raise ValueError(msg)
         self.particles.append(ptc)
             
+    def n_particles(self):
+        return sum(comp.num() for comp in self._components.values())
+    
+    def n_charged_hadrons(self):
+        return self._components[211].num()
+            
     def __getattr__(self, attr):
         return getattr(self._components, attr)
     

--- a/particles/test_jet.py
+++ b/particles/test_jet.py
@@ -1,7 +1,8 @@
 import unittest
 import pprint
+import copy
 from tlv.jet import Jet
-from jet import JetConstituents, JetTags
+from jet import JetConstituents, JetTags, JetComponent
 from tlv.particle import Particle
 from ROOT import TLorentzVector
 
@@ -18,11 +19,12 @@ class TestJet(unittest.TestCase):
             jet_const.append(ptc)
         jet_const.sort()
         jet = Jet(jetp4)
+        jet.constituents = jet_const
         self.assertEqual( jet.e(), 8)
         keys = sorted(list(jet_const.keys()))
         self.assertEqual( keys, [1, 2, 11, 13, 22, 130, 211])
-        self.assertEqual(jet_const[211], [ptcs[1], ptcs[0]])
-        self.assertEqual(jet_const[22], [ptcs[2]])
+        self.assertEqual(jet_const[211].particles(), [ptcs[1], ptcs[0]])
+        self.assertEqual(jet_const[22].particles(), [ptcs[2]])
         self.assertEqual(jet_const[211].e(), 3)
         self.assertEqual(jet_const[130].num(), 0)
         self.assertEqual(jet_const[11].num(), 0)
@@ -31,6 +33,13 @@ class TestJet(unittest.TestCase):
         self.assertEqual(jet_const[22].pdgid(), 22)
         self.assertEqual(jet_const[211].pdgid(), 211)
         self.assertRaises(ValueError, jet_const[211].append, ptcs[2])
+        # test copy
+        comp = JetComponent(211)
+        comp.append(ptcs[0])
+        comp_copy = copy.deepcopy(comp)
+        self.assertEqual(comp_copy.num(), comp.num())
+        jet_const_copy = copy.deepcopy(jet_const)
+        self.assertEqual(jet_const_copy[211].num(), jet_const[211].num())
         
     def test_jet_tags(self):
         tags = JetTags()

--- a/particles/tlv/resonance.py
+++ b/particles/tlv/resonance.py
@@ -52,7 +52,7 @@ class Resonance2(Resonance):
         return self.legs[1]
 
     def acollinearity(self):
-        '''return the angle between the two legs, in radians'''
+        '''return the angle between the two legs, in degrees'''
         return self.leg1().p3().Angle(self.leg2().p3()) * 180 / math.pi
     
     def acoplanarity(self, axis=None):

--- a/statistics/counter.py
+++ b/statistics/counter.py
@@ -63,6 +63,7 @@ class Counter(diclist):
         retstr = 'Counter %s :\n' % self.name
         prev = None
         init = None
+        level_len = max(len(key) for key in self.keys()) + 5
         for level, count in self:
             if prev == None:
                 prev = count
@@ -75,7 +76,10 @@ class Counter(diclist):
                 eff2 = -1.
             else:
                 eff2 = float(count)/init
-            retstr += '\t {level:<60} {count:>9} \t {eff1:4.2f} \t {eff2:6.4f}\n'.format(
+            form = '\t {{level:<{level_len}}} {{count:>9}} \t {{eff1:4.2f}} \t {{eff2:6.4f}}\n'.format(
+                level_len=level_len
+            )
+            retstr += form.format(
                 level=level,
                 count=count,
                 eff1=eff1,

--- a/test/analysis_ee_ZH_cfg.py
+++ b/test/analysis_ee_ZH_cfg.py
@@ -129,6 +129,12 @@ zeds = cfg.Analyzer(
     pdgid = 23
 )
 
+from heppy.analyzers.ResonanceLegExtractor import ResonanceLegExtractor
+leg_extractor = cfg.Analyzer(
+    ResonanceLegExtractor,
+    resonances = 'zeds'
+)
+
 # Computing the recoil p4 (here, p_initial - p_zed)
 # help(RecoilBuilder) for more information
 sqrts = Collider.SQRTS 
@@ -225,6 +231,7 @@ sequence = cfg.Sequence(
     iso_leptons,
     sel_iso_leptons,
     zeds,
+    leg_extractor, 
     recoil,
     missing_energy,
     particles_not_zed,

--- a/test/analysis_ee_Z_cfg.py
+++ b/test/analysis_ee_Z_cfg.py
@@ -29,7 +29,7 @@ random.seed(0xdeadbeef)
 from heppy.configuration import Collider
 Collider.BEAMS = 'ee'
 Collider.SQRTS = 91.
-do_clic = False
+do_clic = True
 nfiles = 4
 files = glob.glob('data/ee_Z_ddbar_pythia*.root')[:nfiles]
 # input definition

--- a/utils/diclist.py
+++ b/utils/diclist.py
@@ -11,14 +11,36 @@ class diclist( list ):
         super( diclist, self).__init__()
         # internal dictionary, will contain key -> index in list
         self.dico = {}
+        self.__indexed__keys = {}
 
     def add( self, key, value ):
         if isinstance(key, (int, long)):
             raise ValueError("key cannot be an integer")
         if key in self.dico:
             raise ValueError("key '{key}' already exists".format(key=key) )
-        self.dico[key] = len(self)
+        index = len(self)
+        self.dico[key] = index
+        self.__indexed__keys[index] = key
         self.append(value)
+
+    def values(self):
+        '''dictionary signature. preserves ordering'''
+        return self
+    
+    def iteritems(self):
+        '''dictionary signature. preserves ordering'''
+        for index, value in enumerate(self):
+            yield self.__indexed__keys[index], value
+            
+    def keys(self):
+        '''dictionary signature. preserves ordering'''
+        keys = []
+        for index, value in enumerate(self):
+            keys.append(self.__indexed__keys[index])
+        return keys
+
+    def __setitem__(self, index, value):
+        self.add(index, value)
 
     def __getitem__(self, index):
         '''index can be a dictionary key, or an integer specifying 
@@ -33,12 +55,6 @@ class diclist( list ):
             # and return the corresponding value from the list
             return super(diclist, self).__getitem__( self.dico[index] )
             
-    def __setitem__(self, index, value):
-        '''These functions are quite risky...'''
-        try:
-            return super(diclist, self).__setitem__(index, value)
-        except TypeError as ValueError:
-            return super(diclist, self).__setitem__( self.dico[index], value )
             
 
     

--- a/utils/diclist.py
+++ b/utils/diclist.py
@@ -23,6 +23,18 @@ class diclist( list ):
         self.__indexed__keys[index] = key
         self.append(value)
 
+##  This is complicated, need to re-index the two dictionaries...       
+##    def rm(self, key):
+##        if isinstance(key, (int, long)):
+##            raise ValueError("key cannot be an integer")
+##        if not key in self.dico:
+##            raise ValueError("key '{key}' does not exist".format(key=key) )
+##        index = self.dico[key]
+##        self.pop(index)
+##        del self.dico[key]
+##        self.__indexed__keys = dict()
+##        for key
+
     def values(self):
         '''dictionary signature. preserves ordering'''
         return self

--- a/utils/test_diclist.py
+++ b/utils/test_diclist.py
@@ -24,6 +24,27 @@ class DiclistTestCase(unittest.TestCase):
         self.assertRaises(IndexError, dl.__getitem__, 2)
         self.assertEqual(dl[2.], 'b')
 
+    def test_add_brackets(self):
+        dl = diclist()
+        dl['a'] = 1
+        self.assertEqual(dl['a'], 1)
+        self.assertEqual(dl[0], 1)
+        
+    def test_iter(self):
+        dl = diclist()
+        dl.add('a', 1)
+        dl.add('b', 2)
+        dl.add('c', 3)
+        dl.values()
+        keyval = []
+        for key, value in dl.iteritems():
+            keyval.append((key, value))
+        self.assertListEqual(keyval,
+                             [('a', 1), ('b', 2), ('c', 3)])
+        self.assertListEqual(dl.keys(), ['a', 'b', 'c'])
+        self.assertListEqual(dl.values(), [1, 2, 3])
+        
+        
 
 if __name__ == '__main__':
     unittest.main()

--- a/utils/test_diclist.py
+++ b/utils/test_diclist.py
@@ -10,7 +10,7 @@ class DiclistTestCase(unittest.TestCase):
         dl.add('b', 2)
         dl.add('c', 3)
         self.assertEqual([1,2,3], [value for value in dl] ) 
-        self.assertEqual(dl['c'], 3)
+        self.assertEqual(dl['c'], 3)        
 
     def test_bad_int_key(self):
         dl = diclist()


### PR DESCRIPTION
Hi again, this is the first PR as promised.
@clementhelsens I think it would be good if these changes are ok on the FCC-hh side. 
Cheers, 
C

**Physics tools:** 
* Resonance leg extraction now in separate module
* Jets:
    * Jet components: the particle list of the jet was copied, which was slow. Not the case anymore
    * Jet constituents now has a method to return the number of ptcs, and the number of charged hadrons
    * The JetClusterizer has been made more flexible. Possibly backward incompatible, WARNING. 
    * Jet charge is now computed
    * bug fix: can now print jets that were deepcopied
* Isolation: 
   * veto area can now be defined
   * bug fix: negative e and mu in the isolation cone where considered as charged hadrons
   * consistently use theta instead of eta in ee mode
   * can now remove a particle from isolation info (final state radiation recovery)

**Papas detectors:** 
* CLD: 
   * refactoring
   * geometry updated (fixed) 

**Other tools:** 
* added Tagger analyzer
* added EventByNumber (selects a given event) and EventSkipper, useful for debugging
* genbrowser: bug fix in self decays (e.g. photon radiation)
* added text input backend (to process text files)
